### PR TITLE
Expand save area struct for AVX2 registers

### DIFF
--- a/libdebug/cffi/ptrace_cffi_build.py
+++ b/libdebug/cffi/ptrace_cffi_build.py
@@ -96,6 +96,7 @@ if architecture == "x86_64":
             // ymm0 starts at offset 576
             struct reg_128 ymm0[16];
             unsigned char padding3[64];
+            unsigned char padding4[192]; // mpx save area
         };
         #pragma pack(pop)
         """

--- a/libdebug/cffi/ptrace_cffi_source.c
+++ b/libdebug/cffi/ptrace_cffi_source.c
@@ -29,7 +29,7 @@
     #if (FPREGS_AVX == 0)
         _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 512, "user_fpregs_struct size is not 512 bytes");
     #elif (FPREGS_AVX == 1)
-        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 896, "user_fpregs_struct size is not 896 bytes");
+        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 1088, "user_fpregs_struct size is not 1088 bytes");
     #elif (FPREGS_AVX == 2)
         _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 2696, "user_fpregs_struct size is not 2696 bytes");
     #else


### PR DESCRIPTION
Now this works even if the processor has MPX support, which requires 256 more bytes in the save area.