### PR TITLE
Hotfix

### DIFF
--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -29,13 +29,39 @@ The best of both worlds
 -----------------------
 The `dbg` option is the combination of the `pipe` and `debugger` options. It displays all logs related to the debugging operations performed on the process by libdebug, as well as interactions with the process pipe: bytes received and bytes sent.
 
-Temporary Logging
------------------
+Change logger levels at runtime
+-------------------------------
+Logger levels can be changed at runtime using the `libcontext` module. The following example shows how to change the logger levels at runtime.
+
+.. code-block:: python
+
+    from libdebug import libcontext
+    libcontext.pipe_logger = 'DEBUG'
+    libcontext.debugger_logger = 'DEBUG'
+    libcontext.general_logger = 'DEBUG'
+
+The `general_logger` refers to the logger used for the general logs, different from the `pipe` and `debugger` logs.
 
 Logger levels can be temporarily enabled at runtime using a `with` statement, as shown in the following example.
 
 .. code-block:: python
 
     from libdebug import libcontext
-    with libcontext.tmp(pipe_logger='INFO', debugger_logger='DEBUG'):
+    with libcontext.tmp(pipe_logger='SILENT', debugger_logger='DEBUG'):
         r.sendline(b'gimme the flag')
+
+In this example, the `pipe_logger` is set to `SILENT`, and the `debugger_logger` is set to `DEBUG`. The logger levels are restored to their previous values when the `with` block is exited.
+
+The supported logger levels are the following:
+
+- ``pipe_logger``: ``DEBUG``, ``SILENT``
+- ``debugger_logger``: ``DEBUG``, ``SILENT``
+- ``general_logger``: ``DEBUG``, ``INFO``, ``WARNING``, ``SILENT``
+
+The default logger levels are:
+
+- ``pipe_logger``: ``SILENT``
+- ``debugger_logger``: ``SILENT``
+- ``general_logger``: ``DEBUG``
+
+The `DEBUG` level is the most verbose, including all logs. The `INFO` level includes all logs except for the `DEBUG` logs. The `WARNING` level includes only the `WARNING` logs. The `SILENT` level disables all logs.

--- a/libdebug/architectures/amd64/amd64_stack_unwinder.py
+++ b/libdebug/architectures/amd64/amd64_stack_unwinder.py
@@ -13,6 +13,7 @@ from libdebug.architectures.stack_unwinding_manager import StackUnwindingManager
 if TYPE_CHECKING:
     from libdebug.state.thread_context import ThreadContext
 
+
 class Amd64StackUnwinder(StackUnwindingManager):
     """Class that provides stack unwinding for the x86_64 architecture."""
 
@@ -47,6 +48,12 @@ class Amd64StackUnwinder(StackUnwindingManager):
                 stack_trace.append(return_address)
             except (OSError, ValueError):
                 break
+
+        # If we are in the prolouge of a function, we need to get the return address from the stack
+        # using a slightly more complex method
+        first_return_address = self.get_return_address(target)
+        if first_return_address != stack_trace[1]:
+            stack_trace.insert(1, first_return_address)
 
         return stack_trace
 

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -207,7 +207,7 @@ class InternalDebugger:
         )
         self.__polling_thread.start()
 
-    def _background_invalid_call(self: InternalDebugger) -> None:
+    def _background_invalid_call(self: InternalDebugger, *_: ..., **__: ...) -> None:
         """Raises an error when an invalid call is made in background mode."""
         raise RuntimeError("This method is not available in a callback.")
 

--- a/libdebug/liblog.py
+++ b/libdebug/liblog.py
@@ -32,12 +32,16 @@ class LibLog:
         if self._initialized:
             return
 
+        # Add custom log levels
+        logging.addLevelName(60, "SILENT")
+        logging.SILENT = 60
+
         # General logger
         self.general_logger = self._setup_logger("libdebug", logging.INFO)
 
         # Component-specific loggers
-        self.debugger_logger = self._setup_logger("debugger", logging.INFO)
-        self.pipe_logger = self._setup_logger("pipe", logging.INFO)
+        self.debugger_logger = self._setup_logger("debugger", logging.SILENT)
+        self.pipe_logger = self._setup_logger("pipe", logging.SILENT)
 
         self._initialized = True
 

--- a/libdebug/utils/elf_utils.py
+++ b/libdebug/utils/elf_utils.py
@@ -53,6 +53,7 @@ def _debuginfod(buildid: str) -> Path:
     debuginfod_path = Path.home() / ".cache" / "debuginfod_client" / buildid / "debuginfo"
 
     if not debuginfod_path.exists():
+        liblog.info(f"Downloading debuginfo file for buildid {buildid}")
         _download_debuginfod(buildid, debuginfod_path)
 
     return debuginfod_path

--- a/libdebug/utils/libcontext.py
+++ b/libdebug/utils/libcontext.py
@@ -17,6 +17,9 @@ class LibContext:
     """A class that holds the global context of the library."""
 
     _instance = None
