### PR TITLE
d.gdb fixes

### DIFF
--- a/libdebug/data/terminals.py
+++ b/libdebug/data/terminals.py
@@ -26,6 +26,7 @@ class TerminalTypes:
         "tmux: server": ["tmux", "split-window", "-h"],
         "xfce4-terminal": ["xfce4-terminal", "--tab", "-e"],
         "terminator": ["terminator", "--new-tab", "-e"],
+        "ptyxis-agent": ["ptyxis-agent", "--tab", "-x"],
     }
 
     @staticmethod

--- a/libdebug/data/terminals.py
+++ b/libdebug/data/terminals.py
@@ -26,7 +26,7 @@ class TerminalTypes:
         "tmux: server": ["tmux", "split-window", "-h"],
         "xfce4-terminal": ["xfce4-terminal", "--tab", "-e"],
         "terminator": ["terminator", "--new-tab", "-e"],
-        "ptyxis-agent": ["ptyxis-agent", "--tab", "-x"],
+        "ptyxis-agent": ["ptyxis", "--tab", "-x"],
     }
 
     @staticmethod

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -897,8 +897,8 @@ class InternalDebugger:
         """
         # Check if the terminal has been configured correctly
         try:
-            check_call(libcontext.terminal, stderr=DEVNULL)
-        except CalledProcessError as err:
+            check_call([*libcontext.terminal, "uname"], stderr=DEVNULL, stdout=DEVNULL)
+        except (CalledProcessError, FileNotFoundError) as err:
             raise RuntimeError(
                 "Failed to open GDB in terminal. Check the terminal configuration in libcontext.terminal.",
             ) from err

--- a/libdebug/ptrace/native/libdebug_ptrace_interface.h
+++ b/libdebug/ptrace/native/libdebug_ptrace_interface.h
@@ -59,6 +59,7 @@ public:
     // Debugger process methods
     int attach(const pid_t);
     void detach_for_migration();
+    void reattach_from_migration();
     void detach_and_cont();
     void detach_for_kill();
     void set_tracing_options();

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -522,14 +522,14 @@ class PtraceInterface(DebuggingInterface):
                         bp.address,
                     )
 
-        self.lib_trace.ptrace_detach_for_migration(self._global_state, self.process_id)
+        self.lib_trace.detach_for_migration()
 
     def migrate_from_gdb(self: PtraceInterface) -> None:
         """Migrates the current process from GDB."""
-        self.lib_trace.ptrace_reattach_from_gdb(self._global_state, self.process_id)
-
         invalidate_process_cache()
-        self.status_handler.check_for_new_threads(self.process_id)
+        self.status_handler.check_for_changes_in_threads(self.process_id)
+
+        self.lib_trace.reattach_from_migration()
 
         # We have to reinstall any hardware breakpoint
         for bp in self._internal_debugger.breakpoints.values():

--- a/test/other_tests/gdb_migration_test.py
+++ b/test/other_tests/gdb_migration_test.py
@@ -11,7 +11,7 @@ Single thread test
 """
 d = debugger("../binaries/amd64/basic_test")
 
-libcontext.terminal = ["tmux", "splitw", "-h"]
+# libcontext.terminal = ["tmux", "splitw", "-h"]
 # libcontext.terminal = ["gnome-terminal", "--tab", "--"]
 
 d.run()

--- a/test/other_tests/gdb_migration_test.py
+++ b/test/other_tests/gdb_migration_test.py
@@ -11,7 +11,7 @@ Single thread test
 """
 d = debugger("../binaries/amd64/basic_test")
 
-# libcontext.terminal = ["tmux", "splitw", "-h"]
+libcontext.terminal = ["tmux", "splitw", "-h"]
 # libcontext.terminal = ["gnome-terminal", "--tab", "--"]
 
 d.run()

--- a/test/other_tests/gdb_migration_test.py
+++ b/test/other_tests/gdb_migration_test.py
@@ -6,9 +6,12 @@
 
 from libdebug import debugger, libcontext
 
-d = debugger("binaries/basic_test")
+"""
+Single thread test
+"""
+d = debugger("../binaries/amd64/basic_test")
 
-libcontext.terminal = ["tmux", "splitw", "-h"]
+# libcontext.terminal = ["tmux", "splitw", "-h"]
 # libcontext.terminal = ["gnome-terminal", "--tab", "--"]
 
 d.run()
@@ -32,5 +35,49 @@ print(hex(d.regs.rip))
 d.step()
 
 print(hex(d.regs.rip))
+
+d.kill()
+
+"""
+Multi thread test 1
+"""
+d = debugger("../binaries/amd64/multithread_input")
+
+d.run(redirect_pipes=False)
+
+# Before other threads are created
+d.bp(0x12e1, file="binary")
+
+d.cont()
+
+d.wait()
+
+
+# Continue until all the threads are created
+d.gdb()
+
+assert len(d.threads) > 1
+
+d.kill()
+
+
+"""
+Multi thread test 2
+"""
+d = debugger("../binaries/amd64/multithread_input")
+
+d.run(redirect_pipes=False)
+
+# After other threads are created
+d.bp(0x1390, file="binary")
+
+d.cont()
+
+d.wait()
+
+# Continue and input until a couple of threads finish their execution
+d.gdb()
+
+assert len([t for t in d.threads if t.dead]) > 1
 
 d.kill()


### PR DESCRIPTION
This PR fixes `d.gdb` for the new `libdebug` version based on `nanobind`.

Moreover, it:
- Introduces support for the `ptyxis` terminal for autodetection. I ask @MrIndeciso to test it on your Fedora-based supercomputer. On Ubuntu 22.04, the official setup involves Flathub.
- Solves some edge cases when the terminal is not correctly set.