### PR TITLE
Fix syscall signal conflict

### DIFF
--- a/libdebug/ptrace/ptrace_status_handler.py
+++ b/libdebug/ptrace/ptrace_status_handler.py
@@ -429,7 +429,7 @@ class PtraceStatusHandler:
             thread = self.internal_debugger.get_thread_by_id(pid)
 
             if thread is not None:
-                thread._signal_number = signum
+                thread._signal_number = signum & 0x7F
 
                 # Handle the signal
                 self._handle_signal(thread)


### PR DESCRIPTION
This pull request fixes #182 .

The fix is based on #151, but the issue presents itself in versions prior to nanobind conversion.