### PR TITLE
pprint_syscalls fix and improvements

### DIFF
--- a/libdebug/builtin/pretty_print_syscall_handler.py
+++ b/libdebug/builtin/pretty_print_syscall_handler.py
@@ -18,32 +18,35 @@ if TYPE_CHECKING:
     from libdebug.state.thread_context import ThreadContext
 
 
-def pprint_on_enter(d: ThreadContext, syscall_number: int, **kwargs: int) -> None:
+def pprint_on_enter(t: ThreadContext, syscall_number: int, **kwargs: int) -> None:
     """Function that will be called when a syscall is entered in pretty print mode.
 
     Args:
-        d (ThreadContext): the thread context.
+        t (ThreadContext): the thread context.
         syscall_number (int): the syscall number.
         **kwargs (bool): the keyword arguments.
     """
-    syscall_name = resolve_syscall_name(d._internal_debugger.arch, syscall_number)
-    syscall_args = resolve_syscall_arguments(d._internal_debugger.arch, syscall_number)
+    syscall_name = resolve_syscall_name(t._internal_debugger.arch, syscall_number)
+    syscall_args = resolve_syscall_arguments(t._internal_debugger.arch, syscall_number)
 
     values = [
-        d.syscall_arg0,
-        d.syscall_arg1,
-        d.syscall_arg2,
-        d.syscall_arg3,
-        d.syscall_arg4,
-        d.syscall_arg5,
+        t.syscall_arg0,
+        t.syscall_arg1,
+        t.syscall_arg2,
+        t.syscall_arg3,
+        t.syscall_arg4,
+        t.syscall_arg5,
     ]
+
+    # Print the thread id
+    header = f"{ANSIColors.BOLD}{t.tid}{ANSIColors.RESET} "
 
     if "old_args" in kwargs:
         old_args = kwargs["old_args"]
         entries = [
             f"{arg} = {ANSIColors.BRIGHT_YELLOW}0x{value:x}{ANSIColors.DEFAULT_COLOR}"
             if old_value == value
-            else f"{arg} = {ANSIColors.BRIGHT_YELLOW}0x{old_value:x} -> {ANSIColors.BRIGHT_YELLOW}0x{value:x}{ANSIColors.DEFAULT_COLOR}"
+            else f"{arg} = {ANSIColors.STRIKE}{ANSIColors.BRIGHT_YELLOW}0x{old_value:x}{ANSIColors.RESET} {ANSIColors.BRIGHT_YELLOW}0x{value:x}{ANSIColors.DEFAULT_COLOR}"
             for arg, value, old_value in zip(syscall_args, values, old_args, strict=False)
             if arg is not None
         ]
@@ -58,16 +61,16 @@ def pprint_on_enter(d: ThreadContext, syscall_number: int, **kwargs: int) -> Non
     user_handled = kwargs.get("callback", False)
     if hijacked:
         print(
-            f"{ANSIColors.RED}(user hijacked) {ANSIColors.STRIKE}{ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}){ANSIColors.RESET}",
+            f"{header}{ANSIColors.RED}(hijacked) {ANSIColors.STRIKE}{ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}){ANSIColors.RESET}",
         )
     elif user_handled:
         print(
-            f"{ANSIColors.RED}(callback) {ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
+            f"{header}{ANSIColors.RED}(callback) {ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
             end="",
         )
     else:
         print(
-            f"{ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
+            f"{header}{ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
             end="",
         )
 

--- a/libdebug/builtin/pretty_print_syscall_handler.py
+++ b/libdebug/builtin/pretty_print_syscall_handler.py
@@ -59,6 +59,7 @@ def pprint_on_enter(t: ThreadContext, syscall_number: int, **kwargs: int) -> Non
 
     hijacked = kwargs.get("hijacked", False)
     user_handled = kwargs.get("callback", False)
+    hijacker = kwargs.get("hijacker", None)
     if hijacked:
         print(
             f"{header}{ANSIColors.RED}(hijacked) {ANSIColors.STRIKE}{ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}){ANSIColors.RESET}",
@@ -66,6 +67,11 @@ def pprint_on_enter(t: ThreadContext, syscall_number: int, **kwargs: int) -> Non
     elif user_handled:
         print(
             f"{header}{ANSIColors.RED}(callback) {ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
+            end="",
+        )
+    elif hijacker:
+        print(
+            f"{header}{ANSIColors.RED}(executed) {ANSIColors.BLUE}{syscall_name}{ANSIColors.DEFAULT_COLOR}({', '.join(entries)}) = ",
             end="",
         )
     else:

--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -184,13 +184,13 @@ class PtraceStatusHandler:
                         callback_hijack._skip_exit = True
             elif handler.on_enter_pprint:
                 # Pretty print the syscall number
-                handler.on_enter_pprint(thread, syscall_number, callback=True)
+                handler.on_enter_pprint(thread, syscall_number, callback=True, old_args=old_args)
                 handler._has_entered = True
             else:
                 handler._has_entered = True
         elif handler.on_enter_pprint:
             # Pretty print the syscall number
-            handler.on_enter_pprint(thread, syscall_number)
+            handler.on_enter_pprint(thread, syscall_number, callback=(handler.on_exit_user is not None))
             handler._has_entered = True
         elif handler.on_exit_pprint or handler.on_exit_user:
             # The syscall has been entered but the user did not define an on_enter callback

--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -144,6 +144,7 @@ class PtraceStatusHandler:
             syscall_number_after_callback = thread.syscall_number
 
             if syscall_number_after_callback != syscall_number:
+                # The syscall number has changed
                 # Pretty print the syscall number before the callback
                 if handler.on_enter_pprint:
                     handler.on_enter_pprint(
@@ -152,7 +153,6 @@ class PtraceStatusHandler:
                         hijacked=True,
                         old_args=old_args,
                     )
-                # The syscall number has changed
                 if syscall_number_after_callback in self.internal_debugger.handled_syscalls:
                     callback_hijack = self.internal_debugger.handled_syscalls[syscall_number_after_callback]
 
@@ -175,7 +175,7 @@ class PtraceStatusHandler:
                         )
                     elif callback_hijack.on_enter_pprint:
                         # Pretty print the syscall number
-                        callback_hijack.on_enter_pprint(thread, syscall_number_after_callback)
+                        callback_hijack.on_enter_pprint(thread, syscall_number_after_callback, hijacker=True)
                         callback_hijack._has_entered = True
                         callback_hijack._skip_exit = True
                     else:

--- a/test/scripts/pprint_syscalls_test.py
+++ b/test/scripts/pprint_syscalls_test.py
@@ -157,7 +157,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertIn("getcwd", self.capturedOutput.getvalue())
         self.assertIn("exit_group", self.capturedOutput.getvalue())
         self.assertIn(
-            "(user hijacked) \x1b[9m\x1b[94mgetcwd\x1b[39m",
+            "(hijacked) \x1b[9m\x1b[94mgetcwd\x1b[39m",
             self.capturedOutput.getvalue(),
         )
 


### PR DESCRIPTION
Now the pprint_syscalls handles correctly the on_exit callback, shows the tid of the thread originating the syscall, and better manages when the user changes the arguments 