### PR TITLE
Unwind fix

### DIFF
--- a/libdebug/architectures/amd64/amd64_stack_unwinder.py
+++ b/libdebug/architectures/amd64/amd64_stack_unwinder.py
@@ -63,7 +63,7 @@ class Amd64StackUnwinder(StackUnwindingManager):
                 stack_trace.append(first_return_address)
         except (OSError, ValueError):
             liblog.warning(
-                "Failed to get the return address from the stack. Check stack frame registers (e.g., base pointer). The stack trace may be incomplete.",
+                "Failed to get the return address. Check stack frame registers (e.g., base pointer). The stack trace may be incomplete.",
             )
 
         return stack_trace

--- a/libdebug/architectures/stack_unwinding_manager.py
+++ b/libdebug/architectures/stack_unwinding_manager.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from libdebug.data.memory_map import MemoryMap
     from libdebug.state.thread_context import ThreadContext
 
 
@@ -21,5 +22,5 @@ class StackUnwindingManager(ABC):
         """Unwind the stack of the target process."""
 
     @abstractmethod
-    def get_return_address(self: StackUnwindingManager, target: ThreadContext) -> int:
+    def get_return_address(self: StackUnwindingManager, target: ThreadContext, vmaps: list[MemoryMap]) -> int:
         """Get the return address of the current function."""

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -310,7 +310,7 @@ class PtraceInterface(DebuggingInterface):
             invalidate_process_cache()
         elif heuristic == "backtrace":
             # Breakpoint to return address
-            last_saved_instruction_pointer = thread.current_return_address()
+            last_saved_instruction_pointer = thread.saved_ip
 
             # If a breakpoint already exists at the return address, we don't need to set a new one
             found = False

--- a/libdebug/state/thread_context.py
+++ b/libdebug/state/thread_context.py
@@ -201,8 +201,9 @@ class ThreadContext:
             else:
                 print(f"{PrintStyle.RED}{return_address:#x} <{return_address_symbol}> {PrintStyle.RESET}")
 
-    def current_return_address(self: ThreadContext) -> int:
-        """Returns the return address of the current function."""
+    @property
+    def saved_ip(self: ThreadContext) -> int:
+        """The return address of the current function."""
         self._internal_debugger._ensure_process_stopped()
         stack_unwinder = stack_unwinding_provider(self._internal_debugger.arch)
 
@@ -249,8 +250,7 @@ class ThreadContext:
         self._internal_debugger.finish(self, heuristic=heuristic)
 
     def next(self: ThreadContext) -> None:
-        """Executes the next instruction of the process. If the instruction is a call, the debugger will continue until the called function returns.
-        """
+        """Executes the next instruction of the process. If the instruction is a call, the debugger will continue until the called function returns."""
         self._internal_debugger.next(self)
 
     def si(self: ThreadContext) -> None:
@@ -288,6 +288,5 @@ class ThreadContext:
         self._internal_debugger.finish(self, heuristic)
 
     def ni(self: ThreadContext) -> None:
-        """Alias for the `next` method. Executes the next instruction of the process. If the instruction is a call, the debugger will continue until the called function returns.
-        """
+        """Alias for the `next` method. Executes the next instruction of the process. If the instruction is a call, the debugger will continue until the called function returns."""
         self._internal_debugger.next(self)

--- a/libdebug/state/thread_context.py
+++ b/libdebug/state/thread_context.py
@@ -207,7 +207,7 @@ class ThreadContext:
         stack_unwinder = stack_unwinding_provider(self._internal_debugger.arch)
 
         try:
-            return_address = stack_unwinder.get_return_address(self)
+            return_address = stack_unwinder.get_return_address(self, self._internal_debugger.debugging_interface.maps())
         except (OSError, ValueError) as e:
             raise ValueError(
                 "Failed to get the return address. Check stack frame registers (e.g., base pointer).",

--- a/test/aarch64/scripts/finish_test.py
+++ b/test/aarch64/scripts/finish_test.py
@@ -234,19 +234,19 @@ class FinishTest(unittest.TestCase):
         # We need to repeat the check for the three stages of the function preamble
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.kill()

--- a/test/aarch64/scripts/finish_test.py
+++ b/test/aarch64/scripts/finish_test.py
@@ -234,19 +234,19 @@ class FinishTest(unittest.TestCase):
         # We need to repeat the check for the three stages of the function preamble
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.kill()

--- a/test/amd64/scripts/finish_test.py
+++ b/test/amd64/scripts/finish_test.py
@@ -234,19 +234,19 @@ class FinishTest(unittest.TestCase):
         # We need to repeat the check for the three stages of the function preamble
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = d.current_return_address()
+        curr_srip = d.saved_ip
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.kill()

--- a/test/amd64/scripts/finish_test.py
+++ b/test/amd64/scripts/finish_test.py
@@ -234,19 +234,19 @@ class FinishTest(unittest.TestCase):
         # We need to repeat the check for the three stages of the function preamble
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.step()
 
         # Get current return address
-        curr_srip = stack_unwinder.get_return_address(d)
+        curr_srip = d.current_return_address()
         self.assertEqual(curr_srip, RETURN_POINT_FROM_C)
 
         d.kill()


### PR DESCRIPTION
There was an issue introduced in the integration of `get_return_address` into `unwind` that caused an index out-of-range exception.