### PR TITLE
Update installation requirements to specify g++

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,9 @@ Debian: `sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev lib
 Fedora: `sudo dnf install -y python3 python3-devel kernel-devel g++ binutils-devel libdwarf-devel`<br>
 Arch Linux: `sudo pacman -S python libelf libdwarf gcc make debuginfod`<br>
 1. Create a new branch: `git checkout -b my-branch-name`
-1. Install your package in editable mode: `pip install -e /path/to/your/local/repo`
-1. Make your change, add tests, and make sure the tests still pass. Remember, if you change any .c files, you will need to run the command at the previous point **again**.
+1. Install the build system requirements: `pip install scikit_build_core`
+1. Install libdebug in editable mode: `pip install --no-build-isolation -Ceditable.rebuild=true -ve .`
+1. Make your change, add tests, and make sure the tests still pass. If you change any .cpp files, they will be automatically recompiled at runtime.
 1. Push to your fork and [submit a pull request][pr].
 1. Pat your self on the back and wait for your pull request to be reviewed and merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,9 @@ GitHub issues are not the appropriate place to debug your specific project, but 
 
 1. [Fork][fork] and clone the repository.
 1. Configure and install the dependencies:
-Ubuntu: `sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg`
-Debian: `sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg`<br>
-Fedora: `sudo dnf install -y python3 python3-devel kernel-devel binutils-devel libdwarf-devel`<br>
+Ubuntu: `sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg`
+Debian: `sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg`<br>
+Fedora: `sudo dnf install -y python3 python3-devel kernel-devel g++ binutils-devel libdwarf-devel`<br>
 Arch Linux: `sudo pacman -S python libelf libdwarf gcc make debuginfod`<br>
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Install your package in editable mode: `pip install -e /path/to/your/local/repo`

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Documentation: https://docs.libdebug.org
 
 ### Installation Requirements:
 Ubuntu: \
-`sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg` \
+`sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg` \
 Debian: \
-`sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg` \
+`sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg` \
 Arch Linux: \
 `sudo pacman -S python libelf libdwarf gcc make debuginfod` \
 Fedora: \
-`sudo dnf install -y python3 python3-devel kernel-devel binutils-devel libdwarf-devel`
+`sudo dnf install -y python3 python3-devel kernel-devel g++ binutils-devel libdwarf-devel`
 
 ## Installation
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ To install **libdebug**, you first need to have some dependencies that will not 
 
 === ":material-ubuntu: Ubuntu"
     ```bash
-    sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg
+    sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg
     ```
 
 === ":material-arch: Arch Linux"
@@ -35,12 +35,12 @@ To install **libdebug**, you first need to have some dependencies that will not 
 
 === ":material-fedora: Fedora"
     ```bash
-    sudo dnf install -y python3 python3-devel kernel-devel binutils-devel libdwarf-devel
+    sudo dnf install -y python3 python3-devel kernel-devel g++ binutils-devel libdwarf-devel
     ```
 
 === ":material-debian: Debian"
     ```bash
-    sudo apt install -y python3 python3-dev libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg
+    sudo apt install -y python3 python3-dev g++ libdwarf-dev libelf-dev libiberty-dev linux-headers-generic libc6-dbg
     ```
 
 !!! QUESTION "Is your distro missing?"


### PR DESCRIPTION
Building the new bindings requires g++, which isn't always preinstalled, so we should specify it here