### PR TITLE
Fix race and logs

### DIFF
--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -1487,7 +1487,7 @@ class InternalDebugger:
         if not self.running:
             return
 
-        if self.auto_interrupt_on_command and not self.threds[0].zombie:
+        if self.auto_interrupt_on_command and not self.threads[0].zombie:
             self.interrupt()
 
         self._join_and_check_status()

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -404,11 +404,8 @@ class InternalDebugger:
         """Kills the process."""
         if not self.is_debugging:
             raise RuntimeError("No process currently debugged, cannot kill.")
-        try:
-            self._ensure_process_stopped()
-        except (OSError, RuntimeError):
-            # This exception might occur if the process has already died
-            liblog.debugger("OSError raised during kill")
+
+        self._ensure_process_stopped()
 
         self._process_memory_manager.close()
 
@@ -1471,7 +1468,7 @@ class InternalDebugger:
         if not self.running:
             return
 
-        if self.auto_interrupt_on_command:
+        if self.auto_interrupt_on_command and not self.threads[0].zombie:
             self.interrupt()
 
         self._join_and_check_status()
@@ -1490,7 +1487,7 @@ class InternalDebugger:
         if not self.running:
             return
 
-        if self.auto_interrupt_on_command:
+        if self.auto_interrupt_on_command and not self.threds[0].zombie:
             self.interrupt()
 
         self._join_and_check_status()

--- a/libdebug/ptrace/ptrace_interface.py
+++ b/libdebug/ptrace/ptrace_interface.py
@@ -757,7 +757,7 @@ class PtraceInterface(DebuggingInterface):
             raise RuntimeError("Unexpected error") from e
 
         liblog.debugger(
-            "POKEDATA at address %d returned with result %d",
+            "POKEDATA at address %d returned with result %s",
             address,
             result,
         )


### PR DESCRIPTION
This should solve a race condition when the process is a zombie and `auto_interrupt_on_command` is enabled. I also fixed a broken log that sometimes generated an incorrect message.

This likely requires a period of testing.