### PR TITLE
Make Control-C more reliable

### DIFF
--- a/libdebug/__init__.py
+++ b/libdebug/__init__.py
@@ -1,11 +1,11 @@
-from .libdebug import debugger
-from .utils.libcontext import libcontext
-
 try:
     from rich.traceback import install
 except ImportError:
     pass
 else:
     install()
+
+from .libdebug import debugger
+from .utils.libcontext import libcontext
 
 __all__ = ["debugger", "libcontext"]

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -444,7 +444,7 @@ class InternalDebugger:
 
         self._join_and_check_status()
 
-    def atexit_terminate(self: InternalDebugger) -> None:
+    def _atexit_terminate(self: InternalDebugger) -> None:
         """Terminate the background threads with an aggressive approach. This is meant to be used in atexit handlers."""
         if self.__polling_thread is not None:
             # When the main thread terminates, the polling thread will be terminated as well in any case,

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -460,11 +460,15 @@ class InternalDebugger:
             # but it is less likely.
             self.__polling_thread_command_queue.put((THREAD_TERMINATE, ()))
             self.__polling_thread.join(0.5)
+            if self.__polling_thread.is_alive():
+                liblog.debugger("Polling thread is still alive after THREAD_TERMINATE. It might be stuck.")
 
         if self.__timeout_thread is not None:
             # It is unlikely that the timeout thread gets stuck, but we use the same approach here. Just to be sure.
             self.__timeout_thread_command_queue.put(THREAD_TERMINATE)
-            self.__polling_thread.join(0.5)
+            self.__timeout_thread.join(0.5)
+            if self.__timeout_thread.is_alive():
+                liblog.debugger("Timeout thread is still alive after THREAD_TERMINATE. It might be stuck.")
 
     def terminate(self: InternalDebugger) -> None:
         """Interrupts the process, kills it and then terminates the background thread.

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -444,6 +444,28 @@ class InternalDebugger:
 
         self._join_and_check_status()
 
+    def atexit_terminate(self: InternalDebugger) -> None:
+        """Terminate the background threads with an aggressive approach. This is meant to be used in atexit handlers."""
+        if self.__polling_thread is not None:
+            # When the main thread terminates, the polling thread will be terminated as well in any case,
+            # as it is a daemon thread. However, the nanobind C++ exit handler might race with the Python
+            # atexit handler defined by us. In that case, we might see an error message of the type
+            # `terminate called without an active exception` with a consequent core dump.
+            # This has no real consequences, but it is annoying and inelegant. To avoid, as much as possible,
+            # this behavior, we send a command to the polling thread to terminate. However, the polling thread
+            # might be stuck in an endless callback or waiting for an event that will never happen due to some
+            # edge cases we missed. Since we MUST finish the execution of the script as soon as possible, we call
+            # join() on it with a reasonable timeout. If it does terminate in time, we are sure that everything is
+            # fine and we will have no race. If not, the other thread is probably stuck. The race might still happen,
+            # but it is less likely.
+            self.__polling_thread_command_queue.put((THREAD_TERMINATE, ()))
+            self.__polling_thread.join(0.5)
+
+        if self.__timeout_thread is not None:
+            # It is unlikely that the timeout thread gets stuck, but we use the same approach here. Just to be sure.
+            self.__timeout_thread_command_queue.put(THREAD_TERMINATE)
+            self.__polling_thread.join(0.5)
+
     def terminate(self: InternalDebugger) -> None:
         """Interrupts the process, kills it and then terminates the background thread.
 
@@ -1551,17 +1573,19 @@ class InternalDebugger:
             if return_value is not None:
                 self.__polling_thread_response_queue.join()
 
-    def _join_and_check_status(self: InternalDebugger) -> None:
-        # Wait for the background thread to signal "task done" before returning
-        # We don't want any asynchronous behaviour here
-        self.__polling_thread_command_queue.join()
-
-        # Check for any exceptions raised by the background thread
+    def _check_status(self: InternalDebugger) -> None:
+        """Check for any exceptions raised by the background thread."""
         if not self.__polling_thread_response_queue.empty():
             response = self.__polling_thread_response_queue.get()
             self.__polling_thread_response_queue.task_done()
             if response is not None:
                 raise response
+
+    def _join_and_check_status(self: InternalDebugger) -> None:
+        """Wait for the background thread to signal "task done" before returning."""
+        # We don't want any asynchronous behaviour here
+        self.__polling_thread_command_queue.join()
+        self._check_status()
 
     @functools.cached_property
     def _process_full_path(self: InternalDebugger) -> str:
