### PR TITLE
Add RT signals to the mapping

### DIFF
--- a/libdebug/utils/signal_utils.py
+++ b/libdebug/utils/signal_utils.py
@@ -20,6 +20,13 @@ def create_signal_mappings() -> tuple[dict, dict]:
             signal_to_number[name] = number
             number_to_signal[number] = name
 
+    # RT signals have a different convention
+    for i in range(1, signal.SIGRTMAX - signal.SIGRTMIN):
+        name = f"SIGRTMIN+{i}"
+        number = signal.SIGRTMIN + i
+        signal_to_number[name] = number
+        number_to_signal[number] = name
+
     return signal_to_number, number_to_signal
 
 


### PR DESCRIPTION
They are always available, but Python does not define them in the signals enum.