### PR TITLE
Watchpoints fix

### DIFF
--- a/libdebug/data/breakpoint.py
+++ b/libdebug/data/breakpoint.py
@@ -63,14 +63,10 @@ class Breakpoint:
         """Returns whether the breakpoint has been hit on the given thread context."""
         if not self.enabled:
             return False
-        elif self.condition == "x":
-            # TODO: We can unify this with the watchpoint hit check in the future, when
-            # we will have a better management of step, finish, etc.
-            return thread_context.instruction_pointer == self.address
-        else:
-            internal_debugger = provide_internal_debugger(self)
-            internal_debugger._ensure_process_stopped()
-            return internal_debugger.resume_context.breakpoint_hit.get(thread_context.thread_id) == self
+
+        internal_debugger = provide_internal_debugger(self)
+        internal_debugger._ensure_process_stopped()
+        return internal_debugger.resume_context.breakpoint_hit.get(thread_context.thread_id) == self
 
     def __hash__(self: Breakpoint) -> int:
         """Hash the breakpoint by its address, so that it can be used in sets and maps correctly."""

--- a/libdebug/data/breakpoint.py
+++ b/libdebug/data/breakpoint.py
@@ -61,8 +61,23 @@ class Breakpoint:
 
     def hit_on(self: Breakpoint, thread_context: ThreadContext) -> bool:
         """Returns whether the breakpoint has been hit on the given thread context."""
-        return self.enabled and thread_context.instruction_pointer == self.address
+        if not self.enabled:
+            return False
+        elif self.condition == "x":
+            # TODO: We can unify this with the watchpoint hit check in the future, when
+            # we will have a better management of step, finish, etc.
+            return thread_context.instruction_pointer == self.address
+        else:
+            internal_debugger = provide_internal_debugger(self)
+            internal_debugger._ensure_process_stopped()
+            return internal_debugger.resume_context.breakpoint_hit.get(thread_context.thread_id) == self
 
     def __hash__(self: Breakpoint) -> int:
         """Hash the breakpoint by its address, so that it can be used in sets and maps correctly."""
         return hash(self.address)
+
+    def __eq__(self: Breakpoint, other: object) -> bool:
+        """Check if two breakpoints are equal."""
+        if not isinstance(other, Breakpoint):
+            return False
+        return self.address == other.address

--- a/libdebug/data/breakpoint.py
+++ b/libdebug/data/breakpoint.py
@@ -74,6 +74,4 @@ class Breakpoint:
 
     def __eq__(self: Breakpoint, other: object) -> bool:
         """Check if two breakpoints are equal."""
-        if not isinstance(other, Breakpoint):
-            return False
-        return self.address == other.address
+        return id(self) == id(other)

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -242,7 +242,7 @@ class PtraceInterface(DebuggingInterface):
         self._internal_debugger.resume_context.event_type = None
 
         # Reset the breakpoint hit
