### PR TITLE
Fix Exception when ccess to very high addresses

### DIFF
--- a/libdebug/memory/process_memory_manager.py
+++ b/libdebug/memory/process_memory_manager.py
@@ -25,12 +25,9 @@ class ProcessMemoryManager:
     def _split_seek(self: ProcessMemoryManager, file_obj: object, address: int) -> None:
         """Seeks to an address in a file, splitting the seek if necessary to avoid overflow."""
         if address > self.max_size:
-            base = (address // self.max_size) * self.max_size
-            remainder = address - base
-            # Absolute seek to base offset
-            file_obj.seek(base, os.SEEK_SET)
-            # Relative seek for remainder
-            file_obj.seek(remainder, os.SEEK_CUR)
+            # We need to split the seek
+            file_obj.seek(self.max_size, os.SEEK_SET)
+            file_obj.seek(address - self.max_size, os.SEEK_CUR)
         else:
             # We can seek directly
             file_obj.seek(address, os.SEEK_SET)

--- a/libdebug/memory/process_memory_manager.py
+++ b/libdebug/memory/process_memory_manager.py
@@ -6,9 +6,13 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
 
 class ProcessMemoryManager:
     """A class that provides accessors to the memory of a process, through /proc/pid/mem."""
+    max_size = sys.maxsize
 
     def open(self: ProcessMemoryManager, process_id: int) -> None:
         """Initializes the ProcessMemoryManager."""
@@ -17,6 +21,19 @@ class ProcessMemoryManager:
 
     def _open(self: ProcessMemoryManager) -> None:
         self._mem_file = open(f"/proc/{self.process_id}/mem", "r+b", buffering=0)
+
+    def _split_seek(self: ProcessMemoryManager, file_obj: object, address: int) -> None:
+        """Seeks to an address in a file, splitting the seek if necessary to avoid overflow."""
+        if address > self.max_size:
+            base = (address // self.max_size) * self.max_size
+            remainder = address - base
+            # Absolute seek to base offset
+            file_obj.seek(base, os.SEEK_SET)
+            # Relative seek for remainder
+            file_obj.seek(remainder, os.SEEK_CUR)
+        else:
+            # We can seek directly
+            file_obj.seek(address, os.SEEK_SET)
 
     def read(self: ProcessMemoryManager, address: int, size: int) -> bytes:
         """Reads memory from the target process.
@@ -31,7 +48,7 @@ class ProcessMemoryManager:
         if not self._mem_file:
             self._open()
 
-        self._mem_file.seek(address)
+        self._split_seek(self._mem_file, address)
         return self._mem_file.read(size)
 
     def write(self: ProcessMemoryManager, address: int, data: bytes) -> None:
@@ -44,7 +61,7 @@ class ProcessMemoryManager:
         if not self._mem_file:
             self._open()
 
-        self._mem_file.seek(address)
+        self._split_seek(self._mem_file, address)
         self._mem_file.write(data)
 
     def close(self: ProcessMemoryManager) -> None:


### PR DESCRIPTION
This should fix the issue in #196 

There is a tweak to discuss here. We will not be able to read addresses that large in any case (kernel space stuff—we simply cannot). However, I believe that supporting seeking to those addresses is a more elegant solution than manually handling different exceptions and re-raising the correct one. The solution might be a bit overkill, but I think it's more consistent and less likely to break in case of changes in Python and its exceptions.