### PR TITLE
Fix gdb cffi skill issue

### DIFF
--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -520,7 +520,6 @@ class PtraceInterface(DebuggingInterface):
             if bp.hardware:
                 for thread in self._internal_debugger.threads:
                     self.lib_trace.unregister_hw_breakpoint(
-                        self._global_state,
                         thread.thread_id,
                         bp.address,
                     )

--- a/test/other_tests/gdb_migration_test.py
+++ b/test/other_tests/gdb_migration_test.py
@@ -39,6 +39,38 @@ print(hex(d.regs.rip))
 d.kill()
 
 """
+Single thread test with hardware breakpoint
+"""
+d = debugger("../binaries/amd64/basic_test")
+
+# libcontext.terminal = ["tmux", "splitw", "-h"]
+# libcontext.terminal = ["gnome-terminal", "--tab", "--"]
+
+d.run()
+
+bp = d.breakpoint("register_test", hardware=True)
+
+d.step()
+d.step()
+
+print(hex(d.regs.rip))
+
+d.gdb()
+
+print(hex(d.regs.rip))
+
+d.cont()
+d.wait()
+
+print(hex(d.regs.rip))
+
+d.step()
+
+print(hex(d.regs.rip))
+
+d.kill()
+
+"""
 Multi thread test 1
 """
 d = debugger("../binaries/amd64/multithread_input")


### PR DESCRIPTION
@MrIndeciso  will forgive me for opening this very small PR with a fundamental fix that prevents `d.gdb` from working properly with hardware breakpoints due to a skill issue (bad merge conflict?)