+    _pipe_logger_levels: list[str]
+    _debugger_logger_levels: list[str]
+    _general_logger_levels: list[str]
 
     def __new__(cls: type):
         """Create a new instance of the class if it does not exist yet.
@@ -34,10 +37,13 @@ class LibContext:
         if self._initialized:
             return
 
+        self._pipe_logger_levels = ["DEBUG", "SILENT"]
+        self._debugger_logger_levels = ["DEBUG", "SILENT"]
+        self._general_logger_levels = ["DEBUG", "INFO", "WARNING", "SILENT"]
         self._sym_lvl = 3
 
-        self._debugger_logger = "INFO"
-        self._pipe_logger = "INFO"
+        self._debugger_logger = "SILENT"
+        self._pipe_logger = "SILENT"
         self._general_logger = "INFO"
 
         # Adjust log levels based on command-line arguments
@@ -95,12 +101,14 @@ class LibContext:
 
     @debugger_logger.setter
     def debugger_logger(self: LibContext, value: str) -> None:
-        """Property setter for debugger_logger, ensuring it's a valid logging level."""
-        if value in ["DEBUG", "INFO"]:
+        """Property setter for debugger_logger, ensuring it's a supported logging level."""
+        if value in self._debugger_logger_levels:
             self._debugger_logger = value
             liblog.debugger_logger.setLevel(value)
         else:
-            raise ValueError("debugger_logger must be a valid logging level")
+            raise ValueError(
+                f"debugger_logger must be a supported logging level. The supported levels are: {self._debugger_logger_levels}",
+            )
 
     @property
     def pipe_logger(self: LibContext) -> str:
@@ -113,12 +121,14 @@ class LibContext:
 
     @pipe_logger.setter
     def pipe_logger(self: LibContext, value: str) -> None:
-        """Property setter for pipe_logger, ensuring it's a valid logging level."""
-        if value in ["DEBUG", "INFO"]:
+        """Property setter for pipe_logger, ensuring it's a supported logging level."""
+        if value in self._pipe_logger_levels:
             self._pipe_logger = value
             liblog.pipe_logger.setLevel(value)
         else:
-            raise ValueError("pipe_logger must be a valid logging level")
+            raise ValueError(
+                f"pipe_logger must be a supported logging level. The supported levels are: {self._pipe_logger_levels}",
+            )
 
     @property
     def general_logger(self: LibContext) -> str:
@@ -131,12 +141,14 @@ class LibContext:
 
     @general_logger.setter
     def general_logger(self: LibContext, value: str) -> None:
-        """Property setter for general_logger, ensuring it's a valid logging level."""
-        if value in ["DEBUG", "INFO"]:
+        """Property setter for general_logger, ensuring it's a supported logging level."""
+        if value in self._general_logger_levels:
             self._general_logger = value
             liblog.general_logger.setLevel(value)
         else:
-            raise ValueError("general_logger must be a valid logging level")
+            raise ValueError(
+                f"general_logger must be a supported logging level. The supported levels are: {self._general_logger_levels}",
+            )
 
     @property
     def arch(self: LibContext) -> str:

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -115,6 +115,8 @@ def fast_suite():
     suite.addTest(AutoWaitingNlinks("test_nlinks"))
     suite.addTest(WatchpointTest("test_watchpoint"))
     suite.addTest(WatchpointTest("test_watchpoint_callback"))
+    suite.addTest(WatchpointTest("test_watchpoint_disable"))
+    suite.addTest(WatchpointTest("test_watchpoint_disable_reenable"))
     suite.addTest(WatchpointAliasTest("test_watchpoint_alias"))
     suite.addTest(WatchpointAliasTest("test_watchpoint_callback"))
     suite.addTest(HandleSyscallTest("test_handles"))

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -65,6 +65,7 @@ def fast_suite():
     suite.addTest(MemoryTest("test_memory_access_methods"))
     suite.addTest(HwBasicTest("test_basic"))
     suite.addTest(HwBasicTest("test_registers"))
+    suite.addTest(BacktraceTest("test_backtrace_as_symbols"))
     suite.addTest(BacktraceTest("test_backtrace"))
     suite.addTest(AttachDetachTest("test_attach"))
     suite.addTest(AttachDetachTest("test_attach_and_detach_1"))

--- a/test/scripts/backtrace_test.py
+++ b/test/scripts/backtrace_test.py
@@ -13,6 +13,96 @@ class BacktraceTest(unittest.TestCase):
     def setUp(self):
         self.d = debugger("binaries/backtrace_test")
 
