### PR TITLE
Default for continue_to_binary_entrypoint equal to False

### DIFF
--- a/libdebug/libdebug.py
+++ b/libdebug/libdebug.py
@@ -15,7 +15,7 @@ def debugger(
     aslr: bool = True,
     env: dict[str, str] | None = None,
     escape_antidebug: bool = False,
-    continue_to_binary_entrypoint: bool = True,
+    continue_to_binary_entrypoint: bool = False,
     auto_interrupt_on_command: bool = False,
     fast_memory: bool = False,
     kill_on_exit: bool = True,

--- a/test/scripts/pprint_syscalls_test.py
+++ b/test/scripts/pprint_syscalls_test.py
@@ -38,7 +38,7 @@ class PPrintSyscallsTest(TestCase):
         sys.stdout = sys.__stdout__
 
     def test_pprint_syscalls_generic(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
         d.pprint_syscalls = True
@@ -66,7 +66,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count("exit_group"), 1)
 
     def test_pprint_syscalls_with_statement(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
         with d.pprint_syscalls_context(True):
@@ -100,7 +100,7 @@ class PPrintSyscallsTest(TestCase):
         def on_exit_read(d, sh):
             d.syscall_return = 0xDEADBEEF
 
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
         d.pprint_syscalls = True
@@ -136,7 +136,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count("callback"), 1)
 
     def test_pprint_hijack_syscall(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -171,7 +171,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count("hijacked"), 1)
 
     def test_pprint_which_syscalls_pprint_after(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -196,7 +196,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count(MMAP_NAME), 1)
 
     def test_pprint_which_syscalls_pprint_before(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
         r = d.run()
 
         d.syscalls_to_pprint = [READ_NUM, "write", MMAP_NUM]  # before d.pprint_syscalls = True
@@ -220,7 +220,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count(MMAP_NAME), 1)
 
     def test_pprint_which_syscalls_pprint_after_and_before(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
         r = d.run()
 
         d.syscalls_to_pprint = [READ_NUM, "write", MMAP_NUM]
@@ -244,7 +244,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count(MMAP_NAME), 1)
 
     def test_pprint_which_syscalls_not_pprint_after(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
         r = d.run()
 
         d.pprint_syscalls = True
@@ -267,7 +267,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count("exit_group"), 1)
 
     def test_pprint_which_syscalls_not_pprint_before(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
         r = d.run()
 
         d.syscalls_to_not_pprint = [READ_NUM, "write", MMAP_NUM]
@@ -290,7 +290,7 @@ class PPrintSyscallsTest(TestCase):
         self.assertEqual(self.capturedOutput.getvalue().count("exit_group"), 1)
 
     def test_pprint_which_syscalls_not_pprint_after_and_before(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
         r = d.run()
 
         d.syscalls_to_not_pprint = [READ_NUM, "write", MMAP_NUM]

--- a/test/scripts/syscall_handle_test.py
+++ b/test/scripts/syscall_handle_test.py
@@ -64,7 +64,7 @@ class SyscallHandleTest(TestCase):
         self.log_handler.close()
 
     def test_handles(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -117,7 +117,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handles_with_pprint(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -173,7 +173,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handle_disabling(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -235,7 +235,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handle_disabling_with_pprint(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -299,7 +299,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handle_overwrite(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -372,7 +372,7 @@ class SyscallHandleTest(TestCase):
         )
 
     def test_handle_overwrite_with_pprint(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -448,7 +448,7 @@ class SyscallHandleTest(TestCase):
 
 
     def test_handles_sync(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -511,7 +511,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
     
     def test_handles_sync_with_pprint(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -576,7 +576,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handles_sync_hit_on(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -654,7 +654,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
 
     def test_handles_empty_callback(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         r = d.run()
 
@@ -675,7 +675,7 @@ class SyscallHandleTest(TestCase):
         self.assertEqual(handler3.hit_count, 1)
         
     def test_handle_all_syscalls(self):
-        d = debugger(RESOLVE_EXE("handle_syscall_test"))
+        d = debugger(RESOLVE_EXE("handle_syscall_test"), continue_to_binary_entrypoint=True)
 
         for value in ["all", "*", "ALL", -1, "pkm"]:
             r = d.run()


### PR DESCRIPTION
This is a proposal for version 0.8.0.

All tests have passed (I only modified the tests related to syscalls to exclude some additional syscalls made before the entry point).

The advantage is improved performance, as there will be no breakpoint at each run.