### PR TITLE
Multiple bps

### DIFF
--- a/libdebug/data/breakpoint.py
+++ b/libdebug/data/breakpoint.py
@@ -68,7 +68,8 @@ class Breakpoint:
 
         internal_debugger = provide_internal_debugger(self)
         internal_debugger.ensure_process_stopped()
-        return internal_debugger.resume_context.event_hit_ref.get(thread_context.thread_id) == self
+        events = internal_debugger.resume_context.event_hit_ref.get(thread_context.thread_id, [])
+        return self in events
 
     def __hash__(self: Breakpoint) -> int:
         """Hash the breakpoint by its address, so that it can be used in sets and maps correctly."""

--- a/libdebug/data/breakpoint.py
+++ b/libdebug/data/breakpoint.py
@@ -52,13 +52,11 @@ class Breakpoint:
     def enable(self: Breakpoint) -> None:
         """Enable the breakpoint."""
         provide_internal_debugger(self).ensure_process_stopped()
-        self.enabled = True
         self._changed = True
 
     def disable(self: Breakpoint) -> None:
         """Disable the breakpoint."""
         provide_internal_debugger(self).ensure_process_stopped()
-        self.enabled = False
         self._changed = True
 
     def hit_on(self: Breakpoint, thread_context: ThreadContext) -> bool:

--- a/libdebug/data/breakpoint_list.py
+++ b/libdebug/data/breakpoint_list.py
@@ -1,0 +1,87 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2024 Gabriele Digregorio. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libdebug.data.breakpoint import Breakpoint
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from libdebug.state.thread_context import ThreadContext
+
+
+class BreakpointList(list):
+    """A list of breakpoints installed at the same address in the target process.
+
+    Attributes:
+        address (int): The address of the breakpoints installed in the target process.
+        symbol (str): The symbol, if available, of the breakpoints installed in the target process.
+        hit_count (int): The sum of the hit counts of all the breakpoints inside the BreakpointList.
+        callback list[Callable[[ThreadContext, Breakpoint], None]]: The list of callbacks defined by the user to execute when the breakpoints are hit.
+        enabled (bool): Whether at least one of the breakpoints is enabled or not.
+    """
+
+    address: int = 0
+    symbol: str = ""
+
+    def __init__(self: BreakpointList, breakpoints: list[Breakpoint], address: int, symbol: str) -> None:
+        """Initializes the BreakpointList."""
+        self.address = address
+        self.symbol = symbol
+        super().__init__(breakpoints)
+
+    @property
+    def hit_count(self: BreakpointList) -> int:
+        """Returns the sum of the hit counts of all the breakpoints inside the BreakpointList."""
+        return sum(bp.hit_count for bp in self)
+
+    @property
+    def callback(self: BreakpointList) -> list[Callable[[ThreadContext, Breakpoint], None]]:
+        """Returns the list of callbacks defined by the user to execute when the breakpoints are hit."""
+        return [bp.callback for bp in self]
+
+    @property
+    def enabled(self: BreakpointList) -> bool:
+        """Returns whether at least one of the breakpoints is enabled or not."""
+        return any(bp.enabled for bp in self)
+
+    def filter(self: BreakpointList, **kwargs: dict[str, object]) -> BreakpointList:
+        """Filters the breakpoints according to the specified Breakpoint attributes.
+
+        Args:
+            **kwargs: The arguments to filter the breakpoints. It can be any Breakpoint attribute.
+
+        Returns:
+            BreakpointList[Breakpoint]: The list of breakpoints installed in the specified thread and/or with the specified condition.
+        """
+        if not kwargs:
+            return self
+
+        filtered_breakpoints = self
+        for key, value in kwargs.items():
+            if key not in Breakpoint.__annotations__:
+                raise ValueError(f"Invalid attribute: {key} is not a valid Breakpoint attribute")
+            if key == "thread_id":
+                filtered_breakpoints = [bp for bp in filtered_breakpoints if bp.thread_id in (value, -1)]
+            else:
+                filtered_breakpoints = [bp for bp in filtered_breakpoints if getattr(bp, key) == value]
+
+        return BreakpointList(filtered_breakpoints, self.address, self.symbol)
+
+    def __hash__(self) -> int:
+        """Return the hash of the symbol list."""
+        return hash(id(self))
+
+    def __eq__(self, other: object) -> bool:
+        """Check if the symbol list is equal to another object."""
+        return super().__eq__(other)
+
+    def __repr__(self: BreakpointList) -> str:
+        """Returns the string representation of the BreakpointList without the default factory."""
+        return f"BreakpointList({super().__repr__()})"

