### PR TITLE
Add even more padding to the fp_regs struct

### DIFF
--- a/libdebug/cffi/ptrace_cffi_build.py
+++ b/libdebug/cffi/ptrace_cffi_build.py
@@ -62,7 +62,8 @@ def parse_fp_regs_x86():
             struct reg_256 zmm0[16];
             // zmm1 starts at offset 1664
             struct reg_512 zmm1[16];
-            unsigned char padding4[8];
+            unsigned int pkru;
+            unsigned char padding7[60];
         };
         #pragma pack(pop)
         """
@@ -95,8 +96,13 @@ def parse_fp_regs_x86():
             unsigned char padding2[64];
             // ymm0 starts at offset 576
             struct reg_128 ymm0[16];
-            unsigned char padding3[64];
-            unsigned char padding4[192]; // mpx save area
+            unsigned char padding3[128];
+            struct reg_128 bndregs[4];
+            struct reg_128 bndcfg;
+            unsigned char padding4[48];
+            unsigned char padding6[1600];
+            unsigned int pkru;
+            unsigned char padding7[60];
         };
         #pragma pack(pop)
         """

--- a/libdebug/cffi/ptrace_cffi_source.c
+++ b/libdebug/cffi/ptrace_cffi_source.c
@@ -29,9 +29,9 @@
     #if (FPREGS_AVX == 0)
         _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 512, "user_fpregs_struct size is not 512 bytes");
     #elif (FPREGS_AVX == 1)
-        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 1088, "user_fpregs_struct size is not 1088 bytes");
+        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 2752, "user_fpregs_struct size is not 2752 bytes");
     #elif (FPREGS_AVX == 2)
-        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 2696, "user_fpregs_struct size is not 2696 bytes");
+        _Static_assert((sizeof(struct fp_regs_struct) - offsetof(struct fp_regs_struct, padding0)) == 2752, "user_fpregs_struct size is not 2752 bytes");
     #else
         #error "FPREGS_AVX must be 0, 1 or 2"
     #endif


### PR DESCRIPTION
Some devices have PKRU enabled and a very inefficient xsave state for some reason. It's just wrong.

Note: this is not the best way of solving the issue, it's just a temporary fix until we deploy a better build system (shortly, I hope)