### PR TITLE
Removed -getpgid from wait (2)

### DIFF
--- a/libdebug/data/symbol_list.py
+++ b/libdebug/data/symbol_list.py
@@ -79,12 +79,22 @@ class SymbolList(list):
 
         return SymbolList(filtered_symbols)
 
-    def __getitem__(self: SymbolList, key: str) -> Symbol:
-        """Returns the symbol with the specified name."""
+    def __getitem__(self: SymbolList, key: str | int) -> SymbolList[Symbol] | Symbol:
+        """Returns the symbol with the specified name.
+
+        Args:
+            key (str, int): The name of the symbol to return, or the index of the symbol in the list.
+
+        Returns:
+            Symbol | SymbolList[Symbol]: The symbol at the specified index, or the SymbolList of symbols with the specified name.
+        """
+        if isinstance(key, int):
+            return super().__getitem__(key)
+
         symbols = [symbol for symbol in self if symbol.name == key]
         if not symbols:
             raise KeyError(f"Symbol '{key}' not found.")
-        return symbols
+        return SymbolList(symbols)
 
     def __hash__(self) -> int:
         """Return the hash of the symbol list."""

--- a/libdebug/data/symbol_list.py
+++ b/libdebug/data/symbol_list.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024 Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2024-2025 Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/libdebug/data/terminals.py
+++ b/libdebug/data/terminals.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024 Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2024-2025 Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
+# Copyright (c) 2023-2025 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/libdebug/native/symbols/debug_sym_parser.cpp
+++ b/libdebug/native/symbols/debug_sym_parser.cpp
@@ -1,6 +1,6 @@
 //
 // This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-// Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+// Copyright (c) 2023-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 

--- a/libdebug/native/symbols/debug_sym_parser.cpp
+++ b/libdebug/native/symbols/debug_sym_parser.cpp
@@ -142,7 +142,7 @@ const ElfInfo read_elf_info(const std::string &elf_file_path, const int debug_in
     }
 
     if (access(elf_file_path.c_str(), R_OK) == -1) {
-        throw std::invalid_argument("File not found or not readable: " + elf_file_path);
+        return {"", "", symbols};
     }
 
     if ((fd = open(elf_file_path.c_str(), O_RDONLY, 0)) < 0) {

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -460,6 +460,10 @@ std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_
         }
     }
 
+    if (tid == -1) {
+        throw std::runtime_error("waitpid failed");
+    }
+
     thread_statuses.push_back({tid, status});
 
     // We must interrupt all the other threads with a SIGSTOP

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -1,6 +1,6 @@
 //
 // This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-// Copyright (c) 2024 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
+// Copyright (c) 2024-2025 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 

--- a/libdebug/ptrace/native/libdebug_ptrace_interface.h
+++ b/libdebug/ptrace/native/libdebug_ptrace_interface.h
@@ -12,7 +12,7 @@ class LibdebugPtraceInterface
 {
 
 private:
-    pid_t process_id, group_id;
+    pid_t process_id;
     bool handle_syscall;
     std::map<pid_t, Thread> threads, dead_threads;
     std::map<unsigned long, SoftwareBreakpoint> software_breakpoints;

--- a/libdebug/ptrace/native/libdebug_ptrace_interface.h
+++ b/libdebug/ptrace/native/libdebug_ptrace_interface.h
@@ -1,6 +1,6 @@
 //
 // This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-// Copyright (c) 2024 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
+// Copyright (c) 2024-2025 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini, Francesco Panebianco. All rights reserved.
+# Copyright (c) 2023-2025 Gabriele Digregorio, Roberto Alessandro Bertolini, Francesco Panebianco. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2023-2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/test/other_tests/gdb_migration_test.py
+++ b/test/other_tests/gdb_migration_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2023-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
+# Copyright (c) 2023-2025 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -42,6 +42,7 @@ def fast_suite():
     suite.addTest(TestLoader().loadTestsFromTestCase(scripts.SyscallHijackTest))
     suite.addTest(TestLoader().loadTestsFromTestCase(scripts.ThreadTest))
     suite.addTest(TestLoader().loadTestsFromTestCase(scripts.WatchpointTest))
+    suite.addTest(TestLoader().loadTestsFromTestCase(scripts.SymbolTest))
 
     return suite
 

--- a/test/scripts/__init__.py
+++ b/test/scripts/__init__.py
@@ -31,6 +31,7 @@ from .syscall_hijack_test import SyscallHijackTest
 from .thread_test import ThreadTest
 from .vmwhere1_test import Vmwhere1Test
 from .watchpoint_test import WatchpointTest
+from .symbol_test import SymbolTest
 
 
-__all__ = ["AliasTest", "AntidebugEscapingTest", "AttachDetachTest", "AutoWaitingTest", "BacktraceTest", "BreakpointTest", "BruteTest", "CallbackTest", "ControlFlowTest", "DeathTest", "DeepDiveDivisionTest", "FinishTest", "FloatingPointTest", "JumpoutTest", "JumpstartTest", "LargeBinarySymTest", "MemoryTest", "MemoryFastTest", "MultipleDebuggersTest", "NextTest", "NlinksTest", "PPrintSyscallsTest", "RegisterTest", "SignalCatchTest", "SignalMultithreadTest", "SpeedTest", "SyscallHandleTest", "SyscallHijackTest", "ThreadTest", "Vmwhere1Test", "WatchpointTest"]
+__all__ = ["AliasTest", "AntidebugEscapingTest", "AttachDetachTest", "AutoWaitingTest", "BacktraceTest", "BreakpointTest", "BruteTest", "CallbackTest", "ControlFlowTest", "DeathTest", "DeepDiveDivisionTest", "FinishTest", "FloatingPointTest", "JumpoutTest", "JumpstartTest", "LargeBinarySymTest", "MemoryTest", "MemoryFastTest", "MultipleDebuggersTest", "NextTest", "NlinksTest", "PPrintSyscallsTest", "RegisterTest", "SignalCatchTest", "SignalMultithreadTest", "SpeedTest", "SyscallHandleTest", "SyscallHijackTest", "ThreadTest", "Vmwhere1Test", "WatchpointTest", "SymbolTest"]

--- a/test/scripts/symbol_test.py
+++ b/test/scripts/symbol_test.py
@@ -1,0 +1,26 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Gabriele Digregorio. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from unittest import TestCase
+from utils.binary_utils import RESOLVE_EXE
+
+from libdebug.data.symbol_list import SymbolList
+from libdebug.data.symbol import Symbol
+
+from libdebug import debugger
+
+class SymbolTest(TestCase):
+    def test_bps(self):
+        d = debugger(RESOLVE_EXE("breakpoint_test"))
+
+        d.run()
+
+        self.assertIsInstance(d.symbols["random_function"], SymbolList)
+        self.assertIsInstance(d.symbols[0], Symbol)
+        self.assertIsInstance(d.symbols.filter("random_function"), SymbolList)
+
+        d.kill()
+        d.terminate()


### PR DESCRIPTION
This is the same as #161 but adapted for nanobind. This should address #160.

Dedicated tests will arrive with the multiprocessing feature, as tests on multiprocessing will cover the use case of this fix.