-        self._internal_debugger.resume_context.breakpoint_hit = None
+        self._internal_debugger.resume_context.breakpoint_hit = {}
 
         result = self.lib_trace.cont_all_and_set_bps(
             self._global_state,

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -238,6 +238,12 @@ class PtraceInterface(DebuggingInterface):
         else:
             self._global_state.handle_syscall_enabled = False
 
+        # Reset the event type
+        self._internal_debugger.resume_context.event_type = None
+
+        # Reset the breakpoint hit
+        self._internal_debugger.resume_context.breakpoint_hit = None
+
         result = self.lib_trace.cont_all_and_set_bps(
             self._global_state,
             self.process_id,

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -263,6 +263,12 @@ class PtraceInterface(DebuggingInterface):
         for bp in self._internal_debugger.breakpoints.values():
             bp._disabled_for_step = True
 
+        # Reset the event type
+        self._internal_debugger.resume_context.event_type = None
+
+        # Reset the breakpoint hit
+        self._internal_debugger.resume_context.breakpoint_hit.clear()
+
         result = self.lib_trace.singlestep(self._global_state, thread.thread_id)
         if result == -1:
             errno_val = self.ffi.errno
@@ -281,6 +287,12 @@ class PtraceInterface(DebuggingInterface):
         # Disable all breakpoints for the single step
         for bp in self._internal_debugger.breakpoints.values():
             bp._disabled_for_step = True
+
+        # Reset the event type
+        self._internal_debugger.resume_context.event_type = None
+
+        # Reset the breakpoint hit
+        self._internal_debugger.resume_context.breakpoint_hit.clear()
 
         result = self.lib_trace.step_until(
             self._global_state,
@@ -302,6 +314,12 @@ class PtraceInterface(DebuggingInterface):
             thread (ThreadContext): The thread to step.
             heuristic (str): The heuristic to use.
         """
+        # Reset the event type
+        self._internal_debugger.resume_context.event_type = None
+
+        # Reset the breakpoint hit
+        self._internal_debugger.resume_context.breakpoint_hit.clear()
+
         if heuristic == "step-mode":
             result = self.lib_trace.stepping_finish(
                 self._global_state,
@@ -359,6 +377,11 @@ class PtraceInterface(DebuggingInterface):
 
     def next(self: PtraceInterface, thread: ThreadContext) -> None:
         """Executes the next instruction of the process. If the instruction is a call, the debugger will continue until the called function returns."""
+        # Reset the event type
+        self._internal_debugger.resume_context.event_type = None
+
+        # Reset the breakpoint hit
+        self._internal_debugger.resume_context.breakpoint_hit.clear()
 
         opcode_window = thread.memory.read(thread.instruction_pointer, 8)
 

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -242,7 +242,7 @@ class PtraceInterface(DebuggingInterface):
         self._internal_debugger.resume_context.event_type = None
 
         # Reset the breakpoint hit
-        self._internal_debugger.resume_context.breakpoint_hit = {}
+        self._internal_debugger.resume_context.breakpoint_hit.clear()
 
         result = self.lib_trace.cont_all_and_set_bps(
             self._global_state,

--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -109,7 +109,7 @@ class PtraceStatusHandler:
                 liblog.debugger("Watchpoint hit at 0x%x", bp.address)
 
         if bp:
-            self.internal_debugger.resume_context.breakpoint_hit = bp
+            self.internal_debugger.resume_context.breakpoint_hit[thread_id] = bp
             self.forward_signal = False
             bp.hit_count += 1
 

--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -17,6 +17,7 @@ from libdebug.architectures.ptrace_software_breakpoint_patcher import (
 from libdebug.debugger.internal_debugger_instance_manager import provide_internal_debugger
 from libdebug.liblog import liblog
 from libdebug.ptrace.ptrace_constants import SYSCALL_SIGTRAP, StopEvents
+from libdebug.state.resume_context import EventType
 from libdebug.utils.signal_utils import resolve_signal_name
 
 if TYPE_CHECKING:
@@ -69,6 +70,7 @@ class PtraceStatusHandler:
         if not hasattr(thread, "instruction_pointer"):
             # This is a signal trap hit on process startup
             # Do not resume the process until the user decides to do so
+            self.internal_debugger.resume_context.event_type = EventType.STARTUP
             self.internal_debugger.resume_context.resume = False
             self.forward_signal = False
             return
@@ -107,6 +109,7 @@ class PtraceStatusHandler:
                 liblog.debugger("Watchpoint hit at 0x%x", bp.address)
 
         if bp:
+            self.internal_debugger.resume_context.breakpoint_hit = bp
             self.forward_signal = False
             bp.hit_count += 1
 
@@ -114,6 +117,7 @@ class PtraceStatusHandler:
                 bp.callback(thread, bp)
             else:
                 # If the breakpoint has no callback, we need to stop the process despite the other signals
+                self.internal_debugger.resume_context.event_type = EventType.BREAKPOINT
                 self.internal_debugger.resume_context.resume = False
 
     def _manage_syscall_on_enter(
@@ -193,6 +197,7 @@ class PtraceStatusHandler:
             handler._has_entered = True
         if not handler.on_enter_user and not handler.on_exit_user and handler.enabled:
             # If the syscall has no callback, we need to stop the process despite the other signals
+            self.internal_debugger.resume_context.event_type = EventType.SYSCALL
             handler._has_entered = True
             self.internal_debugger.resume_context.resume = False
 
@@ -257,6 +262,7 @@ class PtraceStatusHandler:
             handler._skip_exit = False
             if not handler.on_enter_user and not handler.on_exit_user and handler.enabled:
                 # If the syscall has no callback, we need to stop the process despite the other signals
+                self.internal_debugger.resume_context.event_type = EventType.SYSCALL
                 self.internal_debugger.resume_context.resume = False
 
     def _manage_caught_signal(
@@ -308,6 +314,7 @@ class PtraceStatusHandler:
                         )
             else:
                 # If the caught signal has no callback, we need to stop the process despite the other signals
+                self.internal_debugger.resume_context.event = EventType.SIGNAL
                 self.internal_debugger.resume_context.resume = False
 
     def _handle_signal(self: PtraceStatusHandler, thread: ThreadContext) -> bool:
@@ -339,6 +346,7 @@ class PtraceStatusHandler:
                 pid,
                 resolve_signal_name(signum),
             )
+            self.internal_debugger.resume_context.event_type = EventType.USER_INTERRUPT
             self.internal_debugger.resume_context.resume = False
             self.internal_debugger.resume_context.force_interrupt = False
             self.forward_signal = False
@@ -349,6 +357,7 @@ class PtraceStatusHandler:
 
             if self.internal_debugger.resume_context.is_a_step:
                 # The process is stepping, we need to stop the execution
+                self.internal_debugger.resume_context.event_type = EventType.STEP
                 self.internal_debugger.resume_context.resume = False
                 self.internal_debugger.resume_context.is_a_step = False
                 self.forward_signal = False

--- a/libdebug/state/resume_context.py
+++ b/libdebug/state/resume_context.py
@@ -6,6 +6,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from libdebug.data.breakpoint import Breakpoint
+
 
 class ResumeContext:
     """A class representing the context of the resume decision."""
@@ -18,6 +23,8 @@ class ResumeContext:
         self.is_startup: bool = False
         self.block_on_signal: bool = False
         self.threads_with_signals_to_forward: list[int] = []
+        self.event_type: EventType | None = None
+        self.breakpoint_hit: Breakpoint | None = None
 
     def clear(self: ResumeContext) -> None:
         """Clears the context."""
@@ -27,3 +34,17 @@ class ResumeContext:
         self.is_startup = False
         self.block_on_signal = False
         self.threads_with_signals_to_forward.clear()
+        self.event_type = None
+        self.breakpoint_hit = None
+
+
+class EventType:
+    """A class representing the type of event that caused the resume decision."""
+
+    UNKNOWN = "unknown event"
+    BREAKPOINT = "breakpoint"
+    SYSCALL = "syscall"
+    SIGNAL = "signal"
+    USER_INTERRUPT = "user interrupt"
+    STEP = "step"
+    STARTUP = "process startup"

--- a/libdebug/state/resume_context.py
+++ b/libdebug/state/resume_context.py
@@ -35,7 +35,7 @@ class ResumeContext:
         self.block_on_signal = False
         self.threads_with_signals_to_forward.clear()
         self.event_type = None
-        self.breakpoint_hit = {}
+        self.breakpoint_hit.clear()
 
 
 class EventType:

--- a/libdebug/state/resume_context.py
+++ b/libdebug/state/resume_context.py
@@ -24,7 +24,7 @@ class ResumeContext:
         self.block_on_signal: bool = False
         self.threads_with_signals_to_forward: list[int] = []
         self.event_type: EventType | None = None
-        self.breakpoint_hit: Breakpoint | None = None
+        self.breakpoint_hit: dict[int, Breakpoint] = {}
 
     def clear(self: ResumeContext) -> None:
         """Clears the context."""
@@ -35,7 +35,7 @@ class ResumeContext:
         self.block_on_signal = False
         self.threads_with_signals_to_forward.clear()
         self.event_type = None
-        self.breakpoint_hit = None
+        self.breakpoint_hit = {}
 
 
 class EventType:

--- a/test/amd64/scripts/watchpoint_test.py
+++ b/test/amd64/scripts/watchpoint_test.py
@@ -20,8 +20,9 @@ class WatchpointTest(unittest.TestCase):
         wp_long = d.breakpoint("global_long", hardware=True, condition="rw", length=8)
 
         d.cont()
-
+        
         self.assertEqual(d.regs.rip, 0x401111)  # mov byte ptr [global_char], 0x1
+        self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 0)
         self.assertEqual(wp_long.hit_count, 0)
@@ -29,6 +30,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401124)  # mov dword ptr [global_int], 0x4050607
+        self.assertTrue(wp_int.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 0)
@@ -38,6 +40,7 @@ class WatchpointTest(unittest.TestCase):
         self.assertEqual(
             d.regs.rip, 0x401135
         )  # mov qword ptr [global_long], 0x8090a0b0c0d0e0f
+        self.assertTrue(wp_long.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 1)
@@ -45,6 +48,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401155)  # movzx eax, byte ptr [global_char]
+        self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 2)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 1)
@@ -52,6 +56,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401173)  # mov rax, qword ptr [global_long]
+        self.assertTrue(wp_long.hit_on(d))
         self.assertEqual(wp_char.hit_count, 2)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 2)
@@ -148,6 +153,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401111)  # mov byte ptr [global_char], 0x1
+        self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 0)
         self.assertEqual(wp_long.hit_count, 0)
@@ -155,6 +161,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401124)  # mov dword ptr [global_int], 0x4050607
+        self.assertTrue(wp_int.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 0)
@@ -164,6 +171,7 @@ class WatchpointTest(unittest.TestCase):
         self.assertEqual(
             d.regs.rip, 0x401135
         )  # mov qword ptr [global_long], 0x8090a0b0c0d0e0f
+        self.assertTrue(wp_long.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 1)
@@ -174,6 +182,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401173)  # mov rax, qword ptr [global_long]
+        self.assertTrue(wp_long.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 2)
@@ -194,6 +203,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401111)  # mov byte ptr [global_char], 0x1
+        self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 0)
         self.assertEqual(wp_long.hit_count, 0)
@@ -201,6 +211,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401124)  # mov dword ptr [global_int], 0x4050607
+        self.assertTrue(wp_int.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 0)
@@ -212,6 +223,7 @@ class WatchpointTest(unittest.TestCase):
 
 
         self.assertEqual(d.regs.rip, 0x401155)  # movzx eax, byte ptr [global_char]
+        self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 2)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 0)
@@ -222,6 +234,7 @@ class WatchpointTest(unittest.TestCase):
         d.cont()
 
         self.assertEqual(d.regs.rip, 0x401173)  # mov rax, qword ptr [global_long]
+        self.assertTrue(wp_long.hit_on(d))
         self.assertEqual(wp_char.hit_count, 2)
         self.assertEqual(wp_int.hit_count, 1)
         self.assertEqual(wp_long.hit_count, 1)

--- a/test/amd64/scripts/watchpoint_test.py
+++ b/test/amd64/scripts/watchpoint_test.py
@@ -20,7 +20,7 @@ class WatchpointTest(unittest.TestCase):
         wp_long = d.breakpoint("global_long", hardware=True, condition="rw", length=8)
 
         d.cont()
-        
+ 
         self.assertEqual(d.regs.rip, 0x401111)  # mov byte ptr [global_char], 0x1
         self.assertTrue(wp_char.hit_on(d))
         self.assertEqual(wp_char.hit_count, 1)


### PR DESCRIPTION
This PR resolves issue #116. 
Additionally, it addresses a collision problem with the Python dictionaries and the dataclass used for breakpoints.

Note: The solution for #116 may seem overly complicated. This complexity is intentional, as most of the code has been cherry-picked from the pipe.interactive() branch. In that context, the code will be more appropriate, and further clean-up and improvements are planned.