### PR TITLE
fix: Add return types to the debugger.run() method

### DIFF
--- a/libdebug/debugger/debugger.py
+++ b/libdebug/debugger/debugger.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from libdebug.data.syscall_handler import SyscallHandler
     from libdebug.debugger.internal_debugger import InternalDebugger
     from libdebug.state.thread_context import ThreadContext
+    from libdebug.utils.pipe_manager import PipeManager
 
 
 class Debugger:
@@ -36,7 +37,7 @@ class Debugger:
     _sentinel: object = object()
     """A sentinel object."""
 
-    _internal_debugger: InternalDebugger | None = None
+    _internal_debugger: InternalDebugger = None
     """The internal debugger object."""
 
     def __init__(self: Debugger) -> None:
@@ -47,7 +48,7 @@ class Debugger:
         self._internal_debugger = internal_debugger
         self._internal_debugger.start_up()
 
-    def run(self: Debugger) -> None:
+    def run(self: Debugger) -> PipeManager:
         """Starts the process and waits for it to stop."""
         return self._internal_debugger.run()
 

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -242,7 +242,7 @@ class InternalDebugger:
         """Raises an error when an invalid call is made in background mode."""
         raise RuntimeError("This method is not available in a callback.")
 
-    def run(self: InternalDebugger) -> None:
+    def run(self: InternalDebugger) -> PipeManager:
         """Starts the process and waits for it to stop."""
         if not self.argv:
             raise RuntimeError("No binary file specified.")


### PR DESCRIPTION
The `_internal_debugger` is also been set to None even if the typechecker complains since this method for forward declaration is used in other parts of the project. The class expects always to be a valid `_internal_debbuger` so it's more aligned with the class.