### PR TITLE
fix: now the interactive mode pull all the update at each refresh

### DIFF
--- a/libdebug/commlink/libterminal.py
+++ b/libdebug/commlink/libterminal.py
@@ -179,7 +179,7 @@ class LibTerminal:
 
             # Update the output field with the messages in the queue
             msg = b""
-            if not self._app_message_queue.empty():
+            while not self._app_message_queue.empty():
                 msg += self._app_message_queue.get()
 
             if msg:


### PR DESCRIPTION
Picture this: I was sitting in a dark corner, debugging code that output messages slower than a snail wearing cement shoes—only to realize I’d been yanking just one teeny‐tiny chunk from the queue each half-second! Cue facepalm. So I swapped that single get() call for a glorious while not empty(): get() loop. Suddenly, the floodgates opened, my output soared, and children from neighboring villages came to applaud. My cat even gave me an approving meow (a monumental achievement, trust me). And with that one neat trick, I banished those ancient output delays forever. Now I’m the proud owner of lightning‐fast printing—and my cat still won’t stop meowing for more.

_GPT o1, the real author of this PR_