### PR TITLE
Strict memory maps len checks

### DIFF
--- a/libdebug/memory/abstract_memory_view.py
+++ b/libdebug/memory/abstract_memory_view.py
@@ -117,6 +117,8 @@ class AbstractMemoryView(MutableSequence, ABC):
             occurrences = find_all_overlapping_occurrences(value, memory_content, start)
         else:
             maps = self.maps.filter(file)
+            if not maps:
+                raise ValueError("No memory map found for the specified backing file.")
             start = self.resolve_address(start, file, True) if start is not None else maps[0].start
             end = self.resolve_address(end, file, True) if end is not None else maps[-1].end - 1
 

--- a/libdebug/utils/debugging_utils.py
+++ b/libdebug/utils/debugging_utils.py
@@ -25,7 +25,7 @@ def normalize_and_validate_address(address: int, maps: MemoryMapList[MemoryMap])
         ValueError: If the specified address does not belong to any memory map.
     """
     if not maps:
-        raise ValueError("No memory maps available to resolve the address. Did you specified a valid backing file?")
+        raise ValueError("No memory maps available to resolve the address. Did you specify a valid backing file?")
     if address < maps[0].start:
         # The address is lower than the base address of the lowest map. Suppose it is a relative address for a PIE binary.
         address += maps[0].start

--- a/libdebug/utils/debugging_utils.py
+++ b/libdebug/utils/debugging_utils.py
@@ -24,6 +24,8 @@ def normalize_and_validate_address(address: int, maps: MemoryMapList[MemoryMap])
     Throws:
         ValueError: If the specified address does not belong to any memory map.
     """
+    if not maps:
+        raise ValueError("No memory maps available to resolve the address. Did you specified a valid backing file?")
     if address < maps[0].start:
         # The address is lower than the base address of the lowest map. Suppose it is a relative address for a PIE binary.
         address += maps[0].start

--- a/test/scripts/find_pointers_test.py
+++ b/test/scripts/find_pointers_test.py
@@ -22,7 +22,7 @@ match PLATFORM:
         raise NotImplementedError(f"Platform {PLATFORM} not supported by this test")
     
 class FindPointersTest(TestCase):
-    def test_find_ref_strings(self):
+    def test_find_pointers_strings(self):
         d = debugger(RESOLVE_EXE("find_ptr_test"))
         
         r = d.run()
@@ -64,7 +64,7 @@ class FindPointersTest(TestCase):
         d.kill()
         d.terminate()
         
-    def test_find_ref_addresses(self):
+    def test_find_pointers_addresses(self):
         d = debugger(RESOLVE_EXE("find_ptr_test"))
         
         r = d.run()
@@ -102,6 +102,29 @@ class FindPointersTest(TestCase):
         
         self.assertEqual(correct_reference, values[2][0])
         self.assertEqual(correct_source, values[2][1])
+        
+        d.wait()
+
+        d.kill()
+        d.terminate()
+    
+    def test_find_pointers_exception(self):
+        d = debugger(RESOLVE_EXE("find_ptr_test"))
+        
+        d.run()
+        d.bp(LOCATION, hardware=True, file="binary")
+
+        d.cont()
+        
+        heap_base = d.maps.filter("heap")[0].start
+        with self.assertRaises(ValueError) as cm:
+            d.memory.find_pointers(heap_base, "invalid")
+        self.assertIn("No memory map found for the specified target.", str(cm.exception))
+        
+        heap_base = d.maps.filter("heap")[0].start
+        with self.assertRaises(ValueError) as cm:
+            d.memory.find_pointers("invalid", heap_base)
+        self.assertIn("No memory map found for the specified where parameter.", str(cm.exception))
         
         d.wait()
 

--- a/test/scripts/memory_no_fast_test.py
+++ b/test/scripts/memory_no_fast_test.py
@@ -114,6 +114,10 @@ class MemoryNoFastTest(TestCase):
             d.memory[0x0, 256, 0xff]
         self.assertIn("Invalid type for the backing file", str(cm.exception))
         
+        with self.assertRaises(ValueError) as cm:
+            d.memory[0x0, 256, "invalid"]
+        self.assertIn("No memory maps available to resolve the address", str(cm.exception))
+        
         with self.assertRaises(TypeError) as cm:
             d.memory[0x0, ctypes.c_uint32(10)] = b"abcd1234"
         self.assertIn("Invalid type for the size", str(cm.exception))
@@ -125,6 +129,10 @@ class MemoryNoFastTest(TestCase):
         with self.assertRaises(TypeError) as cm:
             d.memory[0x0, 256, 0xff] = b"abcd1234"
         self.assertIn("Invalid type for the backing file", str(cm.exception))
+        
+        with self.assertRaises(ValueError) as cm:
+            d.memory[0x0, 256, "invalid"] = b"abcd1234"
+        self.assertIn("No memory maps available to resolve the address", str(cm.exception))
 
         assert d.instruction_pointer == bp.address
 

--- a/test/scripts/memory_test.py
+++ b/test/scripts/memory_test.py
@@ -111,6 +111,10 @@ class MemoryTest(TestCase):
             d.memory[0x0, 256, 0xff]
         self.assertIn("Invalid type for the backing file", str(cm.exception))
         
+        with self.assertRaises(ValueError) as cm:
+            d.memory[0x0, 256, "invalid"]
+        self.assertIn("No memory maps available to resolve the address", str(cm.exception))
+        
         with self.assertRaises(TypeError) as cm:
             d.memory[0x0, ctypes.c_uint32(10)] = b"abcd1234"
         self.assertIn("Invalid type for the size", str(cm.exception))
@@ -122,6 +126,10 @@ class MemoryTest(TestCase):
         with self.assertRaises(TypeError) as cm:
             d.memory[0x0, 256, 0xff] = b"abcd1234"
         self.assertIn("Invalid type for the backing file", str(cm.exception))
+        
+        with self.assertRaises(ValueError) as cm:
+            d.memory[0x0, 256, "invalid"] = b"abcd1234"
+        self.assertIn("No memory maps available to resolve the address", str(cm.exception))
 
         # File should start with ELF magic number
         self.assertTrue(file.startswith(b"\x7fELF"))
@@ -489,6 +497,10 @@ class MemoryTest(TestCase):
         
         # Search for the string "abcd123456" in the heap using start and end
         self.assertTrue(d.memory.find(b"abcd123456", start=start, end=end) == [address + 128])
+        
+        with self.assertRaises(ValueError) as cm:
+            d.memory.find(b"abcd123456", file="invalid")
+        self.assertIn("No memory map found for the specified backing file", str(cm.exception))
 
         d.kill()
         d.terminate()


### PR DESCRIPTION
There were some cases where we attempted to access `maps[0]` on an empty list returned due to an invalid backing file. I'm not sure this PR will cover all such scenarios, but it's a starting point.

Based on #241 
