### PR TITLE
Better cache

### DIFF
--- a/libdebug/native/symbols/debug_sym_parser.cpp
+++ b/libdebug/native/symbols/debug_sym_parser.cpp
@@ -194,6 +194,13 @@ SymbolVector collect_external_symbols(const std::string &debug_file_path, const 
         throw std::invalid_argument("Error opening file: " + debug_file_path);
     }
 
+    // Check if the file is empty
+    if (lseek(fd, 0, SEEK_END) == 0) {
+        // The debug file is empty
+        close(fd);
+        return symbols;
+    }
+
     // Read the ELF file
     if ((elf = elf_begin(fd, ELF_C_READ, NULL)) == NULL) {
         throw std::runtime_error("Error reading ELF file: " + debug_file_path);

--- a/libdebug/utils/elf_utils.py
+++ b/libdebug/utils/elf_utils.py
@@ -20,7 +20,6 @@ from libdebug.utils.libcontext import libcontext
 
 DEBUGINFOD_PATH: Path = Path.home() / ".cache" / "debuginfod_client"
 LOCAL_DEBUG_PATH: Path = Path("/usr/lib/debug/.build-id/")
-URL_BASE: str = "https://debuginfod.elfutils.org/buildid/{}/debuginfo"
 NOT_FOUND: int = 404
 
 
@@ -32,7 +31,7 @@ def _download_debuginfod(buildid: str, debuginfod_path: Path) -> None:
         debuginfod_path (Path): The output directory.
     """
     try:
-        url = URL_BASE.format(buildid)
+        url = libcontext.debuginfod_server + "buildid/" + buildid + "/debuginfo"
         r = requests.get(url, allow_redirects=True, timeout=1)
 
         if r.ok:

--- a/libdebug/utils/elf_utils.py
+++ b/libdebug/utils/elf_utils.py
@@ -21,6 +21,7 @@ from libdebug.utils.libcontext import libcontext
 DEBUGINFOD_PATH: Path = Path.home() / ".cache" / "debuginfod_client"
 LOCAL_DEBUG_PATH: Path = Path("/usr/lib/debug/.build-id/")
 URL_BASE: str = "https://debuginfod.elfutils.org/buildid/{}/debuginfo"
+NOT_FOUND: int = 404
 
 
 def _download_debuginfod(buildid: str, debuginfod_path: Path) -> None:
@@ -35,11 +36,20 @@ def _download_debuginfod(buildid: str, debuginfod_path: Path) -> None:
         r = requests.get(url, allow_redirects=True, timeout=1)
 
         if r.ok:
-            debuginfod_path.parent.mkdir(parents=True, exist_ok=True)
-            with debuginfod_path.open("wb") as f:
-                f.write(r.content)
+            # We found the debuginfo file, just use it
+            content = r.content
+        elif r.status_code == NOT_FOUND:
+            # We need to cache the empty content to avoid multiple requests
+            liblog.error(f"Debuginfo file for buildid {buildid} not found.")
+            content = b""
         else:
+            # We do not cache the content in case of error. We will retry the download next time.
             liblog.error(f"Failed to download debuginfo file. Error code: {r.status_code}")
+            return
+
+        debuginfod_path.parent.mkdir(parents=True, exist_ok=True)
+        with debuginfod_path.open("wb") as f:
+            f.write(content)
     except Exception as e:
         liblog.debugger(f"Exception {e} occurred while downloading debuginfod symbols")
 
@@ -73,6 +83,8 @@ def _collect_external_info(path: str) -> SymbolList[Symbol]:
     Returns:
         SymbolList[Symbol]: A list containing the symbols taken from the external debuginfo file.
     """
+    liblog.debugger("Collecting external symbols from %s", path)
+
     ext_symbols = libdebug_debug_sym_parser.collect_external_symbols(path, libcontext.sym_lvl)
 
     return SymbolList(
@@ -94,6 +106,8 @@ def _parse_elf_file(path: str, debug_info_level: int) -> tuple[SymbolList[Symbol
         buildid (str): The buildid of the specified ELF file.
         debug_file_path (str): The path to the external debuginfo file corresponding.
     """
+    liblog.debugger("Searching for symbols in %s", path)
+
     elfinfo = libdebug_debug_sym_parser.read_elf_info(path, debug_info_level)
 
     symbols = [Symbol(symbol.low_pc, symbol.high_pc, symbol.name, path) for symbol in elfinfo.symbols]

--- a/libdebug/utils/libcontext.py
+++ b/libdebug/utils/libcontext.py
@@ -22,6 +22,7 @@ class LibContext:
     _pipe_logger_levels: list[str]
     _debugger_logger_levels: list[str]
     _general_logger_levels: list[str]
+    _debuginfod_server: str
 
     def __new__(cls: type):
         """Create a new instance of the class if it does not exist yet.
@@ -47,6 +48,8 @@ class LibContext:
         self._debugger_logger = "SILENT"
         self._pipe_logger = "SILENT"
         self._general_logger = "INFO"
+
+        self._debuginfod_server = "https://debuginfod.elfutils.org/"
 
         # Adjust log levels based on command-line arguments
         if len(sys.argv) > 1:
@@ -172,6 +175,24 @@ class LibContext:
             value = [value]
 
         self._terminal = value
+
+    @property
+    def debuginfod_server(self: LibContext) -> str:
+        """Property getter for debuginfod_server.
+
+        Returns:
+            _debuginfod_server (str): the current debuginfod server.
+        """
+        return self._debuginfod_server
+
+    @debuginfod_server.setter
+    def debuginfod_server(self: LibContext, value: str) -> None:
+        """Property setter for debuginfod_server, ensuring it's a valid URL."""
+        self._debuginfod_server = value
+        if type(value) is not str or (not value.startswith("http://") and not value.startswith("https://")):
+            raise ValueError(
+                "debuginfod_server must be a valid string URL in the format 'http://<server>' or 'https://<server>'",
+            )
 
     def update(self: LibContext, **kwargs: ...) -> None:
         """Update the context with the given values."""

--- a/libdebug/utils/libcontext.py
+++ b/libdebug/utils/libcontext.py
@@ -216,4 +216,4 @@ class LibContext:
 
 
 # Global context instance
-libcontext = LibContext()
+libcontext: LibContext = LibContext()

--- a/libdebug/utils/libcontext.py
+++ b/libdebug/utils/libcontext.py
@@ -188,11 +188,11 @@ class LibContext:
     @debuginfod_server.setter
     def debuginfod_server(self: LibContext, value: str) -> None:
         """Property setter for debuginfod_server, ensuring it's a valid URL."""
-        self._debuginfod_server = value
         if type(value) is not str or (not value.startswith("http://") and not value.startswith("https://")):
             raise ValueError(
                 "debuginfod_server must be a valid string URL in the format 'http://<server>' or 'https://<server>'",
             )
+        self._debuginfod_server = value
 
     def update(self: LibContext, **kwargs: ...) -> None:
         """Update the context with the given values."""


### PR DESCRIPTION
This solves #195 and aligns the usage of the debuginfod cache with its external handling in libdebug. In particular, files that are not found are now cached in the same way as found files, but using empty files. This behavior is now consistently used and managed in libdebug as well.