+    def test_backtrace_as_symbols(self):
+        d = self.d
+
+        d.run()
+
+        bp0 = d.breakpoint("main+8")
+        bp1 = d.breakpoint("function1+8")
+        bp2 = d.breakpoint("function2+8")
+        bp3 = d.breakpoint("function3+8")
+        bp4 = d.breakpoint("function4+8")
+        bp5 = d.breakpoint("function5+8")
+        bp6 = d.breakpoint("function6+8")
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp0.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(backtrace[:1], ["main+8"])
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp1.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(backtrace[:2], ["function1+8", "main+16"])
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp2.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(backtrace[:3], ["function2+8", "function1+12", "main+16"])
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp3.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(
+            backtrace[:4], ["function3+8", "function2+1c", "function1+12", "main+16"]
+        )
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp4.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(
+            backtrace[:5],
+            ["function4+8", "function3+1c", "function2+1c", "function1+12", "main+16"],
+        )
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp5.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(
+            backtrace[:6],
+            [
+                "function5+8",
+                "function4+1c",
+                "function3+1c",
+                "function2+1c",
+                "function1+12",
+                "main+16",
+            ],
+        )
+
+        d.cont()
+
+        self.assertTrue(d.regs.rip == bp6.address)
+        backtrace = d.backtrace(as_symbols=True)
+        self.assertIn("_start", backtrace.pop())
+        self.assertEqual(
+            backtrace[:7],
+            [
+                "function6+8",
+                "function5+1c",
+                "function4+1c",
+                "function3+1c",
+                "function2+1c",
+                "function1+12",
+                "main+16",
+            ],
+        )
+
+        d.kill()
+
     def test_backtrace(self):
         d = self.d
 
@@ -30,56 +120,56 @@ class BacktraceTest(unittest.TestCase):
 
         self.assertTrue(d.regs.rip == bp0.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
-        self.assertEqual(backtrace[:1], ["main+8"])
+        backtrace.pop()
+        self.assertEqual(backtrace[:1], [0x555555555151])
 
         d.cont()
 
         self.assertTrue(d.regs.rip == bp1.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
-        self.assertEqual(backtrace[:2], ["function1+8", "main+16"])
+        backtrace.pop()
+        self.assertEqual(backtrace[:2], [0x55555555518a, 0x55555555515f])
 
         d.cont()
 
         self.assertTrue(d.regs.rip == bp2.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
-        self.assertEqual(backtrace[:3], ["function2+8", "function1+12", "main+16"])
+        backtrace.pop()
+        self.assertEqual(backtrace[:3], [0x55555555519e, 0x555555555194, 0x55555555515f])
 
         d.cont()
 
         self.assertTrue(d.regs.rip == bp3.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
+        backtrace.pop()
         self.assertEqual(
-            backtrace[:4], ["function3+8", "function2+1c", "function1+12", "main+16"]
+            backtrace[:4], [0x5555555551bc, 0x5555555551b2, 0x555555555194, 0x55555555515f]
         )
 
         d.cont()
 
         self.assertTrue(d.regs.rip == bp4.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
+        backtrace.pop()
         self.assertEqual(
             backtrace[:5],
-            ["function4+8", "function3+1c", "function2+1c", "function1+12", "main+16"],
+            [0x5555555551da, 0x5555555551d0, 0x5555555551b2, 0x555555555194, 0x55555555515f],
         )
 
         d.cont()
 
         self.assertTrue(d.regs.rip == bp5.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
+        backtrace.pop()
         self.assertEqual(
             backtrace[:6],
             [
-                "function5+8",
-                "function4+1c",
-                "function3+1c",
-                "function2+1c",
-                "function1+12",
-                "main+16",
+                0x5555555551f8,
+                0x5555555551ee,
+                0x5555555551d0,
+                0x5555555551b2,
+                0x555555555194,
+                0x55555555515f,
             ],
         )
 
@@ -87,17 +177,17 @@ class BacktraceTest(unittest.TestCase):
 
         self.assertTrue(d.regs.rip == bp6.address)
         backtrace = d.backtrace()
-        self.assertIn("_start", backtrace.pop())
+        backtrace.pop()
         self.assertEqual(
             backtrace[:7],
             [
-                "function6+8",
-                "function5+1c",
-                "function4+1c",
-                "function3+1c",
-                "function2+1c",
-                "function1+12",
-                "main+16",
+                0x555555555216,
+                0x55555555520c,
+                0x5555555551ee,
+                0x5555555551d0,
+                0x5555555551b2,
+                0x555555555194,
+                0x55555555515f,
             ],
         )
 


### PR DESCRIPTION
Ideally, this PR should be merged before the 0.6.x.

This PR includes:

- A hotfix for the `_background_invalid_call` function, which is called when a user tries to call an unsupported libdebug function in a callback. It did not correctly handle a variadic number of (positional) arguments.
- An info message is now displayed when symbols are downloaded from debuginfod.
- A slight optimization in the performance and logic of breakpoints.
- Improvements in the `backtrace` function. Specifically, the internal workings have been optimized, and a new parameter for the API exposed by libdebug has been added to support the option to return either a list of addresses or symbols. Additionally, a public pretty print for the backtrace has been added. This should solve #84.
- Optimized the debugging levels to address #83  and partially #22 .
- Updated the documentation to address #85 .
- Added tests.