@@ -1986,8 +2010,7 @@ class InternalDebugger:
                 if self.resume_context.is_in_callback:
                     # We have no way to stop the callback, let's notify the user
                     liblog.warning(
-                        "Timeout occurred while executing a callback. "
-                        "Asynchronous callbacks cannot be interrupted.",
+                        "Timeout occurred while executing a callback. Asynchronous callbacks cannot be interrupted.",
                     )
 
                 # Kill it
@@ -2004,7 +2027,7 @@ class InternalDebugger:
                         self.path,
                         self.process_id,
                     )
-                except Exception as e: # noqa: BLE001
+                except Exception as e:  # noqa: BLE001
                     liblog.debugger(
                         "Error while killing timed out debuggee process %s (%d): %s",
                         self.path,

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -69,7 +69,7 @@ def _cleanup_internal_debugger() -> None:
                     os.kill(debugger.process_id, 9)
                     os.waitpid(debugger.process_id, 0)
                 except Exception as e:  # noqa: BLE001
-                    liblog.debugger(f"Error while interrupting debuggee: {e}")
+                    liblog.debugger("Error while interrupting debuggee: %s", e)
 
             # The background thread might have raised an exception that we are unaware of.
             # We want to capture it and notify the user. If the user has issued a Control-C, the traceback will be

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -20,11 +20,10 @@ from libdebug.liblog import liblog
 
 try:
     from rich.console import Console
-    from rich.traceback import Traceback, install
+    from rich.traceback import Traceback
 except ImportError:
     console = None
 else:
-    install()
     console = Console()
 
 

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -1,13 +1,15 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2024-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
 from __future__ import annotations
 
 import atexit
+import os
 import sys
+import traceback
 from dataclasses import dataclass, field
 from termios import TCSANOW, tcsetattr
 from threading import Lock
@@ -15,6 +17,16 @@ from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 from libdebug.liblog import liblog
+
+try:
+    from rich.console import Console
+    from rich.traceback import Traceback, install
+except ImportError:
+    console = None
+else:
+    install()
+    console = Console()
+
 
 if TYPE_CHECKING:
     from libdebug.debugger.internal_debugger import InternalDebugger
@@ -44,16 +56,44 @@ def _cleanup_internal_debugger() -> None:
         except Exception as e:
             liblog.debugger(f"Error while restoring the original stdin settings: {e}")
 
-        if debugger.instanced and debugger.kill_on_exit:
-            try:
-                debugger.interrupt()
-            except Exception as e:
-                liblog.debugger(f"Error while interrupting debuggee: {e}")
+        # The following logic MUST work in any situation. This includes scenarios where the polling thread is stuck
+        # due to an endless callback, an unhandled exceptions that break the thread, a logic error in libdebug or a
+        # race condition causing the thread to wait indefinitely for an event that will never occur.
 
+        # The key idea here is that we cannot rely on the background threads (both polling and timeout threads),
+        # as only the main thread is aware of the script termination or the user's control-C interruption.
+        if debugger.instanced and debugger.kill_on_exit:
+            if debugger.is_debugging:
+                # We will leverage the fact that we are in the wrong thread but the same process to kill the debuggee
+                # process without relying on the background thread.
+                try:
+                    os.kill(debugger.process_id, 9)
+                    os.waitpid(debugger.process_id, 0)
+                except Exception as e:  # noqa: BLE001
+                    liblog.debugger(f"Error while interrupting debuggee: {e}")
+
+            # The background thread might have raised an exception that we are unaware of.
+            # We want to capture it and notify the user. If the user has issued a Control-C, the traceback will be
+            # printed after the one for the KeyboardInterrupt.
             try:
-                debugger.terminate()
-            except Exception as e:
-                liblog.debugger(f"Error while terminating the debugger: {e}")
+                debugger._check_status()
+            except Exception as e:  # noqa: BLE001
+                if console:
+                    tb = Traceback.from_exception(
+                        exc_type=type(e),
+                        exc_value=e,
+                        traceback=e.__traceback__,
+                    )
+                    console.print(tb)
+                else:
+                    traceback.print_exc()
+
+            # Now we can try to terminate both the polling thread and the timeout thread, if any. Again, we cannot
+            # trust them, so we just try to notify them that the process is terminating.
+            try:
+                debugger.atexit_terminate()
+            except Exception as e:  # noqa: BLE001
+                liblog.debugger(f"Error while terminating the internal debugger: {e}")
 
 
 atexit.register(_cleanup_internal_debugger)

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -92,7 +92,7 @@ def _cleanup_internal_debugger() -> None:
             try:
                 debugger.atexit_terminate()
             except Exception as e:  # noqa: BLE001
-                liblog.debugger(f"Error while terminating the internal debugger: {e}")
+                liblog.debugger("Error while terminating the internal debugger: %s", e)
 
 
 atexit.register(_cleanup_internal_debugger)

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -89,7 +89,7 @@ def _cleanup_internal_debugger() -> None:
             # Now we can try to terminate both the polling thread and the timeout thread, if any. Again, we cannot
             # trust them, so we just try to notify them that the process is terminating.
             try:
-                debugger.atexit_terminate()
+                debugger._atexit_terminate()
             except Exception as e:  # noqa: BLE001
                 liblog.debugger("Error while terminating the internal debugger: %s", e)
 

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -67,7 +67,6 @@ def _cleanup_internal_debugger() -> None:
                 # process without relying on the background thread.
                 try:
                     os.kill(debugger.process_id, 9)
-                    os.waitpid(debugger.process_id, 0)
                 except Exception as e:  # noqa: BLE001
                     liblog.debugger("Error while interrupting debuggee: %s", e)
 

--- a/test/scripts/atexit_handler_test.py
+++ b/test/scripts/atexit_handler_test.py
@@ -1,15 +1,15 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2024-2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
+import subprocess
 import psutil
+import os
 from unittest import TestCase
 from utils.binary_utils import RESOLVE_EXE
 from time import sleep
-import os
-import subprocess
 
 from libdebug import debugger
 from libdebug.debugger.internal_debugger_holder import _cleanup_internal_debugger
@@ -68,6 +68,12 @@ class AtexitHandlerTest(TestCase):
         
         # We can actually kill the process
         os.kill(pid, 9)
+        
+
+            
+        
+        # The process should not have been killed
+        self.assertNotIn(pid, psutil.pids())
 
     def test_run_3(self):
         def provola(queue):
@@ -124,6 +130,7 @@ class AtexitHandlerTest(TestCase):
         
         # We can actually kill the process
         os.kill(pid, 9)
+        
 
     def test_attach_detach_1(self):
         def provola(queue):

--- a/test/scripts/atexit_handler_test.py
+++ b/test/scripts/atexit_handler_test.py
@@ -142,6 +142,20 @@ class AtexitHandlerTest(TestCase):
         # We can actually kill the process
         os.kill(pid, 9)
         
+        while True:
+            try:
+                pid, status = os.waitpid(pid, os.WNOHANG)
+                if pid == 0:
+                    continue
+            except OSError:
+                break
+            sleep(0.1)
+        
+        # The process should not have been killed
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(0.5)
+            self.assertNotIn(pid, psutil.pids())
 
     def test_attach_detach_1(self):
         def provola(queue):
@@ -178,6 +192,21 @@ class AtexitHandlerTest(TestCase):
         
         # We can actually kill the process
         os.kill(pid, 9)
+        
+        while True:
+            try:
+                pid, status = os.waitpid(pid, os.WNOHANG)
+                if pid == 0:
+                    continue
+            except OSError:
+                break
+            sleep(0.1)
+        
+        # The process should not have been killed
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(0.5)
+            self.assertNotIn(pid, psutil.pids())
 
     def test_attach_detach_2(self):
         def provola(queue):
@@ -214,6 +243,21 @@ class AtexitHandlerTest(TestCase):
         
         # We can actually kill the process
         os.kill(pid, 9)
+        
+        while True:
+            try:
+                pid, status = os.waitpid(pid, os.WNOHANG)
+                if pid == 0:
+                    continue
+            except OSError:
+                break
+            sleep(0.1)
+        
+        # The process should not have been killed
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(0.5)
+            self.assertNotIn(pid, psutil.pids())
 
     def test_attach_1(self):
         def provola(queue):

--- a/test/scripts/atexit_handler_test.py
+++ b/test/scripts/atexit_handler_test.py
@@ -1,207 +1,231 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024 Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
 import psutil
 from unittest import TestCase
 from utils.binary_utils import RESOLVE_EXE
-from pwn import process
+from time import sleep
+import os
+import subprocess
 
 from libdebug import debugger
 from libdebug.debugger.internal_debugger_holder import _cleanup_internal_debugger
+from multiprocessing import Process, Queue
 
 
 class AtexitHandlerTest(TestCase):
     def test_run_1(self):
-        d = debugger(RESOLVE_EXE("infinite_loop_test"))
+        def provola(queue):
+            d = debugger(RESOLVE_EXE("infinite_loop_test"))
+            r = d.run()
+            pid = d.pid
 
-        r = d.run()
+            d.cont()
+            r.sendline(b"3")
 
-        pid = d.pid
+            _cleanup_internal_debugger()
 
-        d.cont()
+            # Send pid back to the parent
+            queue.put(pid)
 
-        r.sendline(b"3")
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        _cleanup_internal_debugger()
-
-        # The process should have been killed
-        self.assertNotIn(pid, psutil.pids())
-
-        d.terminate()
+        pid = q.get()
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(1)
+            self.assertNotIn(pid, psutil.pids())
 
     def test_run_2(self):
-        d = debugger(RESOLVE_EXE("infinite_loop_test"), kill_on_exit=False)
+        def provola(queue):
+            d = debugger(RESOLVE_EXE("infinite_loop_test"), kill_on_exit=False)
+            r = d.run()
+            pid = d.pid
 
-        r = d.run()
+            d.cont()
+            r.sendline(b"3")
 
-        pid = d.pid
+            _cleanup_internal_debugger()
 
-        d.cont()
+            # Send pid back to the parent
+            queue.put(pid)
+        
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        r.sendline(b"3")
-
-        _cleanup_internal_debugger()
+        pid = q.get()
 
         # The process should not have been killed
         self.assertIn(pid, psutil.pids())
-
-        # We can actually still use the debugger
-        d.interrupt()
-        d.kill()
-
-        # The process should now be dead
-        self.assertNotIn(pid, psutil.pids())
-
-        d.terminate()
+        
+        # We can actually kill the process
+        os.kill(pid, 9)
 
     def test_run_3(self):
-        d = debugger(RESOLVE_EXE("infinite_loop_test"), kill_on_exit=False)
+        def provola(queue):
+            d = debugger(RESOLVE_EXE("infinite_loop_test"), kill_on_exit=False)
+            r = d.run()
+            pid = d.pid
 
-        r = d.run()
+            d.cont()
+            r.sendline(b"3")
+            
+            d.kill_on_exit = True
 
-        pid = d.pid
+            _cleanup_internal_debugger()
 
-        d.cont()
+            # Send pid back to the parent
+            queue.put(pid)
 
-        r.sendline(b"3")
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        d.kill_on_exit = True
-
-        _cleanup_internal_debugger()
-
-        # The process should have been killed
-        self.assertNotIn(pid, psutil.pids())
-
-        d.terminate()
+        pid = q.get()
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(1)
+            self.assertNotIn(pid, psutil.pids())
 
     def test_run_4(self):
-        d = debugger(RESOLVE_EXE("infinite_loop_test"))
+        def provola(queue):
+            d = debugger(RESOLVE_EXE("infinite_loop_test"))
+            r = d.run()
+            pid = d.pid
 
-        r = d.run()
+            d.cont()
+            r.sendline(b"3")
+            
+            d.kill_on_exit = False
 
-        pid = d.pid
+            _cleanup_internal_debugger()
 
-        d.cont()
+            # Send pid back to the parent
+            queue.put(pid)
+        
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        d.kill_on_exit = False
-
-        r.sendline(b"3")
-
-        _cleanup_internal_debugger()
+        pid = q.get()
 
         # The process should not have been killed
         self.assertIn(pid, psutil.pids())
-
-        # We can actually still use the debugger
-        d.interrupt()
-        d.kill()
-
-        # The process should now be dead
-        self.assertNotIn(pid, psutil.pids())
-
-        d.terminate()
+        
+        # We can actually kill the process
+        os.kill(pid, 9)
 
     def test_attach_detach_1(self):
-        p = process(RESOLVE_EXE("infinite_loop_test"))
+        def provola(queue):
+            p = subprocess.Popen([RESOLVE_EXE("infinite_loop_test")], stdin=subprocess.PIPE)
 
-        d = debugger()
+            d = debugger()
+            
+            pid = p.pid
 
-        d.attach(p.pid)
+            d.attach(pid)
 
-        p.sendline(b"3")
+            p.stdin.write(b"3\n")
+            p.stdin.flush()
 
-        d.step()
-        d.step()
+            d.step()
+            d.step()
 
-        d.detach()
+            d.detach()
+            
+            _cleanup_internal_debugger()
+            
+            # Send pid back to the parent
+            queue.put(pid)
+            
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        # If the process is still running, poll() should return None
-        self.assertIsNone(p.poll(block=False))
+        pid = q.get()
 
-        _cleanup_internal_debugger()
-
-        # The process should still be alive
-        self.assertIsNone(p.poll(block=False))
+        # The process should not have been killed
+        self.assertIn(pid, psutil.pids())
         
-        p.kill()
-        
-        # The process should now be dead
-        self.assertIsNotNone(p.poll(block=False))
-
-        d.terminate()
+        # We can actually kill the process
+        os.kill(pid, 9)
 
     def test_attach_detach_2(self):
-        p = process(RESOLVE_EXE("infinite_loop_test"))
+        def provola(queue):
+            p = subprocess.Popen([RESOLVE_EXE("infinite_loop_test")], stdin=subprocess.PIPE)
 
-        d = debugger(kill_on_exit=False)
+            d = debugger(kill_on_exit=False)
+            
+            pid = p.pid
 
-        d.attach(p.pid)
+            d.attach(pid)
 
-        p.sendline(b"3")
+            p.stdin.write(b"3\n")
+            p.stdin.flush()
 
-        d.step()
-        d.step()
+            d.step()
+            d.step()
 
-        d.detach()
+            d.detach()
+            
+            _cleanup_internal_debugger()
+            
+            # Send pid back to the parent
+            queue.put(pid)
 
-        # If the process is still running, poll() should return None
-        self.assertIsNone(p.poll(block=False))
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        _cleanup_internal_debugger()
+        pid = q.get()
 
-        # The process should still be alive
-        self.assertIsNone(p.poll(block=False))
-
-        p.kill()
-
-        # The process should now be dead
-        self.assertIsNotNone(p.poll(block=False))
-
-        d.terminate()
+        # The process should not have been killed
+        self.assertIn(pid, psutil.pids())
+        
+        # We can actually kill the process
+        os.kill(pid, 9)
 
     def test_attach_1(self):
-        p = process(RESOLVE_EXE("infinite_loop_test"))
+        def provola(queue):
+            p = subprocess.Popen([RESOLVE_EXE("infinite_loop_test")], stdin=subprocess.PIPE)
 
-        d = debugger()
+            d = debugger(kill_on_exit=False)
+            
+            pid = p.pid
 
-        d.attach(p.pid)
+            d.attach(pid)
 
-        p.sendline(b"3")
+            p.stdin.write(b"3\n")
+            p.stdin.flush()
 
-        d.step()
-        d.step()
+            d.step()
+            d.step()
+            
+            _cleanup_internal_debugger()
+            
+            # Send pid back to the parent
+            queue.put(pid)
+            
+        q = Queue()
+        process = Process(target=provola, args=(q,))
+        process.start()
+        process.join()
 
-        # If the process is still running, poll() should return None
-        self.assertIsNone(p.poll(block=False))
+        pid = q.get()
 
-        _cleanup_internal_debugger()
-
-        # The process should now be dead
-        self.assertIsNotNone(p.poll(block=False))
-
-        d.terminate()
-
-    def test_attach_2(self):
-        p = process(RESOLVE_EXE("infinite_loop_test"))
-
-        d = debugger()
-
-        d.attach(p.pid)
-
-        p.sendline(b"3")
-
-        d.step()
-        d.step()
-
-        p.kill()
-
-        # The process should now be dead
-        self.assertIsNotNone(p.poll(block=False))
-
-        # Even if we kill the process, the next call should not raise an exception
-        _cleanup_internal_debugger()
-
-        d.terminate()
+        if pid in psutil.pids():
+            # This might be a false positive due to some race conditions
+            sleep(1)
+            self.assertNotIn(pid, psutil.pids())


### PR DESCRIPTION
This PR updates the logic of the atexit handler to better handle edge cases and provide more reliable Ctrl+C behavior. Specifically, it now explicitly accounts for situations where background threads may become stuck—for example, due to exceptions, errors in libdebug causing a thread to wait indefinitely on an event that never occurs, or infinite loop callbacks.

This is a draft until we decide how to better handle exceptions in background threads.