### PR TITLE
README Improvements and Citation Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you intend to use libdebug in your projects, please cite the software using t
 }
 ```
 
-We've also published a poster on libdebug. If you use libdebug in your research, you can cite the following paper:
+We've also published a poster on libdebug. If you use libdebug in your research, you can cite the associated short paper:
 ```bibtex
 @inproceedings{10.1145/3658644.3691391,
 author = {Digregorio, Gabriele and Bertolini, Roberto Alessandro and Panebianco, Francesco and Polino, Mario},

--- a/README.md
+++ b/README.md
@@ -83,17 +83,17 @@ from libdebug import debugger, libcontext
 libcontext.terminal = ['tmux', 'splitw', '-h']
 
 # Define signal catchers
-def catcher_SIGUSR1(t: ThreadContext, catcher: SignalCatcher) -> None:
+def catcher_SIGUSR1(thread, catcher) -> None:
     t.signal = 0x0
     print(f"SIGUSR1: Signal number {catcher}")
 
-def catcher_SIGINT(t: ThreadContext, catcher: SignalCatcher) -> None:
+def catcher_SIGINT(thread, catcher) -> None:
     print(f"SIGINT: Signal number {catcher}")
 
-def catcher_SIGPIPE(t: ThreadContext, catcher: SignalCatcher) -> None:
+def catcher_SIGPIPE(thread, catcher) -> None:
     print(f"SIGPIPE: Signal number {catcher}")
 
-def handler_geteuid(t: ThreadContext, handler: SyscallHandler) -> None:
+def handler_geteuid(thread, handler) -> None:
 	t.regs.rax = 0x0
 
 # Initialize the debugger
@@ -169,9 +169,8 @@ d.kill()
 ```
 
 ## Attribution
-If you intend to use libdebug in your work, please cite this repository using the following biblatex:
-
-```biblatex
+If you intend to use libdebug in your projects, please cite the software using the following bibtex:
+```bibtex
 @software{libdebug_2024,
 	title = {libdebug: {Build} {Your} {Own} {Debugger}},
 	copyright = {MIT Licence},
@@ -180,5 +179,25 @@ If you intend to use libdebug in your work, please cite this repository using th
 	author = {Digregorio, Gabriele and Bertolini, Roberto Alessandro and Panebianco, Francesco and Polino, Mario},
 	year = {2024},
 	doi = {10.5281/zenodo.13151549},
+}
+```
+
+We've also published a poster on libdebug. If you use libdebug in your research, you can cite the following paper:
+```bibtex
+@inproceedings{10.1145/3658644.3691391,
+author = {Digregorio, Gabriele and Bertolini, Roberto Alessandro and Panebianco, Francesco and Polino, Mario},
+title = {Poster: libdebug, Build Your Own Debugger for a Better (Hello) World},
+year = {2024},
+isbn = {9798400706363},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://doi.org/10.1145/3658644.3691391},
+doi = {10.1145/3658644.3691391},
+booktitle = {Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security},
+pages = {4976–4978},
+numpages = {3},
+keywords = {debugging, reverse engineering, software security},
+location = {Salt Lake City, UT, USA},
+series = {CCS '24}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ libcontext.terminal = ['tmux', 'splitw', '-h']
 
 # Define signal catchers
 def catcher_SIGUSR1(thread, catcher) -> None:
-    t.signal = 0x0
+    thread.signal = 0x0
     print(f"SIGUSR1: Signal number {catcher}")
 
 def catcher_SIGINT(thread, catcher) -> None:
@@ -94,7 +94,7 @@ def catcher_SIGPIPE(thread, catcher) -> None:
     print(f"SIGPIPE: Signal number {catcher}")
 
 def handler_geteuid(thread, handler) -> None:
-	t.regs.rax = 0x0
+	thread.regs.rax = 0x0
 
 # Initialize the debugger
 d = debugger('/path/to/executable', continue_to_binary_entrypoint=False, aslr=False)

--- a/docs/blog/posts/14-10-24-08-00.md
+++ b/docs/blog/posts/14-10-24-08-00.md
@@ -14,3 +14,4 @@ If you are attending the conference, please stop by our poster and say hello. We
 ---
 Link to the conference: [ACM CCS 2024](https://www.sigsac.org/ccs/CCS2024/)<br>
 Link to the poster information: [**libdebug** Poster](https://libdebug.org/other/ccs24.html)
+Link to the proceedings: [ACM Digital Library](https://dl.acm.org/doi/10.1145/3658644.3691391)

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ Need to cite **libdebug** as software used in your work? This is the way to cite
 }
 ```
 
-We also have a poster on **libdebug**. If you use **libdebug** in your research, you can cite the following paper:
+We also have a poster on **libdebug**. If you use **libdebug** in your research, you can cite the associated short paper:
 
 ```bibtex
 @inproceedings{10.1145/3658644.3691391,

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ Examples of some known issues include:
 The documentation for versions of **libdebug** older that 0.7.0 has to be accessed manually at [http://docs.libdebug.org/archive/VERSION](http://docs.libdebug.org/archive/VERSION), where `VERSION` is the version number you are looking for.
 
 ## :material-format-quote-open: Cite Us
-Need to cite **libdebug** in your research? Use the following BibTeX entry:
+Need to cite **libdebug** as software used in your work? This is the way to cite us:
 
 ```bibtex
 @software{libdebug_2024,
@@ -118,5 +118,26 @@ Need to cite **libdebug** in your research? Use the following BibTeX entry:
     author = {Digregorio, Gabriele and Bertolini, Roberto Alessandro and Panebianco, Francesco and Polino, Mario},
     year = {2024},
     doi = {10.5281/zenodo.13151549},
+}
+```
+
+We also have a poster on **libdebug**. If you use **libdebug** in your research, you can cite the following paper:
+
+```bibtex
+@inproceedings{10.1145/3658644.3691391,
+author = {Digregorio, Gabriele and Bertolini, Roberto Alessandro and Panebianco, Francesco and Polino, Mario},
+title = {Poster: libdebug, Build Your Own Debugger for a Better (Hello) World},
+year = {2024},
+isbn = {9798400706363},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://doi.org/10.1145/3658644.3691391},
+doi = {10.1145/3658644.3691391},
+booktitle = {Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security},
+pages = {4976–4978},
+numpages = {3},
+keywords = {debugging, reverse engineering, software security},
+location = {Salt Lake City, UT, USA},
+series = {CCS '24}
 }
 ```

--- a/docs/stopping_events/syscalls.md
+++ b/docs/stopping_events/syscalls.md
@@ -90,11 +90,11 @@ The `handle_syscall()` function in the [Debugger](../../from_pydoc/generated/deb
 
 !!! ABSTRACT "Example usage of asynchronous syscall handlers"
     ```python
-    def on_enter_open(t: ThreadContext, handler: SyscallHandler):
+    def on_enter_open(t, handler):
         print("entering open")
         t.syscall_arg0 = 0x1
 
-    def on_exit_open(t: ThreadContext, handler: SyscallHandler):
+    def on_exit_open(t, handler):
         print("exiting open")
         t.syscall_return = 0x0
 


### PR DESCRIPTION
The README.md, the documentation index, and a blogpost have been updated to address the following:
- Remove typing in code examples (documentation and README.md)
- Added ACM CCS 24 Poster citation info alongside Zenodo's software citation.