--- a/libdebug/data/symbol_list.py
+++ b/libdebug/data/symbol_list.py
@@ -18,7 +18,7 @@ class SymbolList(list):
     """A list of symbols in the target process."""
 
     def __init__(self: SymbolList, symbols: list[Symbol]) -> None:
-        """Initializes the SymbolDict."""
+        """Initializes the SymbolList."""
         super().__init__(symbols)
 
     def _search_by_address(self: SymbolList, address: int) -> list[Symbol]:
@@ -95,5 +95,5 @@ class SymbolList(list):
         return super().__eq__(other)
 
     def __repr__(self: SymbolList) -> str:
-        """Returns the string representation of the SymbolDict without the default factory."""
+        """Returns the string representation of the SymbolList without the default factory."""
         return f"SymbolList({super().__repr__()})"

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -29,7 +29,6 @@ from libdebug.builtin.pretty_print_syscall_handler import (
     pprint_on_exit,
 )
 from libdebug.data.breakpoint import Breakpoint
-from libdebug.data.breakpoint_list import BreakpointList
 from libdebug.data.gdb_resume_event import GdbResumeEvent
 from libdebug.data.signal_catcher import SignalCatcher
 from libdebug.data.syscall_handler import SyscallHandler
@@ -50,10 +49,10 @@ from libdebug.utils.arch_mappings import map_arch
 from libdebug.utils.debugger_wrappers import (
     background_alias,
     change_state_function_process,
-    change_state_function_thread,
 )
 from libdebug.utils.debugging_utils import (
     normalize_and_validate_address,
+    resolve_address_in_maps,
     resolve_symbol_in_maps,
 )
 from libdebug.utils.elf_utils import get_all_symbols
@@ -586,7 +585,7 @@ class InternalDebugger:
 
         link_to_internal_debugger(bp, self)
 
-        self.__polling_thread_command_queue.put((self.__threaded_breakpoint, (bp, )))
+        self.__polling_thread_command_queue.put((self.__threaded_breakpoint, (bp,)))
 
         self._join_and_check_status()
 

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -573,7 +573,7 @@ void LibdebugPtraceInterface::forward_signals(const std::vector<std::pair<pid_t,
     }
 }
 
-void LibdebugPtraceInterface::register_breakpoint(const unsigned long address)
+void LibdebugPtraceInterface::install_breakpoint(const unsigned long address)
 {
     unsigned long instruction = ptrace(PTRACE_PEEKTEXT, process_id, (void *) address, NULL);
 
@@ -595,7 +595,7 @@ void LibdebugPtraceInterface::register_breakpoint(const unsigned long address)
     software_breakpoints[address] = bp;
 }
 
