### PR TITLE
Fix callback change state function

### DIFF
--- a/test/scripts/brute_test.py
+++ b/test/scripts/brute_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Francesco Panebianco, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2023-2025 Gabriele Digregorio, Francesco Panebianco, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -34,7 +34,7 @@ class BruteTest(TestCase):
         while not flag or flag != "BRUTINOBRUTONE":
             for c in string.printable:
                 r = d.run()
-                bp = d.breakpoint(ADDRESS, hardware=True)
+                bp = d.breakpoint(ADDRESS, hardware=True, file="binary")
                 d.cont()
 
                 r.sendlineafter(b"chars\n", (flag + c).encode())
@@ -83,7 +83,7 @@ class BruteTest(TestCase):
             for c in string.printable:
                 r = d.run()
 
-                d.breakpoint(ADDRESS, callback=brute_force, hardware=True)
+                d.breakpoint(ADDRESS, callback=brute_force, hardware=True, file="binary")
                 d.cont()
 
                 r.sendlineafter(b"chars\n", (flag + c).encode())

--- a/test/scripts/jumpout_test.py
+++ b/test/scripts/jumpout_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2023-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -83,8 +83,8 @@ class JumpoutTest(TestCase):
         d = debugger(RESOLVE_EXE("CTF/jumpout"))
         r = d.run()
 
-        d.breakpoint(0x140B, callback=second, hardware=True)
-        d.breakpoint(0x157C, callback=third, hardware=True)
+        d.breakpoint(0x140B, callback=second, hardware=True, file="binary")
+        d.breakpoint(0x157C, callback=third, hardware=True, file="binary")
         d.cont()
 
         r.sendline(b"A" * 0x1D)
@@ -115,8 +115,8 @@ class JumpoutTest(TestCase):
             except Exception as e:
                 self.exceptions.append(e)
 
-        d.breakpoint(0x140B, callback=second, hardware=True)
-        bp = d.breakpoint(0x157C, hardware=True)
+        d.breakpoint(0x140B, callback=second, hardware=True, file="binary")
+        bp = d.breakpoint(0x157C, hardware=True, file="binary")
 
         d.cont()
 

--- a/test/scripts/vmwhere1_test.py
+++ b/test/scripts/vmwhere1_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2023-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -27,7 +27,7 @@ class Vmwhere1Test(TestCase):
         while not stop:
             for el in string.printable:
                 r = d.run()
-                bp = d.breakpoint(0x1587, hardware=True)
+                bp = d.breakpoint(0x1587, hardware=True, file="binary")
                 d.cont()
 
                 r.recvline()
@@ -75,7 +75,7 @@ class Vmwhere1Test(TestCase):
         while not stop:
             for el in string.printable:
                 r = d.run()
-                bp = d.breakpoint(0x1587, hardware=True, callback=callback)
+                bp = d.breakpoint(0x1587, hardware=True, callback=callback, file="binary")
                 d.cont()
 
                 r.recvline()


### PR DESCRIPTION
This solves a problem with `set_stopped` that was incorrectly called inside callbacks, causing severe effects. 

Also, I specified the backing file in some more tests to avoid ~annoying~ warnings. 