### PR TITLE
Add some more subclasses and abstract classes to the codebase

### DIFF
--- a/libdebug/architectures/aarch64/aarch64_thread_context.py
+++ b/libdebug/architectures/aarch64/aarch64_thread_context.py
@@ -1,0 +1,27 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libdebug.state.thread_context import ThreadContext
+
+if TYPE_CHECKING:
+    from libdebug.architectures.aarch64.aarch64_ptrace_register_holder import (
+        Aarch64PtraceRegisterHolder,
+    )
+
+
+class Aarch64ThreadContext(ThreadContext):
+    """This object represents a thread in the context of the target aarch64 process. It holds information about the thread's state, registers and stack."""
+
+    def __init__(self: Aarch64ThreadContext, thread_id: int, registers: Aarch64PtraceRegisterHolder) -> None:
+        """Initialize the thread context with the given thread id."""
+        super().__init__(thread_id, registers)
+
+        # Register the thread properties
+        self._register_holder.apply_on_thread(self, Aarch64ThreadContext)

--- a/libdebug/architectures/amd64/amd64_thread_context.py
+++ b/libdebug/architectures/amd64/amd64_thread_context.py
@@ -1,0 +1,27 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libdebug.state.thread_context import ThreadContext
+
+if TYPE_CHECKING:
+    from libdebug.architectures.amd64.amd64_ptrace_register_holder import (
+        Amd64PtraceRegisterHolder,
+    )
+
+
+class Amd64ThreadContext(ThreadContext):
+    """This object represents a thread in the context of the target amd64 process. It holds information about the thread's state, registers and stack."""
+
+    def __init__(self: Amd64ThreadContext, thread_id: int, registers: Amd64PtraceRegisterHolder) -> None:
+        """Initialize the thread context with the given thread id."""
+        super().__init__(thread_id, registers)
+
+        # Register the thread properties
+        self._register_holder.apply_on_thread(self, Amd64ThreadContext)

--- a/libdebug/architectures/amd64/compat/i386_over_amd64_thread_context.py
+++ b/libdebug/architectures/amd64/compat/i386_over_amd64_thread_context.py
@@ -1,0 +1,31 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libdebug.state.thread_context import ThreadContext
+
+if TYPE_CHECKING:
+    from libdebug.architectures.amd64.compat.i386_over_amd64_ptrace_register_holder import (
+        I386OverAMD64PtraceRegisterHolder,
+    )
+
+
+class I386OverAMD64ThreadContext(ThreadContext):
+    """This object represents a thread in the context of the target i386 process when running on amd64. It holds information about the thread's state, registers and stack."""
+
+    def __init__(
+        self: I386OverAMD64ThreadContext,
+        thread_id: int,
+        registers: I386OverAMD64PtraceRegisterHolder,
+    ) -> None:
+        """Initialize the thread context with the given thread id."""
+        super().__init__(thread_id, registers)
+
+        # Register the thread properties
+        self._register_holder.apply_on_thread(self, I386OverAMD64ThreadContext)

--- a/libdebug/architectures/i386/i386_thread_context.py
+++ b/libdebug/architectures/i386/i386_thread_context.py
@@ -1,0 +1,27 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libdebug.state.thread_context import ThreadContext
+
+if TYPE_CHECKING:
+    from libdebug.architectures.i386.i386_ptrace_register_holder import (
+        I386PtraceRegisterHolder,
+    )
+
+
+class I386ThreadContext(ThreadContext):
+    """This object represents a thread in the context of the target i386 process. It holds information about the thread's state, registers and stack."""
+
+    def __init__(self: I386ThreadContext, thread_id: int, registers: I386PtraceRegisterHolder) -> None:
+        """Initialize the thread context with the given thread id."""
+        super().__init__(thread_id, registers)
+
+        # Register the thread properties
+        self._register_holder.apply_on_thread(self, I386ThreadContext)

