### PR TITLE
internal_debugger not available fix (again)

### DIFF
--- a/libdebug/utils/pprint_primitives.py
+++ b/libdebug/utils/pprint_primitives.py
@@ -7,6 +7,7 @@
 from libdebug.data.memory_map_list import MemoryMapList
 from libdebug.data.registers import Registers
 from libdebug.data.symbol_list import SymbolList
+from libdebug.debugger.internal_debugger_instance_manager import extend_internal_debugger
 from libdebug.snapshots.memory.memory_map_snapshot_list import MemoryMapSnapshotList
 from libdebug.utils.ansi_escape_codes import ANSIColors
 from libdebug.utils.debugging_utils import resolve_symbol_name_in_maps_util
@@ -43,7 +44,8 @@ def pprint_backtrace_util(
     """Pretty prints the current backtrace of the thread."""
     for return_address in backtrace:
         filtered_maps = maps.filter(return_address)
-        return_address_symbol = resolve_symbol_name_in_maps_util(return_address, filtered_maps, external_symbols)
+        with extend_internal_debugger(maps._internal_debugger):
+            return_address_symbol = resolve_symbol_name_in_maps_util(return_address, filtered_maps, external_symbols)
         permissions = filtered_maps[0].permissions
         if "rwx" in permissions:
             style = f"{ANSIColors.UNDERLINE}{ANSIColors.RED}"
@@ -199,6 +201,7 @@ def pprint_diff_substring(content: str, start: int, end: int) -> None:
 
     print(f"{content[:start]}{color}{content[start:end]}{ANSIColors.RESET}{content[end:]}")
 
+
 def pprint_memory_util(
     address_start: int,
     extract: bytes,
@@ -225,6 +228,7 @@ def pprint_memory_util(
 
         # Print the memory diff with the address for this word
         print(f"{current_address_str}:  {out}")
+
 
 def pprint_memory_diff_util(
     address_start: int,


### PR DESCRIPTION
Dear Esteemed and Visionary Code Artisan,

I stand in awe before this magnificent, intricate, and astoundingly elegant single line of code. It is not merely a fix—it is an architectural marvel, a testament to human ingenuity, and a philosophical reflection on the very nature of software development.

Many would have shied away from the challenge, but not you. No, you embraced the chaos, wrestled with the very fabric of logic itself, and emerged victorious with this masterpiece. Your deft manipulation of syntax, your poetic use of operators, and your fearless approach to nesting conditions in ways never before conceived by mere mortals—truly, you have redefined the boundaries of what is possible in a single line of code.

One might say, "Could this be broken down for readability?" But to do so would be an insult to the art form you have crafted. It is a riddle wrapped in an enigma, a puzzle for future maintainers to unravel, a testament to the notion that clarity is for the weak.

As I gaze upon this line, I can only imagine the countless hours of deep contemplation that went into its creation—the coffee-fueled nights, the existential crises, the whispered incantations to the gods of programming. Surely, this will be studied in universities, its complexity analyzed by generations of software engineers.

Let the commit history forever enshrine this work of art, this ode to efficiency, this impenetrable fortress of logic.

May the debugging gods smile upon us all.