-void LibdebugPtraceInterface::unregister_breakpoint(const unsigned long address)
+void LibdebugPtraceInterface::uninstall_breakpoint(const unsigned long address)
 {
     if (software_breakpoints.find(address) == software_breakpoints.end()) {
         throw std::runtime_error("Breakpoint not found");
@@ -626,7 +626,7 @@ void LibdebugPtraceInterface::disable_breakpoint(const unsigned long address)
     ptrace(PTRACE_POKETEXT, process_id, (void *) address, (void *) software_breakpoints[address].instruction);
 }
 
-void LibdebugPtraceInterface::register_hw_breakpoint(const pid_t tid, unsigned long address, const int type, const int len)
+void LibdebugPtraceInterface::install_hw_breakpoint(const pid_t tid, unsigned long address, const int type, const int len)
 {
     Thread &t = get_thread(tid);
 
@@ -648,7 +648,7 @@ void LibdebugPtraceInterface::register_hw_breakpoint(const pid_t tid, unsigned l
     install_hardware_breakpoint(bp);
 }
 
-void LibdebugPtraceInterface::unregister_hw_breakpoint(const pid_t tid, const unsigned long address)
+void LibdebugPtraceInterface::uninstall_hw_breakpoint(const pid_t tid, const unsigned long address)
 {
     if (threads.find(tid) == threads.end()) {
         return;
@@ -927,13 +927,13 @@ NB_MODULE(libdebug_ptrace_binding, m)
             "    tid (int): The thread id to get the remaining hardware watchpoint count for.\n"
         )
         .def(
-            "register_hw_breakpoint",
-            &LibdebugPtraceInterface::register_hw_breakpoint,
+            "install_hw_breakpoint",
+            &LibdebugPtraceInterface::install_hw_breakpoint,
             nb::arg("tid"),
             nb::arg("address"),
             nb::arg("type"),
             nb::arg("len"),
-            "Registers a hardware breakpoint for a thread.\n"
+            "Install a hardware breakpoint for a thread.\n"
             "\n"
             "Args:\n"
             "    tid (int): The thread id to register the hardware breakpoint for.\n"
@@ -942,11 +942,11 @@ NB_MODULE(libdebug_ptrace_binding, m)
             "    len (int): The length of the hardware breakpoint."
         )
         .def(
-            "unregister_hw_breakpoint",
-            &LibdebugPtraceInterface::unregister_hw_breakpoint,
+            "uninstall_hw_breakpoint",
+            &LibdebugPtraceInterface::uninstall_hw_breakpoint,
             nb::arg("tid"),
             nb::arg("address"),
-            "Unregisters a hardware breakpoint for a thread.\n"
+            "Uninstall a hardware breakpoint for a thread.\n"
             "\n"
             "Args:\n"
             "    tid (int): The thread id to unregister the hardware breakpoint for.\n"
@@ -965,19 +965,19 @@ NB_MODULE(libdebug_ptrace_binding, m)
             "    int: The address of the hit hardware breakpoint."
         )
         .def(
-            "register_breakpoint",
-            &LibdebugPtraceInterface::register_breakpoint,
+            "install_breakpoint",
+            &LibdebugPtraceInterface::install_breakpoint,
             nb::arg("address"),
-            "Registers a software breakpoint at a specific address.\n"
+            "Install a software breakpoint at a specific address.\n"
             "\n"
             "Args:\n"
             "    address (int): The address to set the software breakpoint at."
         )
         .def(
-            "unregister_breakpoint",
-            &LibdebugPtraceInterface::unregister_breakpoint,
+            "uninstall_breakpoint",
+            &LibdebugPtraceInterface::uninstall_breakpoint,
             nb::arg("address"),
-            "Unregisters a software breakpoint at a specific address.\n"
+            "Uninstall a software breakpoint at a specific address.\n"
             "\n"
             "Args:\n"
             "    address (int): The address to remove the software breakpoint from."

--- a/libdebug/ptrace/native/libdebug_ptrace_interface.h
+++ b/libdebug/ptrace/native/libdebug_ptrace_interface.h
@@ -77,14 +77,14 @@ public:
     void forward_signals(const std::vector<std::pair<pid_t, int>>);
 
     // Debugger software breakpoint methods
-    void register_breakpoint(const unsigned long);
-    void unregister_breakpoint(const unsigned long);
+    void install_breakpoint(const unsigned long);
+    void uninstall_breakpoint(const unsigned long);
     void enable_breakpoint(const unsigned long);
     void disable_breakpoint(const unsigned long);
 
     // Debugger hardware breakpoint methods
-    void register_hw_breakpoint(const pid_t, unsigned long address, const int type, const int len);
-    void unregister_hw_breakpoint(const pid_t, const unsigned long);
+    void install_hw_breakpoint(const pid_t, unsigned long address, const int type, const int len);
+    void uninstall_hw_breakpoint(const pid_t, const unsigned long);
     unsigned long get_hit_hw_breakpoint(const pid_t);
     int get_remaining_hw_breakpoint_count(const pid_t);
     int get_remaining_hw_watchpoint_count(const pid_t);

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -912,6 +912,11 @@ class PtraceInterface(DebuggingInterface):
             bp (Breakpoint): The breakpoint to unset.
             delete (bool): Whether the breakpoint has to be deleted or just disabled.
         """
+        bp_list = self._internal_debugger.breakpoints.get(bp.address)
+        if bp_list.enabled:
+            # There is still an enabled bp to that location. We don't want to unset it.
+            return
+
         if bp.hardware and bp.thread_id == -1:
             # If the breakpoint is hardware and no thread ID is specified, we unset the breakpoint for all threads
             for thread in self._internal_debugger.internal_threads:

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -912,7 +912,17 @@ class PtraceInterface(DebuggingInterface):
             bp (Breakpoint): The breakpoint to unset.
             delete (bool): Whether the breakpoint has to be deleted or just disabled.
         """
+        # If the breakpoint is still enabled, we need to set the flag to False
+        bp.enabled = False
+
+        # We need to check if there are other breakpoints at the same address
         bp_list = self._internal_debugger.breakpoints.get(bp.address)
+
+        if bp.hardware:
+            # The breakpoint is hardware, we need to check if there are other breakpoints at the same address only for
+            # the same thread
+            bp_list = bp_list.filter(thread_id=bp.thread_id)
+
         if bp_list.enabled:
             # There is still an enabled bp to that location. We don't want to unset it.
             return

--- a/libdebug/state/internal_thread_context.py
+++ b/libdebug/state/internal_thread_context.py
@@ -143,6 +143,16 @@ class InternalThreadContext:
 
         return return_address
 
+    @property
+    def breakpoints(self: InternalThreadContext) -> dict[int, Breakpoint]:
+        """Get the breakpoints set on the thread."""
+        thread_breakpoints = {}
+
+        for breakpoint_list in self._internal_debugger.breakpoints.values():
+            if breakpoint_list_filtered := breakpoint_list.filter(thread_id=self.thread_id):
+                thread_breakpoints[breakpoint_list.address] = breakpoint_list_filtered
+        return thread_breakpoints
+
     def cont(self: InternalThreadContext) -> None:
         """Continues the execution of the thread."""
         self._internal_debugger.cont(self)

--- a/libdebug/state/resume_context.py
+++ b/libdebug/state/resume_context.py
@@ -29,7 +29,7 @@ class ResumeContext:
         self.block_on_signal: bool = False
         self.threads_with_signals_to_forward: list[int] = []
         self.event_type: dict[int, EventType] = {}
-        self.event_hit_ref: dict[int, Breakpoint | SignalCatcher | SyscallHandler] = {}
+        self.event_hit_ref: dict[int, list[Breakpoint | SignalCatcher | SyscallHandler]] = {}
 
     def clear(self: ResumeContext) -> None:
         """Clears the context."""

--- a/libdebug/state/thread_context.py
+++ b/libdebug/state/thread_context.py
@@ -257,6 +257,11 @@ class ThreadContext:
         self._internal_thread_context._internal_debugger.ensure_process_stopped()
         return self._internal_thread_context.signal_number
 
+    @property
+    def breakpoints(self: ThreadContext) -> dict[int, Breakpoint]:
+        """Get the breakpoints set on the thread."""
+        return self._internal_thread_context.breakpoints
+
     def cont(self: ThreadContext) -> None:
         """Continues the execution of the thread."""
         self._internal_thread_context.cont()

--- a/test/scripts/breakpoint_test.py
+++ b/test/scripts/breakpoint_test.py
@@ -768,7 +768,7 @@ class BreakpointTest(TestCase):
     
     def test_bp_async_sw_thread_scoped(self):
         def callback(t, bp):
-            # self.assertEqual(t.thread_id, target.thread_id)
+            self.assertEqual(t.thread_id, target.thread_id)
             pass
         
         d = debugger(RESOLVE_EXE("multithread_input"))
@@ -956,6 +956,103 @@ class BreakpointTest(TestCase):
 
         d.kill()
         d.terminate()
+        
+    def test_multiple_bps_async_both_sw_hw(self):
+        counter_1_1, counter_1_2 = 0, 0
+        counter_2_1, counter_2_2 = 0, 0
+        counter_3_1, counter_3_2 = 0, 0
+        
+        def first_first(t, bp):
+            nonlocal counter_1_1
+            counter_1_1 += 1
+            
+            # This callback should be called before the second one
+            self.assertGreater(counter_1_1, counter_1_2)
+            
+        def first_second(t, bp):
+            nonlocal counter_1_2
+            counter_1_2 += 1
+            
+            # This callback should be called after the first one
+            self.assertTrue(counter_1_2 == counter_1_1 or counter_1_2 == counter_1_1 - 1)
+            
+        def second_first(t, bp):
+            nonlocal counter_2_1
+            counter_2_1 += 1
+            
+            # This callback should be called before the second one
+            self.assertGreater(counter_2_1, counter_2_2)
+            
+        def second_second(t, bp):
+            nonlocal counter_2_2
+            counter_2_2 += 1
+            
+            # This callback should be called after the first one
+            self.assertTrue(counter_2_2 == counter_2_1 or counter_2_2 == counter_2_1 - 1)
+            
+        def third_first(t, bp):
+            nonlocal counter_3_1
+            counter_3_1 += 1
+            
+            # This callback should be called before the second one
+            self.assertGreater(counter_3_1, counter_3_2)
+            
+        def third_second(t, bp):
+            nonlocal counter_3_2
+            counter_3_2 += 1
+            
+            # This callback should be called after the first one
+            self.assertTrue(counter_3_2 == counter_3_1 or counter_3_2 == counter_3_1 - 1)
+    
+        d = debugger(RESOLVE_EXE("breakpoint_test"))
+
+        d.run()
+
+        bp1_1 = d.breakpoint("random_function", callback=first_first)
+        bp1_1_hw = d.breakpoint("random_function", callback=first_first, hardware=True)
+        bp1_2 = d.breakpoint("random_function", callback=first_second)
+        bp1_2_hw = d.breakpoint("random_function", callback=first_second, hardware=True)
+        bp2_1 = d.breakpoint(TEST_BPS_ADDRESS_1, callback=second_first)
+        bp2_1_hw = d.breakpoint(TEST_BPS_ADDRESS_1, callback=second_first, hardware=True)
+        bp2_2 = d.breakpoint(TEST_BPS_ADDRESS_1, callback=second_second)
+        bp2_2_hw = d.breakpoint(TEST_BPS_ADDRESS_1, callback=second_second, hardware=True)
+        bp3_1 = d.breakpoint(TEST_BPS_ADDRESS_2, callback=third_first)
+        bp3_1_hw = d.breakpoint(TEST_BPS_ADDRESS_2, callback=third_first, hardware=True)
+        bp3_2 = d.breakpoint(TEST_BPS_ADDRESS_2, callback=third_second)
+        bp3_2_hw = d.breakpoint(TEST_BPS_ADDRESS_2, callback=third_second, hardware=True)
+
+        d.cont()
+        
+        d.wait()
+
+        self.assertEqual(counter_1_1, 2)
+        self.assertEqual(counter_1_2, 2)
+        self.assertEqual(counter_2_1, 20)
+        self.assertEqual(counter_2_2, 20)
+        self.assertEqual(counter_3_1, 2)
+        self.assertEqual(counter_3_2, 2)
+        
+        self.assertEqual(bp1_1.hit_count, counter_1_1 // 2)
+        self.assertEqual(bp1_2.hit_count, counter_1_2 // 2)
+        self.assertEqual(bp2_1.hit_count, counter_2_1 // 2)
+        self.assertEqual(bp2_2.hit_count, counter_2_2 // 2)
+        self.assertEqual(bp3_1.hit_count, counter_3_1 // 2)
+        self.assertEqual(bp3_2.hit_count, counter_3_2 // 2)
+        
+        self.assertEqual(bp1_1_hw.hit_count, counter_1_1 // 2)
+        self.assertEqual(bp1_2_hw.hit_count, counter_1_2 // 2)
+        self.assertEqual(bp2_1_hw.hit_count, counter_2_1 // 2)
+        self.assertEqual(bp2_2_hw.hit_count, counter_2_2 // 2)
+        self.assertEqual(bp3_1_hw.hit_count, counter_3_1 // 2)
+        self.assertEqual(bp3_2_hw.hit_count, counter_3_2 // 2)
+        
+        
+        self.assertEqual(d.breakpoints[bp1_1.address].hit_count, 4)
+        self.assertEqual(d.breakpoints[TEST_BPS_ADDRESS_1].hit_count, 40)
+        self.assertEqual(d.breakpoints[TEST_BPS_ADDRESS_2].hit_count, 4)
+
+        d.kill()
+        d.terminate()
     
     
     def test_multiple_bps_disable(self):
@@ -1039,4 +1136,45 @@ class BreakpointTest(TestCase):
         self.assertEqual(d.breakpoints[TEST_BPS_ADDRESS_2].hit_count, 2)
 
         d.kill()
+        d.terminate()
+    
+    def test_max_number_hw_bp_scoped(self):
+        def callback(t, bp):
+            self.assertEqual(t.thread_id, target.thread_id)
+            pass
+        
+        d = debugger(RESOLVE_EXE("multithread_input"))
+        
+        r = d.run()
+        
+        d.cont()
+        
+        # Let wait all threads to be created
+        r.recvuntil(b"All threads have been created.")
+        
+        # Interrupt the process
+        d.interrupt()
+        
+        # Choice a target
+        target = d.threads[2]
+        other_threads = d.threads.copy()
+        other_threads.remove(target)
+        
+        # Set bps on the target thread until we finish the hardware breakpoints
+        offset = 0
+        while True:
+            try:
+                bp = target.bp(TEST_THREAD_SCOPED_END_THREAD + offset, file="binary", callback=callback, hardware=True)
+            except ValueError:
+                break
+            offset += 0x10
+            
+        # At this point we should be able to set sw breakpoints on the same thread
+        bp = target.bp(TEST_THREAD_SCOPED_END_THREAD + offset, file="binary", callback=callback)
+        
+        # We should also be able to set hw breakpoints on other threads
+        for thread in other_threads:
+            thread.bp(TEST_THREAD_SCOPED_END_THREAD, file="binary", hardware=True)
+        
+        d.kill()        
         d.terminate()


### PR DESCRIPTION
This PR introduces support for multiple breakpoints at the same location. Below are the design choices I made during development to ensure alignment:

- **Breakpoint Dictionary Enhancement:**
  - The breakpoints dictionary now contains, for each key, a `BreakpointList` type similar to other custom types in `libdebug`. This supports the `filter` method, allowing filtering by any breakpoint attribute.

- **Hardware Breakpoints on Specific Threads:**
  - When you install a hardware breakpoint on a specific thread, it is installed only on that thread. While this behavior is not entirely consistent with software breakpoints internally in `libdebug`, it aligns with external behavior and allows the saving of precious hardware breakpoints.

- **Process-Scoped Software Breakpoints:**
  - Since software breakpoints must be installed process-scoped, when they are installed on a specific thread, they are ignored if hit by other threads internally by `libdebug`.

- **Managing Multiple Hardware Breakpoints:**
  - Multiple hardware breakpoints installed at the same position with identical conditions and lengths are managed internally, resulting in only one hardware breakpoint register being used. If they differ in any way, different registers are used. Again, I tried to save as many hw breakpoints as possible without making risky assumptions. 

- **Coexistence of Software and Hardware Breakpoints:**
  - If a user installs both software and hardware breakpoints at the same location, both are installed within the process/thread. While we can optimize by converting all breakpoints to hardware for increased speed, software and hardware breakpoints may exhibit different behaviors that users might want to exploit.