--- a/libdebug/architectures/thread_context_helper.py
+++ b/libdebug/architectures/thread_context_helper.py
@@ -1,0 +1,32 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2025 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+from libdebug.architectures.aarch64.aarch64_thread_context import Aarch64ThreadContext
+from libdebug.architectures.amd64.amd64_thread_context import Amd64ThreadContext
+from libdebug.architectures.amd64.compat.i386_over_amd64_thread_context import (
+    I386OverAMD64ThreadContext,
+)
+from libdebug.architectures.i386.i386_thread_context import I386ThreadContext
+from libdebug.state.thread_context import ThreadContext
+from libdebug.utils.libcontext import libcontext
+
+
+def thread_context_class_provider(
+    architecture: str,
+) -> type[ThreadContext]:
+    """Returns the class of the thread context to be used by the `_InternalDebugger` class."""
+    match architecture:
+        case "amd64":
+            return Amd64ThreadContext
+        case "aarch64":
+            return Aarch64ThreadContext
+        case "i386":
+            if libcontext.platform == "amd64":
+                return I386OverAMD64ThreadContext
+            else:
+                return I386ThreadContext
+        case _:
+            raise NotImplementedError(f"Architecture {architecture} not available.")

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from libdebug.architectures.call_utilities_provider import call_utilities_provider
 from libdebug.architectures.register_helper import register_holder_provider
+from libdebug.architectures.thread_context_helper import thread_context_class_provider
 from libdebug.commlink.pipe_manager import PipeManager
 from libdebug.data.breakpoint import Breakpoint
 from libdebug.debugger.internal_debugger_instance_manager import (
@@ -27,7 +28,6 @@ from libdebug.interfaces.debugging_interface import DebuggingInterface
 from libdebug.liblog import liblog
 from libdebug.ptrace.native import libdebug_ptrace_binding
 from libdebug.ptrace.ptrace_status_handler import PtraceStatusHandler
-from libdebug.state.thread_context import ThreadContext
 from libdebug.utils.debugging_utils import normalize_and_validate_address
 from libdebug.utils.elf_utils import get_entry_point
 from libdebug.utils.process_utils import (
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from libdebug.data.signal_catcher import SignalCatcher
     from libdebug.data.syscall_handler import SyscallHandler
     from libdebug.debugger.internal_debugger import InternalDebugger
+    from libdebug.state.thread_context import ThreadContext
 
 
 class PtraceInterface(DebuggingInterface):
@@ -552,9 +553,10 @@ class PtraceInterface(DebuggingInterface):
         register_file, fp_register_file = self.lib_trace.register_thread(new_thread_id)
 
         register_holder = register_holder_provider(self._internal_debugger.arch, register_file, fp_register_file)
+        thread_context_class = thread_context_class_provider(self._internal_debugger.arch)
 
         with extend_internal_debugger(self._internal_debugger):
-            thread = ThreadContext(new_thread_id, register_holder)
+            thread = thread_context_class(new_thread_id, register_holder)
 
         self._internal_debugger.insert_new_thread(thread)
 

--- a/libdebug/state/thread_context.py
+++ b/libdebug/state/thread_context.py
@@ -5,6 +5,7 @@
 #
 from __future__ import annotations
 
+from abc import ABC
 from typing import TYPE_CHECKING
 
 from libdebug.architectures.stack_unwinding_provider import stack_unwinding_provider
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from libdebug.memory.abstract_memory_view import AbstractMemoryView
 
 
-class ThreadContext:
+class ThreadContext(ABC):
     """This object represents a thread in the context of the target process. It holds information about the thread's state, registers and stack."""
 
     instruction_pointer: int

--- a/libdebug/state/thread_context.py
+++ b/libdebug/state/thread_context.py
@@ -86,7 +86,6 @@ class ThreadContext:
         regs_class = self._register_holder.provide_regs_class()
         self.regs = regs_class(thread_id, self._register_holder.provide_regs())
         self._register_holder.apply_on_regs(self.regs, regs_class)
-        self._register_holder.apply_on_thread(self, ThreadContext)
 
     def set_as_dead(self: ThreadContext) -> None:
         """Set the thread as dead."""


### PR DESCRIPTION
Fixes an issue where collisions between properties can arise when different architectures are debugged in the same script, currently this can happen only by debugging a i386 executable and an amd64 executable in the same script.

Fixes the CI fail in #186.