### PR TITLE
Correctly handle an edge case of `terminate` when attached to a process

### DIFF
--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -345,7 +345,11 @@ class InternalDebugger:
             self.interrupt()
 
         if self.instanced:
-            self.kill()
+            try:
+                self.kill()
+            except ProcessLookupError:
+                # The process has already been killed by someone or something else
+                liblog.debugger("Killing process failed: already terminated")
 
         self.instanced = False
 

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -342,7 +342,11 @@ class InternalDebugger:
         This method should only be called to free up resources when the debugger object is no longer needed.
         """
         if self.instanced and self.running:
-            self.interrupt()
+            try:
+                self.interrupt()
+            except ProcessLookupError:
+                # The process has already been killed by someone or something else
+                liblog.debugger("Interrupting process failed: already terminated")
 
         if self.instanced:
             try:


### PR DESCRIPTION
The process could have died without us knowing. This fixes an issue with d.terminate() in that case, as the call to kill would raise an exception and thus return before effectively terminating.