### PR TITLE
Include static syscall definitions along with the remote ones

### DIFF
--- a/libdebug/utils/syscall_data/aarch64.json
+++ b/libdebug/utils/syscall_data/aarch64.json
@@ -1,0 +1,5778 @@
+{
+	"kernel": {
+		"abi": {
+			"bits": 64,
+			"calling_convention": {
+				"parameters": [
+					"x0",
+					"x1",
+					"x2",
+					"x3",
+					"x4",
+					"x5"
+				],
+				"syscall_nr": "w8"
+			},
+			"compat": false,
+			"name": "aarch64"
+		},
+		"architecture": {
+			"bits": 64,
+			"name": "arm64"
+		},
+		"syscall_table_symbol": "sys_call_table",
+		"version": "v6.14",
+		"version_source": "vmlinux"
+	},
+	"syscalls": [
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 0,
+			"kconfig": "AIO",
+			"line": 1382,
+			"name": "io_setup",
+			"number": 0,
+			"origname": "io_setup",
+			"signature": [
+				"unsigned nr_events",
+				"aio_context_t *ctxp"
+			],
+			"symbol": "__arm64_sys_io_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 1,
+			"kconfig": "AIO",
+			"line": 1451,
+			"name": "io_destroy",
+			"number": 1,
+			"origname": "io_destroy",
+			"signature": [
+				"aio_context_t ctx"
+			],
+			"symbol": "__arm64_sys_io_destroy"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 2,
+			"kconfig": "AIO",
+			"line": 2081,
+			"name": "io_submit",
+			"number": 2,
+			"origname": "io_submit",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long nr",
+				"struct iocb **iocbpp"
+			],
+			"symbol": "__arm64_sys_io_submit"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 3,
+			"kconfig": "AIO",
+			"line": 2175,
+			"name": "io_cancel",
+			"number": 3,
+			"origname": "io_cancel",
+			"signature": [
+				"aio_context_t ctx_id",
+				"struct iocb *iocb",
+				"struct io_event *result"
+			],
+			"symbol": "__arm64_sys_io_cancel"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 4,
+			"kconfig": "AIO",
+			"line": 2250,
+			"name": "io_getevents",
+			"number": 4,
+			"origname": "io_getevents",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct __kernel_timespec *timeout"
+			],
+			"symbol": "__arm64_sys_io_getevents"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 5,
+			"kconfig": null,
+			"line": 743,
+			"name": "setxattr",
+			"number": 5,
+			"origname": "setxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_setxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 6,
+			"kconfig": null,
+			"line": 750,
+			"name": "lsetxattr",
+			"number": 6,
+			"origname": "lsetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_lsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 7,
+			"kconfig": null,
+			"line": 758,
+			"name": "fsetxattr",
+			"number": 7,
+			"origname": "fsetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_fsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 8,
+			"kconfig": null,
+			"line": 888,
+			"name": "getxattr",
+			"number": 8,
+			"origname": "getxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_getxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 9,
+			"kconfig": null,
+			"line": 894,
+			"name": "lgetxattr",
+			"number": 9,
+			"origname": "lgetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_lgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 10,
+			"kconfig": null,
+			"line": 901,
+			"name": "fgetxattr",
+			"number": 10,
+			"origname": "fgetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_fgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 11,
+			"kconfig": null,
+			"line": 998,
+			"name": "listxattr",
+			"number": 11,
+			"origname": "listxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_listxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 12,
+			"kconfig": null,
+			"line": 1004,
+			"name": "llistxattr",
+			"number": 12,
+			"origname": "llistxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_llistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 13,
+			"kconfig": null,
+			"line": 1010,
+			"name": "flistxattr",
+			"number": 13,
+			"origname": "flistxattr",
+			"signature": [
+				"int fd",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_flistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 14,
+			"kconfig": null,
+			"line": 1097,
+			"name": "removexattr",
+			"number": 14,
+			"origname": "removexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__arm64_sys_removexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 15,
+			"kconfig": null,
+			"line": 1103,
+			"name": "lremovexattr",
+			"number": 15,
+			"origname": "lremovexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__arm64_sys_lremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 16,
+			"kconfig": null,
+			"line": 1109,
+			"name": "fremovexattr",
+			"number": 16,
+			"origname": "fremovexattr",
+			"signature": [
+				"int fd",
+				"const char *name"
+			],
+			"symbol": "__arm64_sys_fremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/d_path.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 17,
+			"kconfig": null,
+			"line": 412,
+			"name": "getcwd",
+			"number": 17,
+			"origname": "getcwd",
+			"signature": [
+				"char *buf",
+				"unsigned long size"
+			],
+			"symbol": "__arm64_sys_getcwd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 19,
+			"kconfig": null,
+			"line": 424,
+			"name": "eventfd2",
+			"number": 19,
+			"origname": "eventfd2",
+			"signature": [
+				"unsigned int count",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_eventfd2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 20,
+			"kconfig": "EPOLL",
+			"line": 2251,
+			"name": "epoll_create1",
+			"number": 20,
+			"origname": "epoll_create1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__arm64_sys_epoll_create1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 21,
+			"kconfig": "EPOLL",
+			"line": 2436,
+			"name": "epoll_ctl",
+			"number": 21,
+			"origname": "epoll_ctl",
+			"signature": [
+				"int epfd",
+				"int op",
+				"int fd",
+				"struct epoll_event *event"
+			],
+			"symbol": "__arm64_sys_epoll_ctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 22,
+			"kconfig": "EPOLL",
+			"line": 2521,
+			"name": "epoll_pwait",
+			"number": 22,
+			"origname": "epoll_pwait",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"int timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_epoll_pwait"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 23,
+			"kconfig": null,
+			"line": 1394,
+			"name": "dup",
+			"number": 23,
+			"origname": "dup",
+			"signature": [
+				"unsigned int fildes"
+			],
+			"symbol": "__arm64_sys_dup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 24,
+			"kconfig": null,
+			"line": 1370,
+			"name": "dup3",
+			"number": 24,
+			"origname": "dup3",
+			"signature": [
+				"unsigned int oldfd",
+				"unsigned int newfd",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_dup3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fcntl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 25,
+			"kconfig": null,
+			"line": 576,
+			"name": "fcntl",
+			"number": 25,
+			"origname": "fcntl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__arm64_sys_fcntl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 26,
+			"kconfig": "INOTIFY_USER",
+			"line": 719,
+			"name": "inotify_init1",
+			"number": 26,
+			"origname": "inotify_init1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__arm64_sys_inotify_init1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 27,
+			"kconfig": "INOTIFY_USER",
+			"line": 729,
+			"name": "inotify_add_watch",
+			"number": 27,
+			"origname": "inotify_add_watch",
+			"signature": [
+				"int fd",
+				"const char *pathname",
+				"u32 mask"
+			],
+			"symbol": "__arm64_sys_inotify_add_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 28,
+			"kconfig": "INOTIFY_USER",
+			"line": 786,
+			"name": "inotify_rm_watch",
+			"number": 28,
+			"origname": "inotify_rm_watch",
+			"signature": [
+				"int fd",
+				"__s32 wd"
+			],
+			"symbol": "__arm64_sys_inotify_rm_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/ioctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 29,
+			"kconfig": null,
+			"line": 892,
+			"name": "ioctl",
+			"number": 29,
+			"origname": "ioctl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__arm64_sys_ioctl"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 30,
+			"kconfig": "BLOCK",
+			"line": 69,
+			"name": "ioprio_set",
+			"number": 30,
+			"origname": "ioprio_set",
+			"signature": [
+				"int which",
+				"int who",
+				"int ioprio"
+			],
+			"symbol": "__arm64_sys_ioprio_set"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 31,
+			"kconfig": "BLOCK",
+			"line": 184,
+			"name": "ioprio_get",
+			"number": 31,
+			"origname": "ioprio_get",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__arm64_sys_ioprio_get"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/locks.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 32,
+			"kconfig": null,
+			"line": 2135,
+			"name": "flock",
+			"number": 32,
+			"origname": "flock",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd"
+			],
+			"symbol": "__arm64_sys_flock"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 33,
+			"kconfig": null,
+			"line": 4266,
+			"name": "mknodat",
+			"number": 33,
+			"origname": "mknodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int dev"
+			],
+			"symbol": "__arm64_sys_mknodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 34,
+			"kconfig": null,
+			"line": 4349,
+			"name": "mkdirat",
+			"number": 34,
+			"origname": "mkdirat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__arm64_sys_mkdirat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 35,
+			"kconfig": null,
+			"line": 4625,
+			"name": "unlinkat",
+			"number": 35,
+			"origname": "unlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"int flag"
+			],
+			"symbol": "__arm64_sys_unlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 36,
+			"kconfig": null,
+			"line": 4710,
+			"name": "symlinkat",
+			"number": 36,
+			"origname": "symlinkat",
+			"signature": [
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__arm64_sys_symlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 37,
+			"kconfig": null,
+			"line": 4890,
+			"name": "linkat",
+			"number": 37,
+			"origname": "linkat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_linkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 38,
+			"kconfig": null,
+			"line": 5264,
+			"name": "renameat",
+			"number": 38,
+			"origname": "renameat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__arm64_sys_renameat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 39,
+			"kconfig": null,
+			"line": 2077,
+			"name": "umount",
+			"number": 39,
+			"origname": "umount",
+			"signature": [
+				"char *name",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_umount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 40,
+			"kconfig": null,
+			"line": 4088,
+			"name": "mount",
+			"number": 40,
+			"origname": "mount",
+			"signature": [
+				"char *dev_name",
+				"char *dir_name",
+				"char *type",
+				"unsigned long flags",
+				"void *data"
+			],
+			"symbol": "__arm64_sys_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 41,
+			"kconfig": null,
+			"line": 4388,
+			"name": "pivot_root",
+			"number": 41,
+			"origname": "pivot_root",
+			"signature": [
+				"const char *new_root",
+				"const char *put_old"
+			],
+			"symbol": "__arm64_sys_pivot_root"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 43,
+			"kconfig": null,
+			"line": 190,
+			"name": "statfs",
+			"number": 43,
+			"origname": "statfs",
+			"signature": [
+				"const char *pathname",
+				"struct statfs *buf"
+			],
+			"symbol": "__arm64_sys_statfs"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 44,
+			"kconfig": null,
+			"line": 211,
+			"name": "fstatfs",
+			"number": 44,
+			"origname": "fstatfs",
+			"signature": [
+				"unsigned int fd",
+				"struct statfs *buf"
+			],
+			"symbol": "__arm64_sys_fstatfs"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 45,
+			"kconfig": null,
+			"line": 148,
+			"name": "truncate",
+			"number": 45,
+			"origname": "truncate",
+			"signature": [
+				"const char *path",
+				"long length"
+			],
+			"symbol": "__arm64_sys_truncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 46,
+			"kconfig": null,
+			"line": 210,
+			"name": "ftruncate",
+			"number": 46,
+			"origname": "ftruncate",
+			"signature": [
+				"unsigned int fd",
+				"off_t length"
+			],
+			"symbol": "__arm64_sys_ftruncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 47,
+			"kconfig": null,
+			"line": 365,
+			"name": "fallocate",
+			"number": 47,
+			"origname": "fallocate",
+			"signature": [
+				"int fd",
+				"int mode",
+				"loff_t offset",
+				"loff_t len"
+			],
+			"symbol": "__arm64_sys_fallocate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 48,
+			"kconfig": null,
+			"line": 535,
+			"name": "faccessat",
+			"number": 48,
+			"origname": "faccessat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode"
+			],
+			"symbol": "__arm64_sys_faccessat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 49,
+			"kconfig": null,
+			"line": 551,
+			"name": "chdir",
+			"number": 49,
+			"origname": "chdir",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__arm64_sys_chdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 50,
+			"kconfig": null,
+			"line": 577,
+			"name": "fchdir",
+			"number": 50,
+			"origname": "fchdir",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__arm64_sys_fchdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 51,
+			"kconfig": null,
+			"line": 594,
+			"name": "chroot",
+			"number": 51,
+			"origname": "chroot",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__arm64_sys_chroot"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 52,
+			"kconfig": null,
+			"line": 663,
+			"name": "fchmod",
+			"number": 52,
+			"origname": "fchmod",
+			"signature": [
+				"unsigned int fd",
+				"umode_t mode"
+			],
+			"symbol": "__arm64_sys_fchmod"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 53,
+			"kconfig": null,
+			"line": 706,
+			"name": "fchmodat",
+			"number": 53,
+			"origname": "fchmodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode"
+			],
+			"symbol": "__arm64_sys_fchmodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 54,
+			"kconfig": null,
+			"line": 825,
+			"name": "fchownat",
+			"number": 54,
+			"origname": "fchownat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"uid_t user",
+				"gid_t group",
+				"int flag"
+			],
+			"symbol": "__arm64_sys_fchownat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 55,
+			"kconfig": null,
+			"line": 865,
+			"name": "fchown",
+			"number": 55,
+			"origname": "fchown",
+			"signature": [
+				"unsigned int fd",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__arm64_sys_fchown"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 56,
+			"kconfig": null,
+			"line": 1454,
+			"name": "openat",
+			"number": 56,
+			"origname": "openat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int flags",
+				"umode_t mode"
+			],
+			"symbol": "__arm64_sys_openat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 57,
+			"kconfig": null,
+			"line": 1565,
+			"name": "close",
+			"number": 57,
+			"origname": "close",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__arm64_sys_close"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 58,
+			"kconfig": null,
+			"line": 1596,
+			"name": "vhangup",
+			"number": 58,
+			"origname": "vhangup",
+			"signature": [],
+			"symbol": "__arm64_sys_vhangup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/pipe.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 59,
+			"kconfig": null,
+			"line": 1043,
+			"name": "pipe2",
+			"number": 59,
+			"origname": "pipe2",
+			"signature": [
+				"int *fildes",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_pipe2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 60,
+			"kconfig": "QUOTACTL",
+			"line": 917,
+			"name": "quotactl",
+			"number": 60,
+			"origname": "quotactl",
+			"signature": [
+				"unsigned int cmd",
+				"const char *special",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__arm64_sys_quotactl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 61,
+			"kconfig": null,
+			"line": 389,
+			"name": "getdents64",
+			"number": 61,
+			"origname": "getdents64",
+			"signature": [
+				"unsigned int fd",
+				"struct linux_dirent64 *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__arm64_sys_getdents64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 62,
+			"kconfig": null,
+			"line": 403,
+			"name": "lseek",
+			"number": 62,
+			"origname": "lseek",
+			"signature": [
+				"unsigned int fd",
+				"off_t offset",
+				"unsigned int whence"
+			],
+			"symbol": "__arm64_sys_lseek"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 63,
+			"kconfig": null,
+			"line": 715,
+			"name": "read",
+			"number": 63,
+			"origname": "read",
+			"signature": [
+				"unsigned int fd",
+				"char *buf",
+				"size_t count"
+			],
+			"symbol": "__arm64_sys_read"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 64,
+			"kconfig": null,
+			"line": 739,
+			"name": "write",
+			"number": 64,
+			"origname": "write",
+			"signature": [
+				"unsigned int fd",
+				"const char *buf",
+				"size_t count"
+			],
+			"symbol": "__arm64_sys_write"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 65,
+			"kconfig": null,
+			"line": 1155,
+			"name": "readv",
+			"number": 65,
+			"origname": "readv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__arm64_sys_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 66,
+			"kconfig": null,
+			"line": 1161,
+			"name": "writev",
+			"number": 66,
+			"origname": "writev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__arm64_sys_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 67,
+			"kconfig": null,
+			"line": 761,
+			"name": "pread64",
+			"number": 67,
+			"origname": "pread64",
+			"signature": [
+				"unsigned int fd",
+				"char *buf",
+				"size_t count",
+				"loff_t pos"
+			],
+			"symbol": "__arm64_sys_pread64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 68,
+			"kconfig": null,
+			"line": 791,
+			"name": "pwrite64",
+			"number": 68,
+			"origname": "pwrite64",
+			"signature": [
+				"unsigned int fd",
+				"const char *buf",
+				"size_t count",
+				"loff_t pos"
+			],
+			"symbol": "__arm64_sys_pwrite64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 69,
+			"kconfig": null,
+			"line": 1167,
+			"name": "preadv",
+			"number": 69,
+			"origname": "preadv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__arm64_sys_preadv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 70,
+			"kconfig": null,
+			"line": 1187,
+			"name": "pwritev",
+			"number": 70,
+			"origname": "pwritev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__arm64_sys_pwritev"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 71,
+			"kconfig": null,
+			"line": 1410,
+			"name": "sendfile64",
+			"number": 71,
+			"origname": "sendfile64",
+			"signature": [
+				"int out_fd",
+				"int in_fd",
+				"loff_t *offset",
+				"size_t count"
+			],
+			"symbol": "__arm64_sys_sendfile64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 72,
+			"kconfig": null,
+			"line": 793,
+			"name": "pselect6",
+			"number": 72,
+			"origname": "pselect6",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct __kernel_timespec *tsp",
+				"void *sig"
+			],
+			"symbol": "__arm64_sys_pselect6"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 73,
+			"kconfig": null,
+			"line": 1095,
+			"name": "ppoll",
+			"number": 73,
+			"origname": "ppoll",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"struct __kernel_timespec *tsp",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_ppoll"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/signalfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 74,
+			"kconfig": "SIGNALFD",
+			"line": 307,
+			"name": "signalfd4",
+			"number": 74,
+			"origname": "signalfd4",
+			"signature": [
+				"int ufd",
+				"sigset_t *user_mask",
+				"size_t sizemask",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_signalfd4"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 75,
+			"kconfig": null,
+			"line": 1583,
+			"name": "vmsplice",
+			"number": 75,
+			"origname": "vmsplice",
+			"signature": [
+				"int fd",
+				"const struct iovec *uiov",
+				"unsigned long nr_segs",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_vmsplice"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 76,
+			"kconfig": null,
+			"line": 1621,
+			"name": "splice",
+			"number": 76,
+			"origname": "splice",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_splice"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 77,
+			"kconfig": null,
+			"line": 1988,
+			"name": "tee",
+			"number": 77,
+			"origname": "tee",
+			"signature": [
+				"int fdin",
+				"int fdout",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_tee"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 78,
+			"kconfig": null,
+			"line": 592,
+			"name": "readlinkat",
+			"number": 78,
+			"origname": "readlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"char *buf",
+				"int bufsiz"
+			],
+			"symbol": "__arm64_sys_readlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 79,
+			"kconfig": null,
+			"line": 526,
+			"name": "newfstatat",
+			"number": 79,
+			"origname": "newfstatat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct stat *statbuf",
+				"int flag"
+			],
+			"symbol": "__arm64_sys_newfstatat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 80,
+			"kconfig": null,
+			"line": 539,
+			"name": "newfstat",
+			"number": 80,
+			"origname": "newfstat",
+			"signature": [
+				"unsigned int fd",
+				"struct stat *statbuf"
+			],
+			"symbol": "__arm64_sys_newfstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 81,
+			"kconfig": null,
+			"line": 111,
+			"name": "sync",
+			"number": 81,
+			"origname": "sync",
+			"signature": [],
+			"symbol": "__arm64_sys_sync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 82,
+			"kconfig": null,
+			"line": 215,
+			"name": "fsync",
+			"number": 82,
+			"origname": "fsync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__arm64_sys_fsync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 83,
+			"kconfig": null,
+			"line": 220,
+			"name": "fdatasync",
+			"number": 83,
+			"origname": "fdatasync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__arm64_sys_fdatasync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 84,
+			"kconfig": null,
+			"line": 363,
+			"name": "sync_file_range",
+			"number": 84,
+			"origname": "sync_file_range",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"loff_t nbytes",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_sync_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 85,
+			"kconfig": null,
+			"line": 395,
+			"name": "timerfd_create",
+			"number": 85,
+			"origname": "timerfd_create",
+			"signature": [
+				"int clockid",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_timerfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 86,
+			"kconfig": null,
+			"line": 560,
+			"name": "timerfd_settime",
+			"number": 86,
+			"origname": "timerfd_settime",
+			"signature": [
+				"int ufd",
+				"int flags",
+				"const struct __kernel_itimerspec *utmr",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__arm64_sys_timerfd_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 87,
+			"kconfig": null,
+			"line": 578,
+			"name": "timerfd_gettime",
+			"number": 87,
+			"origname": "timerfd_gettime",
+			"signature": [
+				"int ufd",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__arm64_sys_timerfd_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 88,
+			"kconfig": null,
+			"line": 143,
+			"name": "utimensat",
+			"number": 88,
+			"origname": "utimensat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct __kernel_timespec *utimes",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_utimensat"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/acct.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 89,
+			"kconfig": "BSD_PROCESS_ACCT",
+			"line": 314,
+			"name": "acct",
+			"number": 89,
+			"origname": "acct",
+			"signature": [
+				"const char *name"
+			],
+			"symbol": "__arm64_sys_acct"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 90,
+			"kconfig": "MULTIUSER",
+			"line": 137,
+			"name": "capget",
+			"number": 90,
+			"origname": "capget",
+			"signature": [
+				"cap_user_header_t header",
+				"cap_user_data_t dataptr"
+			],
+			"symbol": "__arm64_sys_capget"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 91,
+			"kconfig": "MULTIUSER",
+			"line": 216,
+			"name": "capset",
+			"number": 91,
+			"origname": "capset",
+			"signature": [
+				"cap_user_header_t header",
+				"const cap_user_data_t data"
+			],
+			"symbol": "__arm64_sys_capset"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/arm64/kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 92,
+			"kconfig": null,
+			"line": 31,
+			"name": "personality",
+			"number": 92,
+			"origname": "arm64_personality",
+			"signature": [
+				"unsigned int personality"
+			],
+			"symbol": "__arm64_sys_arm64_personality"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 93,
+			"kconfig": null,
+			"line": 1052,
+			"name": "exit",
+			"number": 93,
+			"origname": "exit",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__arm64_sys_exit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 94,
+			"kconfig": null,
+			"line": 1096,
+			"name": "exit_group",
+			"number": 94,
+			"origname": "exit_group",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__arm64_sys_exit_group"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 95,
+			"kconfig": null,
+			"line": 1782,
+			"name": "waitid",
+			"number": 95,
+			"origname": "waitid",
+			"signature": [
+				"int which",
+				"pid_t upid",
+				"struct siginfo *infop",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__arm64_sys_waitid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 96,
+			"kconfig": null,
+			"line": 1949,
+			"name": "set_tid_address",
+			"number": 96,
+			"origname": "set_tid_address",
+			"signature": [
+				"int *tidptr"
+			],
+			"symbol": "__arm64_sys_set_tid_address"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 97,
+			"kconfig": null,
+			"line": 3411,
+			"name": "unshare",
+			"number": 97,
+			"origname": "unshare",
+			"signature": [
+				"unsigned long unshare_flags"
+			],
+			"symbol": "__arm64_sys_unshare"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 98,
+			"kconfig": "FUTEX",
+			"line": 160,
+			"name": "futex",
+			"number": 98,
+			"origname": "futex",
+			"signature": [
+				"u32 *uaddr",
+				"int op",
+				"u32 val",
+				"const struct __kernel_timespec *utime",
+				"u32 *uaddr2",
+				"u32 val3"
+			],
+			"symbol": "__arm64_sys_futex"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 99,
+			"kconfig": "FUTEX",
+			"line": 28,
+			"name": "set_robust_list",
+			"number": 99,
+			"origname": "set_robust_list",
+			"signature": [
+				"struct robust_list_head *head",
+				"size_t len"
+			],
+			"symbol": "__arm64_sys_set_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 100,
+			"kconfig": "FUTEX",
+			"line": 48,
+			"name": "get_robust_list",
+			"number": 100,
+			"origname": "get_robust_list",
+			"signature": [
+				"int pid",
+				"struct robust_list_head **head_ptr",
+				"size_t *len_ptr"
+			],
+			"symbol": "__arm64_sys_get_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/hrtimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 101,
+			"kconfig": null,
+			"line": 2209,
+			"name": "nanosleep",
+			"number": 101,
+			"origname": "nanosleep",
+			"signature": [
+				"struct __kernel_timespec *rqtp",
+				"struct __kernel_timespec *rmtp"
+			],
+			"symbol": "__arm64_sys_nanosleep"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 102,
+			"kconfig": null,
+			"line": 113,
+			"name": "getitimer",
+			"number": 102,
+			"origname": "getitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value"
+			],
+			"symbol": "__arm64_sys_getitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 103,
+			"kconfig": null,
+			"line": 352,
+			"name": "setitimer",
+			"number": 103,
+			"origname": "setitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value",
+				"struct __kernel_old_itimerval *ovalue"
+			],
+			"symbol": "__arm64_sys_setitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kexec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 104,
+			"kconfig": "KEXEC",
+			"line": 242,
+			"name": "kexec_load",
+			"number": 104,
+			"origname": "kexec_load",
+			"signature": [
+				"unsigned long entry",
+				"unsigned long nr_segments",
+				"struct kexec_segment *segments",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_kexec_load"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 105,
+			"kconfig": "MODULES",
+			"line": 3515,
+			"name": "init_module",
+			"number": 105,
+			"origname": "init_module",
+			"signature": [
+				"void *umod",
+				"unsigned long len",
+				"const char *uargs"
+			],
+			"symbol": "__arm64_sys_init_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 106,
+			"kconfig": "MODULE_UNLOAD",
+			"line": 732,
+			"name": "delete_module",
+			"number": 106,
+			"origname": "delete_module",
+			"signature": [
+				"const char *name_user",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_delete_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 107,
+			"kconfig": "POSIX_TIMERS",
+			"line": 480,
+			"name": "timer_create",
+			"number": 107,
+			"origname": "timer_create",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct sigevent *timer_event_spec",
+				"timer_t *created_timer_id"
+			],
+			"symbol": "__arm64_sys_timer_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 108,
+			"kconfig": "POSIX_TIMERS",
+			"line": 676,
+			"name": "timer_gettime",
+			"number": 108,
+			"origname": "timer_gettime",
+			"signature": [
+				"timer_t timer_id",
+				"struct __kernel_itimerspec *setting"
+			],
+			"symbol": "__arm64_sys_timer_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 109,
+			"kconfig": "POSIX_TIMERS",
+			"line": 724,
+			"name": "timer_getoverrun",
+			"number": 109,
+			"origname": "timer_getoverrun",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__arm64_sys_timer_getoverrun"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 110,
+			"kconfig": "POSIX_TIMERS",
+			"line": 914,
+			"name": "timer_settime",
+			"number": 110,
+			"origname": "timer_settime",
+			"signature": [
+				"timer_t timer_id",
+				"int flags",
+				"const struct __kernel_itimerspec *new_setting",
+				"struct __kernel_itimerspec *old_setting"
+			],
+			"symbol": "__arm64_sys_timer_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 111,
+			"kconfig": "POSIX_TIMERS",
+			"line": 994,
+			"name": "timer_delete",
+			"number": 111,
+			"origname": "timer_delete",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__arm64_sys_timer_delete"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 112,
+			"kconfig": null,
+			"line": 1119,
+			"name": "clock_settime",
+			"number": 112,
+			"origname": "clock_settime",
+			"signature": [
+				"const clockid_t which_clock",
+				"const struct __kernel_timespec *tp"
+			],
+			"symbol": "__arm64_sys_clock_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 113,
+			"kconfig": null,
+			"line": 1138,
+			"name": "clock_gettime",
+			"number": 113,
+			"origname": "clock_gettime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__arm64_sys_clock_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 114,
+			"kconfig": null,
+			"line": 1258,
+			"name": "clock_getres",
+			"number": 114,
+			"origname": "clock_getres",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__arm64_sys_clock_getres"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 115,
+			"kconfig": null,
+			"line": 1379,
+			"name": "clock_nanosleep",
+			"number": 115,
+			"origname": "clock_nanosleep",
+			"signature": [
+				"const clockid_t which_clock",
+				"int flags",
+				"const struct __kernel_timespec *rqtp",
+				"struct __kernel_timespec *rmtp"
+			],
+			"symbol": "__arm64_sys_clock_nanosleep"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/printk/printk.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 116,
+			"kconfig": null,
+			"line": 1875,
+			"name": "syslog",
+			"number": 116,
+			"origname": "syslog",
+			"signature": [
+				"int type",
+				"char *buf",
+				"int len"
+			],
+			"symbol": "__arm64_sys_syslog"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/ptrace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 117,
+			"kconfig": null,
+			"line": 1258,
+			"name": "ptrace",
+			"number": 117,
+			"origname": "ptrace",
+			"signature": [
+				"long request",
+				"long pid",
+				"unsigned long addr",
+				"unsigned long data"
+			],
+			"symbol": "__arm64_sys_ptrace"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 118,
+			"kconfig": null,
+			"line": 970,
+			"name": "sched_setparam",
+			"number": 118,
+			"origname": "sched_setparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__arm64_sys_sched_setparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 119,
+			"kconfig": null,
+			"line": 955,
+			"name": "sched_setscheduler",
+			"number": 119,
+			"origname": "sched_setscheduler",
+			"signature": [
+				"pid_t pid",
+				"int policy",
+				"struct sched_param *param"
+			],
+			"symbol": "__arm64_sys_sched_setscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 120,
+			"kconfig": null,
+			"line": 1016,
+			"name": "sched_getscheduler",
+			"number": 120,
+			"origname": "sched_getscheduler",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__arm64_sys_sched_getscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 121,
+			"kconfig": null,
+			"line": 1046,
+			"name": "sched_getparam",
+			"number": 121,
+			"origname": "sched_getparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__arm64_sys_sched_getparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 122,
+			"kconfig": null,
+			"line": 1279,
+			"name": "sched_setaffinity",
+			"number": 122,
+			"origname": "sched_setaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__arm64_sys_sched_setaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 123,
+			"kconfig": null,
+			"line": 1324,
+			"name": "sched_getaffinity",
+			"number": 123,
+			"origname": "sched_getaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__arm64_sys_sched_getaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 124,
+			"kconfig": null,
+			"line": 1377,
+			"name": "sched_yield",
+			"number": 124,
+			"origname": "sched_yield",
+			"signature": [],
+			"symbol": "__arm64_sys_sched_yield"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 125,
+			"kconfig": null,
+			"line": 1485,
+			"name": "sched_get_priority_max",
+			"number": 125,
+			"origname": "sched_get_priority_max",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__arm64_sys_sched_get_priority_max"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 126,
+			"kconfig": null,
+			"line": 1513,
+			"name": "sched_get_priority_min",
+			"number": 126,
+			"origname": "sched_get_priority_min",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__arm64_sys_sched_get_priority_min"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 127,
+			"kconfig": null,
+			"line": 1571,
+			"name": "sched_rr_get_interval",
+			"number": 127,
+			"origname": "sched_rr_get_interval",
+			"signature": [
+				"pid_t pid",
+				"struct __kernel_timespec *interval"
+			],
+			"symbol": "__arm64_sys_sched_rr_get_interval"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 128,
+			"kconfig": null,
+			"line": 3177,
+			"name": "restart_syscall",
+			"number": 128,
+			"origname": "restart_syscall",
+			"signature": [],
+			"symbol": "__arm64_sys_restart_syscall"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 129,
+			"kconfig": null,
+			"line": 3951,
+			"name": "kill",
+			"number": 129,
+			"origname": "kill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__arm64_sys_kill"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 130,
+			"kconfig": null,
+			"line": 4160,
+			"name": "tkill",
+			"number": 130,
+			"origname": "tkill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__arm64_sys_tkill"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 131,
+			"kconfig": null,
+			"line": 4144,
+			"name": "tgkill",
+			"number": 131,
+			"origname": "tgkill",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__arm64_sys_tgkill"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 132,
+			"kconfig": null,
+			"line": 4423,
+			"name": "sigaltstack",
+			"number": 132,
+			"origname": "sigaltstack",
+			"signature": [
+				"const stack_t *uss",
+				"stack_t *uoss"
+			],
+			"symbol": "__arm64_sys_sigaltstack"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 133,
+			"kconfig": null,
+			"line": 4829,
+			"name": "rt_sigsuspend",
+			"number": 133,
+			"origname": "rt_sigsuspend",
+			"signature": [
+				"sigset_t *unewset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_rt_sigsuspend"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 134,
+			"kconfig": null,
+			"line": 4606,
+			"name": "rt_sigaction",
+			"number": 134,
+			"origname": "rt_sigaction",
+			"signature": [
+				"int sig",
+				"const struct sigaction *act",
+				"struct sigaction *oact",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_rt_sigaction"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 135,
+			"kconfig": null,
+			"line": 3320,
+			"name": "rt_sigprocmask",
+			"number": 135,
+			"origname": "rt_sigprocmask",
+			"signature": [
+				"int how",
+				"sigset_t *nset",
+				"sigset_t *oset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_rt_sigprocmask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 136,
+			"kconfig": null,
+			"line": 3392,
+			"name": "rt_sigpending",
+			"number": 136,
+			"origname": "rt_sigpending",
+			"signature": [
+				"sigset_t *uset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_rt_sigpending"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 137,
+			"kconfig": null,
+			"line": 3806,
+			"name": "rt_sigtimedwait",
+			"number": 137,
+			"origname": "rt_sigtimedwait",
+			"signature": [
+				"const sigset_t *uthese",
+				"siginfo_t *uinfo",
+				"const struct __kernel_timespec *uts",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_rt_sigtimedwait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 138,
+			"kconfig": null,
+			"line": 4188,
+			"name": "rt_sigqueueinfo",
+			"number": 138,
+			"origname": "rt_sigqueueinfo",
+			"signature": [
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__arm64_sys_rt_sigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/arm64/kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 139,
+			"kconfig": null,
+			"line": 1107,
+			"name": "rt_sigreturn",
+			"number": 139,
+			"origname": "rt_sigreturn",
+			"signature": [],
+			"symbol": "__arm64_sys_rt_sigreturn"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 140,
+			"kconfig": null,
+			"line": 229,
+			"name": "setpriority",
+			"number": 140,
+			"origname": "setpriority",
+			"signature": [
+				"int which",
+				"int who",
+				"int niceval"
+			],
+			"symbol": "__arm64_sys_setpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 141,
+			"kconfig": null,
+			"line": 299,
+			"name": "getpriority",
+			"number": 141,
+			"origname": "getpriority",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__arm64_sys_getpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/reboot.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 142,
+			"kconfig": null,
+			"line": 722,
+			"name": "reboot",
+			"number": 142,
+			"origname": "reboot",
+			"signature": [
+				"int magic1",
+				"int magic2",
+				"unsigned int cmd",
+				"void *arg"
+			],
+			"symbol": "__arm64_sys_reboot"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 143,
+			"kconfig": "MULTIUSER",
+			"line": 439,
+			"name": "setregid",
+			"number": 143,
+			"origname": "setregid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid"
+			],
+			"symbol": "__arm64_sys_setregid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 144,
+			"kconfig": "MULTIUSER",
+			"line": 485,
+			"name": "setgid",
+			"number": 144,
+			"origname": "setgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__arm64_sys_setgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 145,
+			"kconfig": "MULTIUSER",
+			"line": 605,
+			"name": "setreuid",
+			"number": 145,
+			"origname": "setreuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid"
+			],
+			"symbol": "__arm64_sys_setreuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 146,
+			"kconfig": "MULTIUSER",
+			"line": 668,
+			"name": "setuid",
+			"number": 146,
+			"origname": "setuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__arm64_sys_setuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 147,
+			"kconfig": "MULTIUSER",
+			"line": 753,
+			"name": "setresuid",
+			"number": 147,
+			"origname": "setresuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid",
+				"uid_t suid"
+			],
+			"symbol": "__arm64_sys_setresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 148,
+			"kconfig": "MULTIUSER",
+			"line": 758,
+			"name": "getresuid",
+			"number": 148,
+			"origname": "getresuid",
+			"signature": [
+				"uid_t *ruidp",
+				"uid_t *euidp",
+				"uid_t *suidp"
+			],
+			"symbol": "__arm64_sys_getresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 149,
+			"kconfig": "MULTIUSER",
+			"line": 842,
+			"name": "setresgid",
+			"number": 149,
+			"origname": "setresgid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid",
+				"gid_t sgid"
+			],
+			"symbol": "__arm64_sys_setresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 150,
+			"kconfig": "MULTIUSER",
+			"line": 847,
+			"name": "getresgid",
+			"number": 150,
+			"origname": "getresgid",
+			"signature": [
+				"gid_t *rgidp",
+				"gid_t *egidp",
+				"gid_t *sgidp"
+			],
+			"symbol": "__arm64_sys_getresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 151,
+			"kconfig": "MULTIUSER",
+			"line": 910,
+			"name": "setfsuid",
+			"number": 151,
+			"origname": "setfsuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__arm64_sys_setfsuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 152,
+			"kconfig": "MULTIUSER",
+			"line": 954,
+			"name": "setfsgid",
+			"number": 152,
+			"origname": "setfsgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__arm64_sys_setfsgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 153,
+			"kconfig": null,
+			"line": 1034,
+			"name": "times",
+			"number": 153,
+			"origname": "times",
+			"signature": [
+				"struct tms *tbuf"
+			],
+			"symbol": "__arm64_sys_times"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 154,
+			"kconfig": null,
+			"line": 1084,
+			"name": "setpgid",
+			"number": 154,
+			"origname": "setpgid",
+			"signature": [
+				"pid_t pid",
+				"pid_t pgid"
+			],
+			"symbol": "__arm64_sys_setpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 155,
+			"kconfig": null,
+			"line": 1183,
+			"name": "getpgid",
+			"number": 155,
+			"origname": "getpgid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__arm64_sys_getpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 156,
+			"kconfig": null,
+			"line": 1197,
+			"name": "getsid",
+			"number": 156,
+			"origname": "getsid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__arm64_sys_getsid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 157,
+			"kconfig": null,
+			"line": 1269,
+			"name": "setsid",
+			"number": 157,
+			"origname": "setsid",
+			"signature": [],
+			"symbol": "__arm64_sys_setsid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 158,
+			"kconfig": "MULTIUSER",
+			"line": 161,
+			"name": "getgroups",
+			"number": 158,
+			"origname": "getgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__arm64_sys_getgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 159,
+			"kconfig": "MULTIUSER",
+			"line": 198,
+			"name": "setgroups",
+			"number": 159,
+			"origname": "setgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__arm64_sys_setgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 160,
+			"kconfig": null,
+			"line": 1317,
+			"name": "newuname",
+			"number": 160,
+			"origname": "newuname",
+			"signature": [
+				"struct new_utsname *name"
+			],
+			"symbol": "__arm64_sys_newuname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 161,
+			"kconfig": null,
+			"line": 1385,
+			"name": "sethostname",
+			"number": 161,
+			"origname": "sethostname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__arm64_sys_sethostname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 162,
+			"kconfig": null,
+			"line": 1439,
+			"name": "setdomainname",
+			"number": 162,
+			"origname": "setdomainname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__arm64_sys_setdomainname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 163,
+			"kconfig": null,
+			"line": 1529,
+			"name": "getrlimit",
+			"number": 163,
+			"origname": "getrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__arm64_sys_getrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 164,
+			"kconfig": null,
+			"line": 1742,
+			"name": "setrlimit",
+			"number": 164,
+			"origname": "setrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__arm64_sys_setrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 165,
+			"kconfig": null,
+			"line": 1882,
+			"name": "getrusage",
+			"number": 165,
+			"origname": "getrusage",
+			"signature": [
+				"int who",
+				"struct rusage *ru"
+			],
+			"symbol": "__arm64_sys_getrusage"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 166,
+			"kconfig": null,
+			"line": 1908,
+			"name": "umask",
+			"number": 166,
+			"origname": "umask",
+			"signature": [
+				"int mask"
+			],
+			"symbol": "__arm64_sys_umask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 167,
+			"kconfig": null,
+			"line": 2469,
+			"name": "prctl",
+			"number": 167,
+			"origname": "prctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__arm64_sys_prctl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 168,
+			"kconfig": null,
+			"line": 2822,
+			"name": "getcpu",
+			"number": 168,
+			"origname": "getcpu",
+			"signature": [
+				"unsigned *cpup",
+				"unsigned *nodep",
+				"struct getcpu_cache *unused"
+			],
+			"symbol": "__arm64_sys_getcpu"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 169,
+			"kconfig": null,
+			"line": 140,
+			"name": "gettimeofday",
+			"number": 169,
+			"origname": "gettimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__arm64_sys_gettimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 170,
+			"kconfig": null,
+			"line": 199,
+			"name": "settimeofday",
+			"number": 170,
+			"origname": "settimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__arm64_sys_settimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 171,
+			"kconfig": null,
+			"line": 269,
+			"name": "adjtimex",
+			"number": 171,
+			"origname": "adjtimex",
+			"signature": [
+				"struct __kernel_timex *txc_p"
+			],
+			"symbol": "__arm64_sys_adjtimex"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 172,
+			"kconfig": null,
+			"line": 969,
+			"name": "getpid",
+			"number": 172,
+			"origname": "getpid",
+			"signature": [],
+			"symbol": "__arm64_sys_getpid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 173,
+			"kconfig": null,
+			"line": 986,
+			"name": "getppid",
+			"number": 173,
+			"origname": "getppid",
+			"signature": [],
+			"symbol": "__arm64_sys_getppid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 174,
+			"kconfig": null,
+			"line": 997,
+			"name": "getuid",
+			"number": 174,
+			"origname": "getuid",
+			"signature": [],
+			"symbol": "__arm64_sys_getuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 175,
+			"kconfig": null,
+			"line": 1003,
+			"name": "geteuid",
+			"number": 175,
+			"origname": "geteuid",
+			"signature": [],
+			"symbol": "__arm64_sys_geteuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 176,
+			"kconfig": null,
+			"line": 1009,
+			"name": "getgid",
+			"number": 176,
+			"origname": "getgid",
+			"signature": [],
+			"symbol": "__arm64_sys_getgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 177,
+			"kconfig": null,
+			"line": 1015,
+			"name": "getegid",
+			"number": 177,
+			"origname": "getegid",
+			"signature": [],
+			"symbol": "__arm64_sys_getegid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 178,
+			"kconfig": null,
+			"line": 975,
+			"name": "gettid",
+			"number": 178,
+			"origname": "gettid",
+			"signature": [],
+			"symbol": "__arm64_sys_gettid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 179,
+			"kconfig": null,
+			"line": 2902,
+			"name": "sysinfo",
+			"number": 179,
+			"origname": "sysinfo",
+			"signature": [
+				"struct sysinfo *info"
+			],
+			"symbol": "__arm64_sys_sysinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 180,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 944,
+			"name": "mq_open",
+			"number": 180,
+			"origname": "mq_open",
+			"signature": [
+				"const char *u_name",
+				"int oflag",
+				"umode_t mode",
+				"struct mq_attr *u_attr"
+			],
+			"symbol": "__arm64_sys_mq_open"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 181,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 954,
+			"name": "mq_unlink",
+			"number": 181,
+			"origname": "mq_unlink",
+			"signature": [
+				"const char *u_name"
+			],
+			"symbol": "__arm64_sys_mq_unlink"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 182,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1258,
+			"name": "mq_timedsend",
+			"number": 182,
+			"origname": "mq_timedsend",
+			"signature": [
+				"mqd_t mqdes",
+				"const char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__arm64_sys_mq_timedsend"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 183,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1272,
+			"name": "mq_timedreceive",
+			"number": 183,
+			"origname": "mq_timedreceive",
+			"signature": [
+				"mqd_t mqdes",
+				"char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int *u_msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__arm64_sys_mq_timedreceive"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 184,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1400,
+			"name": "mq_notify",
+			"number": 184,
+			"origname": "mq_notify",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct sigevent *u_notification"
+			],
+			"symbol": "__arm64_sys_mq_notify"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 185,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1452,
+			"name": "mq_getsetattr",
+			"number": 185,
+			"origname": "mq_getsetattr",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct mq_attr *u_mqstat",
+				"struct mq_attr *u_omqstat"
+			],
+			"symbol": "__arm64_sys_mq_getsetattr"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 186,
+			"kconfig": "SYSVIPC",
+			"line": 315,
+			"name": "msgget",
+			"number": 186,
+			"origname": "msgget",
+			"signature": [
+				"key_t key",
+				"int msgflg"
+			],
+			"symbol": "__arm64_sys_msgget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 187,
+			"kconfig": "SYSVIPC",
+			"line": 640,
+			"name": "msgctl",
+			"number": 187,
+			"origname": "msgctl",
+			"signature": [
+				"int msqid",
+				"int cmd",
+				"struct msqid_ds *buf"
+			],
+			"symbol": "__arm64_sys_msgctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 188,
+			"kconfig": "SYSVIPC",
+			"line": 1270,
+			"name": "msgrcv",
+			"number": 188,
+			"origname": "msgrcv",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"long msgtyp",
+				"int msgflg"
+			],
+			"symbol": "__arm64_sys_msgrcv"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 189,
+			"kconfig": "SYSVIPC",
+			"line": 971,
+			"name": "msgsnd",
+			"number": 189,
+			"origname": "msgsnd",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"int msgflg"
+			],
+			"symbol": "__arm64_sys_msgsnd"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 190,
+			"kconfig": "SYSVIPC",
+			"line": 624,
+			"name": "semget",
+			"number": 190,
+			"origname": "semget",
+			"signature": [
+				"key_t key",
+				"int nsems",
+				"int semflg"
+			],
+			"symbol": "__arm64_sys_semget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 191,
+			"kconfig": "SYSVIPC",
+			"line": 1705,
+			"name": "semctl",
+			"number": 191,
+			"origname": "semctl",
+			"signature": [
+				"int semid",
+				"int semnum",
+				"int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__arm64_sys_semctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 192,
+			"kconfig": "SYSVIPC",
+			"line": 2268,
+			"name": "semtimedop",
+			"number": 192,
+			"origname": "semtimedop",
+			"signature": [
+				"int semid",
+				"struct sembuf *tsops",
+				"unsigned int nsops",
+				"const struct __kernel_timespec *timeout"
+			],
+			"symbol": "__arm64_sys_semtimedop"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 193,
+			"kconfig": "SYSVIPC",
+			"line": 2296,
+			"name": "semop",
+			"number": 193,
+			"origname": "semop",
+			"signature": [
+				"int semid",
+				"struct sembuf *tsops",
+				"unsigned nsops"
+			],
+			"symbol": "__arm64_sys_semop"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 194,
+			"kconfig": "SYSVIPC",
+			"line": 842,
+			"name": "shmget",
+			"number": 194,
+			"origname": "shmget",
+			"signature": [
+				"key_t key",
+				"size_t size",
+				"int shmflg"
+			],
+			"symbol": "__arm64_sys_shmget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 195,
+			"kconfig": "SYSVIPC",
+			"line": 1291,
+			"name": "shmctl",
+			"number": 195,
+			"origname": "shmctl",
+			"signature": [
+				"int shmid",
+				"int cmd",
+				"struct shmid_ds *buf"
+			],
+			"symbol": "__arm64_sys_shmctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 196,
+			"kconfig": "SYSVIPC",
+			"line": 1688,
+			"name": "shmat",
+			"number": 196,
+			"origname": "shmat",
+			"signature": [
+				"int shmid",
+				"char *shmaddr",
+				"int shmflg"
+			],
+			"symbol": "__arm64_sys_shmat"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 197,
+			"kconfig": "SYSVIPC",
+			"line": 1829,
+			"name": "shmdt",
+			"number": 197,
+			"origname": "shmdt",
+			"signature": [
+				"char *shmaddr"
+			],
+			"symbol": "__arm64_sys_shmdt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 198,
+			"kconfig": "NET",
+			"line": 1702,
+			"name": "socket",
+			"number": 198,
+			"origname": "socket",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol"
+			],
+			"symbol": "__arm64_sys_socket"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 199,
+			"kconfig": "NET",
+			"line": 1803,
+			"name": "socketpair",
+			"number": 199,
+			"origname": "socketpair",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol",
+				"int *usockvec"
+			],
+			"symbol": "__arm64_sys_socketpair"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 200,
+			"kconfig": "NET",
+			"line": 1851,
+			"name": "bind",
+			"number": 200,
+			"origname": "bind",
+			"signature": [
+				"int fd",
+				"struct sockaddr *umyaddr",
+				"int addrlen"
+			],
+			"symbol": "__arm64_sys_bind"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 201,
+			"kconfig": "NET",
+			"line": 1889,
+			"name": "listen",
+			"number": 201,
+			"origname": "listen",
+			"signature": [
+				"int fd",
+				"int backlog"
+			],
+			"symbol": "__arm64_sys_listen"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 202,
+			"kconfig": "NET",
+			"line": 2010,
+			"name": "accept",
+			"number": 202,
+			"origname": "accept",
+			"signature": [
+				"int fd",
+				"struct sockaddr *upeer_sockaddr",
+				"int *upeer_addrlen"
+			],
+			"symbol": "__arm64_sys_accept"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 203,
+			"kconfig": "NET",
+			"line": 2067,
+			"name": "connect",
+			"number": 203,
+			"origname": "connect",
+			"signature": [
+				"int fd",
+				"struct sockaddr *uservaddr",
+				"int addrlen"
+			],
+			"symbol": "__arm64_sys_connect"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 204,
+			"kconfig": "NET",
+			"line": 2104,
+			"name": "getsockname",
+			"number": 204,
+			"origname": "getsockname",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__arm64_sys_getsockname"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 205,
+			"kconfig": "NET",
+			"line": 2141,
+			"name": "getpeername",
+			"number": 205,
+			"origname": "getpeername",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__arm64_sys_getpeername"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 206,
+			"kconfig": "NET",
+			"line": 2190,
+			"name": "sendto",
+			"number": 206,
+			"origname": "sendto",
+			"signature": [
+				"int fd",
+				"void *buff",
+				"size_t len",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int addr_len"
+			],
+			"symbol": "__arm64_sys_sendto"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 207,
+			"kconfig": "NET",
+			"line": 2248,
+			"name": "recvfrom",
+			"number": 207,
+			"origname": "recvfrom",
+			"signature": [
+				"int fd",
+				"void *ubuf",
+				"size_t size",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int *addr_len"
+			],
+			"symbol": "__arm64_sys_recvfrom"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 208,
+			"kconfig": "NET",
+			"line": 2331,
+			"name": "setsockopt",
+			"number": 208,
+			"origname": "setsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int optlen"
+			],
+			"symbol": "__arm64_sys_setsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 209,
+			"kconfig": "NET",
+			"line": 2397,
+			"name": "getsockopt",
+			"number": 209,
+			"origname": "getsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int *optlen"
+			],
+			"symbol": "__arm64_sys_getsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 210,
+			"kconfig": "NET",
+			"line": 2432,
+			"name": "shutdown",
+			"number": 210,
+			"origname": "shutdown",
+			"signature": [
+				"int fd",
+				"int how"
+			],
+			"symbol": "__arm64_sys_shutdown"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 211,
+			"kconfig": "NET",
+			"line": 2662,
+			"name": "sendmsg",
+			"number": 211,
+			"origname": "sendmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_sendmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 212,
+			"kconfig": "NET",
+			"line": 2871,
+			"name": "recvmsg",
+			"number": 212,
+			"origname": "recvmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_recvmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/readahead.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 213,
+			"kconfig": null,
+			"line": 711,
+			"name": "readahead",
+			"number": 213,
+			"origname": "readahead",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"size_t count"
+			],
+			"symbol": "__arm64_sys_readahead"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 214,
+			"kconfig": null,
+			"line": 115,
+			"name": "brk",
+			"number": 214,
+			"origname": "brk",
+			"signature": [
+				"unsigned long brk"
+			],
+			"symbol": "__arm64_sys_brk"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 215,
+			"kconfig": null,
+			"line": 1081,
+			"name": "munmap",
+			"number": 215,
+			"origname": "munmap",
+			"signature": [
+				"unsigned long addr",
+				"size_t len"
+			],
+			"symbol": "__arm64_sys_munmap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mremap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 216,
+			"kconfig": null,
+			"line": 1045,
+			"name": "mremap",
+			"number": 216,
+			"origname": "mremap",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long old_len",
+				"unsigned long new_len",
+				"unsigned long flags",
+				"unsigned long new_addr"
+			],
+			"symbol": "__arm64_sys_mremap"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 217,
+			"kconfig": "KEYS",
+			"line": 74,
+			"name": "add_key",
+			"number": 217,
+			"origname": "add_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const void *_payload",
+				"size_t plen",
+				"key_serial_t ringid"
+			],
+			"symbol": "__arm64_sys_add_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 218,
+			"kconfig": "KEYS",
+			"line": 167,
+			"name": "request_key",
+			"number": 218,
+			"origname": "request_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const char *_callout_info",
+				"key_serial_t destringid"
+			],
+			"symbol": "__arm64_sys_request_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 219,
+			"kconfig": "KEYS",
+			"line": 1874,
+			"name": "keyctl",
+			"number": 219,
+			"origname": "keyctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__arm64_sys_keyctl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 220,
+			"kconfig": null,
+			"line": 2926,
+			"name": "clone",
+			"number": 220,
+			"origname": "clone",
+			"signature": [
+				"unsigned long clone_flags",
+				"unsigned long newsp",
+				"int *parent_tidptr",
+				"unsigned long tls",
+				"int *child_tidptr"
+			],
+			"symbol": "__arm64_sys_clone"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 221,
+			"kconfig": null,
+			"line": 2111,
+			"name": "execve",
+			"number": 221,
+			"origname": "execve",
+			"signature": [
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp"
+			],
+			"symbol": "__arm64_sys_execve"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/arm64/kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 222,
+			"kconfig": null,
+			"line": 21,
+			"name": "mmap",
+			"number": 222,
+			"origname": "mmap",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long len",
+				"unsigned long prot",
+				"unsigned long flags",
+				"unsigned long fd",
+				"unsigned long off"
+			],
+			"symbol": "__arm64_sys_mmap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/fadvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 223,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 201,
+			"name": "fadvise64_64",
+			"number": 223,
+			"origname": "fadvise64_64",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"loff_t len",
+				"int advice"
+			],
+			"symbol": "__arm64_sys_fadvise64_64"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 224,
+			"kconfig": "SWAP",
+			"line": 3266,
+			"name": "swapon",
+			"number": 224,
+			"origname": "swapon",
+			"signature": [
+				"const char *specialfile",
+				"int swap_flags"
+			],
+			"symbol": "__arm64_sys_swapon"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 225,
+			"kconfig": "SWAP",
+			"line": 2652,
+			"name": "swapoff",
+			"number": 225,
+			"origname": "swapoff",
+			"signature": [
+				"const char *specialfile"
+			],
+			"symbol": "__arm64_sys_swapoff"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 226,
+			"kconfig": "MMU",
+			"line": 858,
+			"name": "mprotect",
+			"number": 226,
+			"origname": "mprotect",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long prot"
+			],
+			"symbol": "__arm64_sys_mprotect"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/msync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 227,
+			"kconfig": "MMU",
+			"line": 32,
+			"name": "msync",
+			"number": 227,
+			"origname": "msync",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_msync"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 228,
+			"kconfig": "MMU",
+			"line": 659,
+			"name": "mlock",
+			"number": 228,
+			"origname": "mlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__arm64_sys_mlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 229,
+			"kconfig": "MMU",
+			"line": 677,
+			"name": "munlock",
+			"number": 229,
+			"origname": "munlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__arm64_sys_munlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 230,
+			"kconfig": "MMU",
+			"line": 745,
+			"name": "mlockall",
+			"number": 230,
+			"origname": "mlockall",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__arm64_sys_mlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 231,
+			"kconfig": "MMU",
+			"line": 774,
+			"name": "munlockall",
+			"number": 231,
+			"origname": "munlockall",
+			"signature": [],
+			"symbol": "__arm64_sys_munlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mincore.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 232,
+			"kconfig": "MMU",
+			"line": 232,
+			"name": "mincore",
+			"number": 232,
+			"origname": "mincore",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned char *vec"
+			],
+			"symbol": "__arm64_sys_mincore"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 233,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1712,
+			"name": "madvise",
+			"number": 233,
+			"origname": "madvise",
+			"signature": [
+				"unsigned long start",
+				"size_t len_in",
+				"int behavior"
+			],
+			"symbol": "__arm64_sys_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 234,
+			"kconfig": "MMU",
+			"line": 1091,
+			"name": "remap_file_pages",
+			"number": 234,
+			"origname": "remap_file_pages",
+			"signature": [
+				"unsigned long start",
+				"unsigned long size",
+				"unsigned long prot",
+				"unsigned long pgoff",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_remap_file_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 235,
+			"kconfig": "NUMA",
+			"line": 1607,
+			"name": "mbind",
+			"number": 235,
+			"origname": "mbind",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_mbind"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 236,
+			"kconfig": "NUMA",
+			"line": 1764,
+			"name": "get_mempolicy",
+			"number": 236,
+			"origname": "get_mempolicy",
+			"signature": [
+				"int *policy",
+				"unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned long addr",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_get_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 237,
+			"kconfig": "NUMA",
+			"line": 1634,
+			"name": "set_mempolicy",
+			"number": 237,
+			"origname": "set_mempolicy",
+			"signature": [
+				"int mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode"
+			],
+			"symbol": "__arm64_sys_set_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 238,
+			"kconfig": "MIGRATION",
+			"line": 1727,
+			"name": "migrate_pages",
+			"number": 238,
+			"origname": "migrate_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long maxnode",
+				"const unsigned long *old_nodes",
+				"const unsigned long *new_nodes"
+			],
+			"symbol": "__arm64_sys_migrate_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/migrate.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 239,
+			"kconfig": "MIGRATION",
+			"line": 2586,
+			"name": "move_pages",
+			"number": 239,
+			"origname": "move_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long nr_pages",
+				"const void **pages",
+				"const int *nodes",
+				"int *status",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_move_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 240,
+			"kconfig": null,
+			"line": 4228,
+			"name": "rt_tgsigqueueinfo",
+			"number": 240,
+			"origname": "rt_tgsigqueueinfo",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__arm64_sys_rt_tgsigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/events/core.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 241,
+			"kconfig": "PERF_EVENTS",
+			"line": 12798,
+			"name": "perf_event_open",
+			"number": 241,
+			"origname": "perf_event_open",
+			"signature": [
+				"struct perf_event_attr *attr_uptr",
+				"pid_t pid",
+				"int cpu",
+				"int group_fd",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_perf_event_open"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 242,
+			"kconfig": "NET",
+			"line": 2004,
+			"name": "accept4",
+			"number": 242,
+			"origname": "accept4",
+			"signature": [
+				"int fd",
+				"struct sockaddr *upeer_sockaddr",
+				"int *upeer_addrlen",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_accept4"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 243,
+			"kconfig": "NET",
+			"line": 3020,
+			"name": "recvmmsg",
+			"number": 243,
+			"origname": "recvmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout"
+			],
+			"symbol": "__arm64_sys_recvmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 260,
+			"kconfig": null,
+			"line": 1874,
+			"name": "wait4",
+			"number": 260,
+			"origname": "wait4",
+			"signature": [
+				"pid_t upid",
+				"int *stat_addr",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__arm64_sys_wait4"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 261,
+			"kconfig": null,
+			"line": 1695,
+			"name": "prlimit64",
+			"number": 261,
+			"origname": "prlimit64",
+			"signature": [
+				"pid_t pid",
+				"unsigned int resource",
+				"const struct rlimit64 *new_rlim",
+				"struct rlimit64 *old_rlim"
+			],
+			"symbol": "__arm64_sys_prlimit64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 262,
+			"kconfig": "FANOTIFY",
+			"line": 1466,
+			"name": "fanotify_init",
+			"number": 262,
+			"origname": "fanotify_init",
+			"signature": [
+				"unsigned int flags",
+				"unsigned int event_f_flags"
+			],
+			"symbol": "__arm64_sys_fanotify_init"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 263,
+			"kconfig": "FANOTIFY",
+			"line": 2003,
+			"name": "fanotify_mark",
+			"number": 263,
+			"origname": "fanotify_mark",
+			"signature": [
+				"int fanotify_fd",
+				"unsigned int flags",
+				"__u64 mask",
+				"int dfd",
+				"const char *pathname"
+			],
+			"symbol": "__arm64_sys_fanotify_mark"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 264,
+			"kconfig": "FHANDLE",
+			"line": 129,
+			"name": "name_to_handle_at",
+			"number": 264,
+			"origname": "name_to_handle_at",
+			"signature": [
+				"int dfd",
+				"const char *name",
+				"struct file_handle *handle",
+				"void *mnt_id",
+				"int flag"
+			],
+			"symbol": "__arm64_sys_name_to_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 265,
+			"kconfig": "FHANDLE",
+			"line": 434,
+			"name": "open_by_handle_at",
+			"number": 265,
+			"origname": "open_by_handle_at",
+			"signature": [
+				"int mountdirfd",
+				"struct file_handle *handle",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_open_by_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 266,
+			"kconfig": null,
+			"line": 1168,
+			"name": "clock_adjtime",
+			"number": 266,
+			"origname": "clock_adjtime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timex *utx"
+			],
+			"symbol": "__arm64_sys_clock_adjtime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 267,
+			"kconfig": null,
+			"line": 149,
+			"name": "syncfs",
+			"number": 267,
+			"origname": "syncfs",
+			"signature": [
+				"int fd"
+			],
+			"symbol": "__arm64_sys_syncfs"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/nsproxy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 268,
+			"kconfig": null,
+			"line": 546,
+			"name": "setns",
+			"number": 268,
+			"origname": "setns",
+			"signature": [
+				"int fd",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_setns"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 269,
+			"kconfig": "NET",
+			"line": 2740,
+			"name": "sendmmsg",
+			"number": 269,
+			"origname": "sendmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_sendmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 270,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 292,
+			"name": "process_vm_readv",
+			"number": 270,
+			"origname": "process_vm_readv",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_process_vm_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 271,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 299,
+			"name": "process_vm_writev",
+			"number": 271,
+			"origname": "process_vm_writev",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_process_vm_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kcmp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 272,
+			"kconfig": "KCMP",
+			"line": 135,
+			"name": "kcmp",
+			"number": 272,
+			"origname": "kcmp",
+			"signature": [
+				"pid_t pid1",
+				"pid_t pid2",
+				"int type",
+				"unsigned long idx1",
+				"unsigned long idx2"
+			],
+			"symbol": "__arm64_sys_kcmp"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 273,
+			"kconfig": "MODULES",
+			"line": 3669,
+			"name": "finit_module",
+			"number": 273,
+			"origname": "finit_module",
+			"signature": [
+				"int fd",
+				"const char *uargs",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_finit_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 274,
+			"kconfig": null,
+			"line": 981,
+			"name": "sched_setattr",
+			"number": 274,
+			"origname": "sched_setattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_sched_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 275,
+			"kconfig": null,
+			"line": 1081,
+			"name": "sched_getattr",
+			"number": 275,
+			"origname": "sched_getattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int usize",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_sched_getattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 276,
+			"kconfig": null,
+			"line": 5257,
+			"name": "renameat2",
+			"number": 276,
+			"origname": "renameat2",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_renameat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/seccomp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 277,
+			"kconfig": "SECCOMP",
+			"line": 2101,
+			"name": "seccomp",
+			"number": 277,
+			"origname": "seccomp",
+			"signature": [
+				"unsigned int op",
+				"unsigned int flags",
+				"void *uargs"
+			],
+			"symbol": "__arm64_sys_seccomp"
+		},
+		{
+			"esoteric": false,
+			"file": "drivers/char/random.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 278,
+			"kconfig": null,
+			"line": 1388,
+			"name": "getrandom",
+			"number": 278,
+			"origname": "getrandom",
+			"signature": [
+				"char *ubuf",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_getrandom"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/memfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 279,
+			"kconfig": "MEMFD_CREATE",
+			"line": 458,
+			"name": "memfd_create",
+			"number": 279,
+			"origname": "memfd_create",
+			"signature": [
+				"const char *uname",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_memfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/bpf/syscall.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 280,
+			"kconfig": "BPF_SYSCALL",
+			"line": 5900,
+			"name": "bpf",
+			"number": 280,
+			"origname": "bpf",
+			"signature": [
+				"int cmd",
+				"union bpf_attr *uattr",
+				"unsigned int size"
+			],
+			"symbol": "__arm64_sys_bpf"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 281,
+			"kconfig": null,
+			"line": 2119,
+			"name": "execveat",
+			"number": 281,
+			"origname": "execveat",
+			"signature": [
+				"int fd",
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_execveat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/userfaultfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 282,
+			"kconfig": "USERFAULTFD",
+			"line": 2155,
+			"name": "userfaultfd",
+			"number": 282,
+			"origname": "userfaultfd",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__arm64_sys_userfaultfd"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/membarrier.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 283,
+			"kconfig": "MEMBARRIER",
+			"line": 625,
+			"name": "membarrier",
+			"number": 283,
+			"origname": "membarrier",
+			"signature": [
+				"int cmd",
+				"unsigned int flags",
+				"int cpu_id"
+			],
+			"symbol": "__arm64_sys_membarrier"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 284,
+			"kconfig": "MMU",
+			"line": 664,
+			"name": "mlock2",
+			"number": 284,
+			"origname": "mlock2",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_mlock2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 285,
+			"kconfig": null,
+			"line": 1637,
+			"name": "copy_file_range",
+			"number": 285,
+			"origname": "copy_file_range",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_copy_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 286,
+			"kconfig": null,
+			"line": 1175,
+			"name": "preadv2",
+			"number": 286,
+			"origname": "preadv2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__arm64_sys_preadv2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 287,
+			"kconfig": null,
+			"line": 1195,
+			"name": "pwritev2",
+			"number": 287,
+			"origname": "pwritev2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__arm64_sys_pwritev2"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 288,
+			"kconfig": null,
+			"line": 866,
+			"name": "pkey_mprotect",
+			"number": 288,
+			"origname": "pkey_mprotect",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long prot",
+				"int pkey"
+			],
+			"symbol": "__arm64_sys_pkey_mprotect"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 289,
+			"kconfig": null,
+			"line": 872,
+			"name": "pkey_alloc",
+			"number": 289,
+			"origname": "pkey_alloc",
+			"signature": [
+				"unsigned long flags",
+				"unsigned long init_val"
+			],
+			"symbol": "__arm64_sys_pkey_alloc"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 290,
+			"kconfig": null,
+			"line": 902,
+			"name": "pkey_free",
+			"number": 290,
+			"origname": "pkey_free",
+			"signature": [
+				"int pkey"
+			],
+			"symbol": "__arm64_sys_pkey_free"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 291,
+			"kconfig": null,
+			"line": 799,
+			"name": "statx",
+			"number": 291,
+			"origname": "statx",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags",
+				"unsigned int mask",
+				"struct statx *buffer"
+			],
+			"symbol": "__arm64_sys_statx"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 292,
+			"kconfig": "AIO",
+			"line": 2275,
+			"name": "io_pgetevents",
+			"number": 292,
+			"origname": "io_pgetevents",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct __kernel_timespec *timeout",
+				"const struct __aio_sigset *usig"
+			],
+			"symbol": "__arm64_sys_io_pgetevents"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/rseq.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 293,
+			"kconfig": "RSEQ",
+			"line": 452,
+			"name": "rseq",
+			"number": 293,
+			"origname": "rseq",
+			"signature": [
+				"struct rseq *rseq",
+				"u32 rseq_len",
+				"int flags",
+				"u32 sig"
+			],
+			"symbol": "__arm64_sys_rseq"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kexec_file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 294,
+			"kconfig": "KEXEC_FILE",
+			"line": 332,
+			"name": "kexec_file_load",
+			"number": 294,
+			"origname": "kexec_file_load",
+			"signature": [
+				"int kernel_fd",
+				"int initrd_fd",
+				"unsigned long cmdline_len",
+				"const char *cmdline_ptr",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_kexec_file_load"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 424,
+			"kconfig": null,
+			"line": 4026,
+			"name": "pidfd_send_signal",
+			"number": 424,
+			"origname": "pidfd_send_signal",
+			"signature": [
+				"int pidfd",
+				"int sig",
+				"siginfo_t *info",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_pidfd_send_signal"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 425,
+			"kconfig": "IO_URING",
+			"line": 3814,
+			"name": "io_uring_setup",
+			"number": 425,
+			"origname": "io_uring_setup",
+			"signature": [
+				"u32 entries",
+				"struct io_uring_params *params"
+			],
+			"symbol": "__arm64_sys_io_uring_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 426,
+			"kconfig": "IO_URING",
+			"line": 3307,
+			"name": "io_uring_enter",
+			"number": 426,
+			"origname": "io_uring_enter",
+			"signature": [
+				"unsigned int fd",
+				"u32 to_submit",
+				"u32 min_complete",
+				"u32 flags",
+				"const void *argp",
+				"size_t argsz"
+			],
+			"symbol": "__arm64_sys_io_uring_enter"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/register.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 427,
+			"kconfig": "IO_URING",
+			"line": 896,
+			"name": "io_uring_register",
+			"number": 427,
+			"origname": "io_uring_register",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int opcode",
+				"void *arg",
+				"unsigned int nr_args"
+			],
+			"symbol": "__arm64_sys_io_uring_register"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 428,
+			"kconfig": null,
+			"line": 2892,
+			"name": "open_tree",
+			"number": 428,
+			"origname": "open_tree",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags"
+			],
+			"symbol": "__arm64_sys_open_tree"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 429,
+			"kconfig": null,
+			"line": 4280,
+			"name": "move_mount",
+			"number": 429,
+			"origname": "move_mount",
+			"signature": [
+				"int from_dfd",
+				"const char *from_pathname",
+				"int to_dfd",
+				"const char *to_pathname",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_move_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 430,
+			"kconfig": null,
+			"line": 114,
+			"name": "fsopen",
+			"number": 430,
+			"origname": "fsopen",
+			"signature": [
+				"const char *_fs_name",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_fsopen"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 431,
+			"kconfig": null,
+			"line": 344,
+			"name": "fsconfig",
+			"number": 431,
+			"origname": "fsconfig",
+			"signature": [
+				"int fd",
+				"unsigned int cmd",
+				"const char *_key",
+				"const void *_value",
+				"int aux"
+			],
+			"symbol": "__arm64_sys_fsconfig"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 432,
+			"kconfig": null,
+			"line": 4156,
+			"name": "fsmount",
+			"number": 432,
+			"origname": "fsmount",
+			"signature": [
+				"int fs_fd",
+				"unsigned int flags",
+				"unsigned int attr_flags"
+			],
+			"symbol": "__arm64_sys_fsmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 433,
+			"kconfig": null,
+			"line": 157,
+			"name": "fspick",
+			"number": 433,
+			"origname": "fspick",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_fspick"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 434,
+			"kconfig": null,
+			"line": 626,
+			"name": "pidfd_open",
+			"number": 434,
+			"origname": "pidfd_open",
+			"signature": [
+				"pid_t pid",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_pidfd_open"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 435,
+			"kconfig": null,
+			"line": 3098,
+			"name": "clone3",
+			"number": 435,
+			"origname": "clone3",
+			"signature": [
+				"struct clone_args *uargs",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_clone3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 436,
+			"kconfig": null,
+			"line": 769,
+			"name": "close_range",
+			"number": 436,
+			"origname": "close_range",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int max_fd",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_close_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 437,
+			"kconfig": null,
+			"line": 1462,
+			"name": "openat2",
+			"number": 437,
+			"origname": "openat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct open_how *how",
+				"size_t usize"
+			],
+			"symbol": "__arm64_sys_openat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 438,
+			"kconfig": null,
+			"line": 854,
+			"name": "pidfd_getfd",
+			"number": 438,
+			"origname": "pidfd_getfd",
+			"signature": [
+				"int pidfd",
+				"int fd",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_pidfd_getfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 439,
+			"kconfig": null,
+			"line": 540,
+			"name": "faccessat2",
+			"number": 439,
+			"origname": "faccessat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode",
+				"int flags"
+			],
+			"symbol": "__arm64_sys_faccessat2"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 440,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1756,
+			"name": "process_madvise",
+			"number": 440,
+			"origname": "process_madvise",
+			"signature": [
+				"int pidfd",
+				"const struct iovec *vec",
+				"size_t vlen",
+				"int behavior",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_process_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 441,
+			"kconfig": "EPOLL",
+			"line": 2532,
+			"name": "epoll_pwait2",
+			"number": 441,
+			"origname": "epoll_pwait2",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"const struct __kernel_timespec *timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__arm64_sys_epoll_pwait2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 442,
+			"kconfig": null,
+			"line": 4847,
+			"name": "mount_setattr",
+			"number": 442,
+			"origname": "mount_setattr",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags",
+				"struct mount_attr *uattr",
+				"size_t usize"
+			],
+			"symbol": "__arm64_sys_mount_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 443,
+			"kconfig": "QUOTACTL",
+			"line": 973,
+			"name": "quotactl_fd",
+			"number": 443,
+			"origname": "quotactl_fd",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__arm64_sys_quotactl_fd"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 444,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 180,
+			"name": "landlock_create_ruleset",
+			"number": 444,
+			"origname": "landlock_create_ruleset",
+			"signature": [
+				"const struct landlock_ruleset_attr *const attr",
+				"const size_t size",
+				"const __u32 flags"
+			],
+			"symbol": "__arm64_sys_landlock_create_ruleset"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 445,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 398,
+			"name": "landlock_add_rule",
+			"number": 445,
+			"origname": "landlock_add_rule",
+			"signature": [
+				"const int ruleset_fd",
+				"const enum landlock_rule_type rule_type",
+				"const void *const rule_attr",
+				"const __u32 flags"
+			],
+			"symbol": "__arm64_sys_landlock_add_rule"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 446,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 451,
+			"name": "landlock_restrict_self",
+			"number": 446,
+			"origname": "landlock_restrict_self",
+			"signature": [
+				"const int ruleset_fd",
+				"const __u32 flags"
+			],
+			"symbol": "__arm64_sys_landlock_restrict_self"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/secretmem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 447,
+			"kconfig": "SECRETMEM",
+			"line": 232,
+			"name": "memfd_secret",
+			"number": 447,
+			"origname": "memfd_secret",
+			"signature": [
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_memfd_secret"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/oom_kill.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 448,
+			"kconfig": "MMU",
+			"line": 1204,
+			"name": "process_mrelease",
+			"number": 448,
+			"origname": "process_mrelease",
+			"signature": [
+				"int pidfd",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_process_mrelease"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 449,
+			"kconfig": "FUTEX",
+			"line": 290,
+			"name": "futex_waitv",
+			"number": 449,
+			"origname": "futex_waitv",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int nr_futexes",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__arm64_sys_futex_waitv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 450,
+			"kconfig": "NUMA",
+			"line": 1540,
+			"name": "set_mempolicy_home_node",
+			"number": 450,
+			"origname": "set_mempolicy_home_node",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long home_node",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_set_mempolicy_home_node"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/filemap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 451,
+			"kconfig": "CACHESTAT_SYSCALL",
+			"line": 4498,
+			"name": "cachestat",
+			"number": 451,
+			"origname": "cachestat",
+			"signature": [
+				"unsigned int fd",
+				"struct cachestat_range *cstat_range",
+				"struct cachestat *cstat",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_cachestat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 452,
+			"kconfig": null,
+			"line": 700,
+			"name": "fchmodat2",
+			"number": 452,
+			"origname": "fchmodat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_fchmodat2"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/arm64/mm/gcs.c",
+			"good_location": true,
+			"grepped_location": true,
+			"index": 453,
+			"kconfig": "X86_USER_SHADOW_STACK",
+			"line": 71,
+			"name": "map_shadow_stack",
+			"number": 453,
+			"origname": "map_shadow_stack",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long size",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_map_shadow_stack"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 454,
+			"kconfig": "FUTEX",
+			"line": 338,
+			"name": "futex_wake",
+			"number": 454,
+			"origname": "futex_wake",
+			"signature": [
+				"void *uaddr",
+				"unsigned long mask",
+				"int nr",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_futex_wake"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 455,
+			"kconfig": "FUTEX",
+			"line": 370,
+			"name": "futex_wait",
+			"number": 455,
+			"origname": "futex_wait",
+			"signature": [
+				"void *uaddr",
+				"unsigned long val",
+				"unsigned long mask",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__arm64_sys_futex_wait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 456,
+			"kconfig": "FUTEX",
+			"line": 414,
+			"name": "futex_requeue",
+			"number": 456,
+			"origname": "futex_requeue",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int flags",
+				"int nr_wake",
+				"int nr_requeue"
+			],
+			"symbol": "__arm64_sys_futex_requeue"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 457,
+			"kconfig": null,
+			"line": 5508,
+			"name": "statmount",
+			"number": 457,
+			"origname": "statmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"struct statmount *buf",
+				"size_t bufsize",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_statmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 458,
+			"kconfig": null,
+			"line": 5615,
+			"name": "listmount",
+			"number": 458,
+			"origname": "listmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"u64 *mnt_ids",
+				"size_t nr_mnt_ids",
+				"unsigned int flags"
+			],
+			"symbol": "__arm64_sys_listmount"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 459,
+			"kconfig": "SECURITY",
+			"line": 77,
+			"name": "lsm_get_self_attr",
+			"number": 459,
+			"origname": "lsm_get_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__arm64_sys_lsm_get_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 460,
+			"kconfig": "SECURITY",
+			"line": 55,
+			"name": "lsm_set_self_attr",
+			"number": 460,
+			"origname": "lsm_set_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 size",
+				"u32 flags"
+			],
+			"symbol": "__arm64_sys_lsm_set_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 461,
+			"kconfig": "SECURITY",
+			"line": 96,
+			"name": "lsm_list_modules",
+			"number": 461,
+			"origname": "lsm_list_modules",
+			"signature": [
+				"u64 *ids",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__arm64_sys_lsm_list_modules"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mseal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 462,
+			"kconfig": null,
+			"line": 265,
+			"name": "mseal",
+			"number": 462,
+			"origname": "mseal",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long flags"
+			],
+			"symbol": "__arm64_sys_mseal"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 463,
+			"kconfig": null,
+			"line": 719,
+			"name": "setxattrat",
+			"number": 463,
+			"origname": "setxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"const struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__arm64_sys_setxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 464,
+			"kconfig": null,
+			"line": 863,
+			"name": "getxattrat",
+			"number": 464,
+			"origname": "getxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__arm64_sys_getxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 465,
+			"kconfig": null,
+			"line": 991,
+			"name": "listxattrat",
+			"number": 465,
+			"origname": "listxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__arm64_sys_listxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 466,
+			"kconfig": null,
+			"line": 1091,
+			"name": "removexattrat",
+			"number": 466,
+			"origname": "removexattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name"
+			],
+			"symbol": "__arm64_sys_removexattrat"
+		}
+	],
+	"systrack_version": "0.7"
+}

--- a/libdebug/utils/syscall_data/aarch64.json
+++ b/libdebug/utils/syscall_data/aarch64.json
@@ -1,5778 +1,2872 @@
 {
-	"kernel": {
-		"abi": {
-			"bits": 64,
-			"calling_convention": {
-				"parameters": [
-					"x0",
-					"x1",
-					"x2",
-					"x3",
-					"x4",
-					"x5"
-				],
-				"syscall_nr": "w8"
-			},
-			"compat": false,
-			"name": "aarch64"
-		},
-		"architecture": {
-			"bits": 64,
-			"name": "arm64"
-		},
-		"syscall_table_symbol": "sys_call_table",
-		"version": "v6.14",
-		"version_source": "vmlinux"
-	},
-	"syscalls": [
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 0,
-			"kconfig": "AIO",
-			"line": 1382,
-			"name": "io_setup",
-			"number": 0,
-			"origname": "io_setup",
-			"signature": [
-				"unsigned nr_events",
-				"aio_context_t *ctxp"
-			],
-			"symbol": "__arm64_sys_io_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 1,
-			"kconfig": "AIO",
-			"line": 1451,
-			"name": "io_destroy",
-			"number": 1,
-			"origname": "io_destroy",
-			"signature": [
-				"aio_context_t ctx"
-			],
-			"symbol": "__arm64_sys_io_destroy"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 2,
-			"kconfig": "AIO",
-			"line": 2081,
-			"name": "io_submit",
-			"number": 2,
-			"origname": "io_submit",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long nr",
-				"struct iocb **iocbpp"
-			],
-			"symbol": "__arm64_sys_io_submit"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 3,
-			"kconfig": "AIO",
-			"line": 2175,
-			"name": "io_cancel",
-			"number": 3,
-			"origname": "io_cancel",
-			"signature": [
-				"aio_context_t ctx_id",
-				"struct iocb *iocb",
-				"struct io_event *result"
-			],
-			"symbol": "__arm64_sys_io_cancel"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 4,
-			"kconfig": "AIO",
-			"line": 2250,
-			"name": "io_getevents",
-			"number": 4,
-			"origname": "io_getevents",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct __kernel_timespec *timeout"
-			],
-			"symbol": "__arm64_sys_io_getevents"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 5,
-			"kconfig": null,
-			"line": 743,
-			"name": "setxattr",
-			"number": 5,
-			"origname": "setxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_setxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 6,
-			"kconfig": null,
-			"line": 750,
-			"name": "lsetxattr",
-			"number": 6,
-			"origname": "lsetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_lsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 7,
-			"kconfig": null,
-			"line": 758,
-			"name": "fsetxattr",
-			"number": 7,
-			"origname": "fsetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_fsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 8,
-			"kconfig": null,
-			"line": 888,
-			"name": "getxattr",
-			"number": 8,
-			"origname": "getxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_getxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 9,
-			"kconfig": null,
-			"line": 894,
-			"name": "lgetxattr",
-			"number": 9,
-			"origname": "lgetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_lgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 10,
-			"kconfig": null,
-			"line": 901,
-			"name": "fgetxattr",
-			"number": 10,
-			"origname": "fgetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_fgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 11,
-			"kconfig": null,
-			"line": 998,
-			"name": "listxattr",
-			"number": 11,
-			"origname": "listxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_listxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 12,
-			"kconfig": null,
-			"line": 1004,
-			"name": "llistxattr",
-			"number": 12,
-			"origname": "llistxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_llistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 13,
-			"kconfig": null,
-			"line": 1010,
-			"name": "flistxattr",
-			"number": 13,
-			"origname": "flistxattr",
-			"signature": [
-				"int fd",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_flistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 14,
-			"kconfig": null,
-			"line": 1097,
-			"name": "removexattr",
-			"number": 14,
-			"origname": "removexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__arm64_sys_removexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 15,
-			"kconfig": null,
-			"line": 1103,
-			"name": "lremovexattr",
-			"number": 15,
-			"origname": "lremovexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__arm64_sys_lremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 16,
-			"kconfig": null,
-			"line": 1109,
-			"name": "fremovexattr",
-			"number": 16,
-			"origname": "fremovexattr",
-			"signature": [
-				"int fd",
-				"const char *name"
-			],
-			"symbol": "__arm64_sys_fremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/d_path.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 17,
-			"kconfig": null,
-			"line": 412,
-			"name": "getcwd",
-			"number": 17,
-			"origname": "getcwd",
-			"signature": [
-				"char *buf",
-				"unsigned long size"
-			],
-			"symbol": "__arm64_sys_getcwd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 19,
-			"kconfig": null,
-			"line": 424,
-			"name": "eventfd2",
-			"number": 19,
-			"origname": "eventfd2",
-			"signature": [
-				"unsigned int count",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_eventfd2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 20,
-			"kconfig": "EPOLL",
-			"line": 2251,
-			"name": "epoll_create1",
-			"number": 20,
-			"origname": "epoll_create1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__arm64_sys_epoll_create1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 21,
-			"kconfig": "EPOLL",
-			"line": 2436,
-			"name": "epoll_ctl",
-			"number": 21,
-			"origname": "epoll_ctl",
-			"signature": [
-				"int epfd",
-				"int op",
-				"int fd",
-				"struct epoll_event *event"
-			],
-			"symbol": "__arm64_sys_epoll_ctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 22,
-			"kconfig": "EPOLL",
-			"line": 2521,
-			"name": "epoll_pwait",
-			"number": 22,
-			"origname": "epoll_pwait",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"int timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_epoll_pwait"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 23,
-			"kconfig": null,
-			"line": 1394,
-			"name": "dup",
-			"number": 23,
-			"origname": "dup",
-			"signature": [
-				"unsigned int fildes"
-			],
-			"symbol": "__arm64_sys_dup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 24,
-			"kconfig": null,
-			"line": 1370,
-			"name": "dup3",
-			"number": 24,
-			"origname": "dup3",
-			"signature": [
-				"unsigned int oldfd",
-				"unsigned int newfd",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_dup3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fcntl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 25,
-			"kconfig": null,
-			"line": 576,
-			"name": "fcntl",
-			"number": 25,
-			"origname": "fcntl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__arm64_sys_fcntl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 26,
-			"kconfig": "INOTIFY_USER",
-			"line": 719,
-			"name": "inotify_init1",
-			"number": 26,
-			"origname": "inotify_init1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__arm64_sys_inotify_init1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 27,
-			"kconfig": "INOTIFY_USER",
-			"line": 729,
-			"name": "inotify_add_watch",
-			"number": 27,
-			"origname": "inotify_add_watch",
-			"signature": [
-				"int fd",
-				"const char *pathname",
-				"u32 mask"
-			],
-			"symbol": "__arm64_sys_inotify_add_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 28,
-			"kconfig": "INOTIFY_USER",
-			"line": 786,
-			"name": "inotify_rm_watch",
-			"number": 28,
-			"origname": "inotify_rm_watch",
-			"signature": [
-				"int fd",
-				"__s32 wd"
-			],
-			"symbol": "__arm64_sys_inotify_rm_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/ioctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 29,
-			"kconfig": null,
-			"line": 892,
-			"name": "ioctl",
-			"number": 29,
-			"origname": "ioctl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__arm64_sys_ioctl"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 30,
-			"kconfig": "BLOCK",
-			"line": 69,
-			"name": "ioprio_set",
-			"number": 30,
-			"origname": "ioprio_set",
-			"signature": [
-				"int which",
-				"int who",
-				"int ioprio"
-			],
-			"symbol": "__arm64_sys_ioprio_set"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 31,
-			"kconfig": "BLOCK",
-			"line": 184,
-			"name": "ioprio_get",
-			"number": 31,
-			"origname": "ioprio_get",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__arm64_sys_ioprio_get"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/locks.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 32,
-			"kconfig": null,
-			"line": 2135,
-			"name": "flock",
-			"number": 32,
-			"origname": "flock",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd"
-			],
-			"symbol": "__arm64_sys_flock"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 33,
-			"kconfig": null,
-			"line": 4266,
-			"name": "mknodat",
-			"number": 33,
-			"origname": "mknodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int dev"
-			],
-			"symbol": "__arm64_sys_mknodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 34,
-			"kconfig": null,
-			"line": 4349,
-			"name": "mkdirat",
-			"number": 34,
-			"origname": "mkdirat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__arm64_sys_mkdirat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 35,
-			"kconfig": null,
-			"line": 4625,
-			"name": "unlinkat",
-			"number": 35,
-			"origname": "unlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"int flag"
-			],
-			"symbol": "__arm64_sys_unlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 36,
-			"kconfig": null,
-			"line": 4710,
-			"name": "symlinkat",
-			"number": 36,
-			"origname": "symlinkat",
-			"signature": [
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__arm64_sys_symlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 37,
-			"kconfig": null,
-			"line": 4890,
-			"name": "linkat",
-			"number": 37,
-			"origname": "linkat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_linkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 38,
-			"kconfig": null,
-			"line": 5264,
-			"name": "renameat",
-			"number": 38,
-			"origname": "renameat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__arm64_sys_renameat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 39,
-			"kconfig": null,
-			"line": 2077,
-			"name": "umount",
-			"number": 39,
-			"origname": "umount",
-			"signature": [
-				"char *name",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_umount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 40,
-			"kconfig": null,
-			"line": 4088,
-			"name": "mount",
-			"number": 40,
-			"origname": "mount",
-			"signature": [
-				"char *dev_name",
-				"char *dir_name",
-				"char *type",
-				"unsigned long flags",
-				"void *data"
-			],
-			"symbol": "__arm64_sys_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 41,
-			"kconfig": null,
-			"line": 4388,
-			"name": "pivot_root",
-			"number": 41,
-			"origname": "pivot_root",
-			"signature": [
-				"const char *new_root",
-				"const char *put_old"
-			],
-			"symbol": "__arm64_sys_pivot_root"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 43,
-			"kconfig": null,
-			"line": 190,
-			"name": "statfs",
-			"number": 43,
-			"origname": "statfs",
-			"signature": [
-				"const char *pathname",
-				"struct statfs *buf"
-			],
-			"symbol": "__arm64_sys_statfs"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 44,
-			"kconfig": null,
-			"line": 211,
-			"name": "fstatfs",
-			"number": 44,
-			"origname": "fstatfs",
-			"signature": [
-				"unsigned int fd",
-				"struct statfs *buf"
-			],
-			"symbol": "__arm64_sys_fstatfs"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 45,
-			"kconfig": null,
-			"line": 148,
-			"name": "truncate",
-			"number": 45,
-			"origname": "truncate",
-			"signature": [
-				"const char *path",
-				"long length"
-			],
-			"symbol": "__arm64_sys_truncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 46,
-			"kconfig": null,
-			"line": 210,
-			"name": "ftruncate",
-			"number": 46,
-			"origname": "ftruncate",
-			"signature": [
-				"unsigned int fd",
-				"off_t length"
-			],
-			"symbol": "__arm64_sys_ftruncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 47,
-			"kconfig": null,
-			"line": 365,
-			"name": "fallocate",
-			"number": 47,
-			"origname": "fallocate",
-			"signature": [
-				"int fd",
-				"int mode",
-				"loff_t offset",
-				"loff_t len"
-			],
-			"symbol": "__arm64_sys_fallocate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 48,
-			"kconfig": null,
-			"line": 535,
-			"name": "faccessat",
-			"number": 48,
-			"origname": "faccessat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode"
-			],
-			"symbol": "__arm64_sys_faccessat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 49,
-			"kconfig": null,
-			"line": 551,
-			"name": "chdir",
-			"number": 49,
-			"origname": "chdir",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__arm64_sys_chdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 50,
-			"kconfig": null,
-			"line": 577,
-			"name": "fchdir",
-			"number": 50,
-			"origname": "fchdir",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__arm64_sys_fchdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 51,
-			"kconfig": null,
-			"line": 594,
-			"name": "chroot",
-			"number": 51,
-			"origname": "chroot",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__arm64_sys_chroot"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 52,
-			"kconfig": null,
-			"line": 663,
-			"name": "fchmod",
-			"number": 52,
-			"origname": "fchmod",
-			"signature": [
-				"unsigned int fd",
-				"umode_t mode"
-			],
-			"symbol": "__arm64_sys_fchmod"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 53,
-			"kconfig": null,
-			"line": 706,
-			"name": "fchmodat",
-			"number": 53,
-			"origname": "fchmodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode"
-			],
-			"symbol": "__arm64_sys_fchmodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 54,
-			"kconfig": null,
-			"line": 825,
-			"name": "fchownat",
-			"number": 54,
-			"origname": "fchownat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"uid_t user",
-				"gid_t group",
-				"int flag"
-			],
-			"symbol": "__arm64_sys_fchownat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 55,
-			"kconfig": null,
-			"line": 865,
-			"name": "fchown",
-			"number": 55,
-			"origname": "fchown",
-			"signature": [
-				"unsigned int fd",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__arm64_sys_fchown"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 56,
-			"kconfig": null,
-			"line": 1454,
-			"name": "openat",
-			"number": 56,
-			"origname": "openat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int flags",
-				"umode_t mode"
-			],
-			"symbol": "__arm64_sys_openat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 57,
-			"kconfig": null,
-			"line": 1565,
-			"name": "close",
-			"number": 57,
-			"origname": "close",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__arm64_sys_close"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 58,
-			"kconfig": null,
-			"line": 1596,
-			"name": "vhangup",
-			"number": 58,
-			"origname": "vhangup",
-			"signature": [],
-			"symbol": "__arm64_sys_vhangup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/pipe.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 59,
-			"kconfig": null,
-			"line": 1043,
-			"name": "pipe2",
-			"number": 59,
-			"origname": "pipe2",
-			"signature": [
-				"int *fildes",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_pipe2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 60,
-			"kconfig": "QUOTACTL",
-			"line": 917,
-			"name": "quotactl",
-			"number": 60,
-			"origname": "quotactl",
-			"signature": [
-				"unsigned int cmd",
-				"const char *special",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__arm64_sys_quotactl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 61,
-			"kconfig": null,
-			"line": 389,
-			"name": "getdents64",
-			"number": 61,
-			"origname": "getdents64",
-			"signature": [
-				"unsigned int fd",
-				"struct linux_dirent64 *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__arm64_sys_getdents64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 62,
-			"kconfig": null,
-			"line": 403,
-			"name": "lseek",
-			"number": 62,
-			"origname": "lseek",
-			"signature": [
-				"unsigned int fd",
-				"off_t offset",
-				"unsigned int whence"
-			],
-			"symbol": "__arm64_sys_lseek"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 63,
-			"kconfig": null,
-			"line": 715,
-			"name": "read",
-			"number": 63,
-			"origname": "read",
-			"signature": [
-				"unsigned int fd",
-				"char *buf",
-				"size_t count"
-			],
-			"symbol": "__arm64_sys_read"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 64,
-			"kconfig": null,
-			"line": 739,
-			"name": "write",
-			"number": 64,
-			"origname": "write",
-			"signature": [
-				"unsigned int fd",
-				"const char *buf",
-				"size_t count"
-			],
-			"symbol": "__arm64_sys_write"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 65,
-			"kconfig": null,
-			"line": 1155,
-			"name": "readv",
-			"number": 65,
-			"origname": "readv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__arm64_sys_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 66,
-			"kconfig": null,
-			"line": 1161,
-			"name": "writev",
-			"number": 66,
-			"origname": "writev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__arm64_sys_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 67,
-			"kconfig": null,
-			"line": 761,
-			"name": "pread64",
-			"number": 67,
-			"origname": "pread64",
-			"signature": [
-				"unsigned int fd",
-				"char *buf",
-				"size_t count",
-				"loff_t pos"
-			],
-			"symbol": "__arm64_sys_pread64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 68,
-			"kconfig": null,
-			"line": 791,
-			"name": "pwrite64",
-			"number": 68,
-			"origname": "pwrite64",
-			"signature": [
-				"unsigned int fd",
-				"const char *buf",
-				"size_t count",
-				"loff_t pos"
-			],
-			"symbol": "__arm64_sys_pwrite64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 69,
-			"kconfig": null,
-			"line": 1167,
-			"name": "preadv",
-			"number": 69,
-			"origname": "preadv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__arm64_sys_preadv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 70,
-			"kconfig": null,
-			"line": 1187,
-			"name": "pwritev",
-			"number": 70,
-			"origname": "pwritev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__arm64_sys_pwritev"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 71,
-			"kconfig": null,
-			"line": 1410,
-			"name": "sendfile64",
-			"number": 71,
-			"origname": "sendfile64",
-			"signature": [
-				"int out_fd",
-				"int in_fd",
-				"loff_t *offset",
-				"size_t count"
-			],
-			"symbol": "__arm64_sys_sendfile64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 72,
-			"kconfig": null,
-			"line": 793,
-			"name": "pselect6",
-			"number": 72,
-			"origname": "pselect6",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct __kernel_timespec *tsp",
-				"void *sig"
-			],
-			"symbol": "__arm64_sys_pselect6"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 73,
-			"kconfig": null,
-			"line": 1095,
-			"name": "ppoll",
-			"number": 73,
-			"origname": "ppoll",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"struct __kernel_timespec *tsp",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_ppoll"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/signalfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 74,
-			"kconfig": "SIGNALFD",
-			"line": 307,
-			"name": "signalfd4",
-			"number": 74,
-			"origname": "signalfd4",
-			"signature": [
-				"int ufd",
-				"sigset_t *user_mask",
-				"size_t sizemask",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_signalfd4"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 75,
-			"kconfig": null,
-			"line": 1583,
-			"name": "vmsplice",
-			"number": 75,
-			"origname": "vmsplice",
-			"signature": [
-				"int fd",
-				"const struct iovec *uiov",
-				"unsigned long nr_segs",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_vmsplice"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 76,
-			"kconfig": null,
-			"line": 1621,
-			"name": "splice",
-			"number": 76,
-			"origname": "splice",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_splice"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 77,
-			"kconfig": null,
-			"line": 1988,
-			"name": "tee",
-			"number": 77,
-			"origname": "tee",
-			"signature": [
-				"int fdin",
-				"int fdout",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_tee"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 78,
-			"kconfig": null,
-			"line": 592,
-			"name": "readlinkat",
-			"number": 78,
-			"origname": "readlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"char *buf",
-				"int bufsiz"
-			],
-			"symbol": "__arm64_sys_readlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 79,
-			"kconfig": null,
-			"line": 526,
-			"name": "newfstatat",
-			"number": 79,
-			"origname": "newfstatat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct stat *statbuf",
-				"int flag"
-			],
-			"symbol": "__arm64_sys_newfstatat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 80,
-			"kconfig": null,
-			"line": 539,
-			"name": "newfstat",
-			"number": 80,
-			"origname": "newfstat",
-			"signature": [
-				"unsigned int fd",
-				"struct stat *statbuf"
-			],
-			"symbol": "__arm64_sys_newfstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 81,
-			"kconfig": null,
-			"line": 111,
-			"name": "sync",
-			"number": 81,
-			"origname": "sync",
-			"signature": [],
-			"symbol": "__arm64_sys_sync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 82,
-			"kconfig": null,
-			"line": 215,
-			"name": "fsync",
-			"number": 82,
-			"origname": "fsync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__arm64_sys_fsync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 83,
-			"kconfig": null,
-			"line": 220,
-			"name": "fdatasync",
-			"number": 83,
-			"origname": "fdatasync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__arm64_sys_fdatasync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 84,
-			"kconfig": null,
-			"line": 363,
-			"name": "sync_file_range",
-			"number": 84,
-			"origname": "sync_file_range",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"loff_t nbytes",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_sync_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 85,
-			"kconfig": null,
-			"line": 395,
-			"name": "timerfd_create",
-			"number": 85,
-			"origname": "timerfd_create",
-			"signature": [
-				"int clockid",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_timerfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 86,
-			"kconfig": null,
-			"line": 560,
-			"name": "timerfd_settime",
-			"number": 86,
-			"origname": "timerfd_settime",
-			"signature": [
-				"int ufd",
-				"int flags",
-				"const struct __kernel_itimerspec *utmr",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__arm64_sys_timerfd_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 87,
-			"kconfig": null,
-			"line": 578,
-			"name": "timerfd_gettime",
-			"number": 87,
-			"origname": "timerfd_gettime",
-			"signature": [
-				"int ufd",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__arm64_sys_timerfd_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 88,
-			"kconfig": null,
-			"line": 143,
-			"name": "utimensat",
-			"number": 88,
-			"origname": "utimensat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct __kernel_timespec *utimes",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_utimensat"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/acct.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 89,
-			"kconfig": "BSD_PROCESS_ACCT",
-			"line": 314,
-			"name": "acct",
-			"number": 89,
-			"origname": "acct",
-			"signature": [
-				"const char *name"
-			],
-			"symbol": "__arm64_sys_acct"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 90,
-			"kconfig": "MULTIUSER",
-			"line": 137,
-			"name": "capget",
-			"number": 90,
-			"origname": "capget",
-			"signature": [
-				"cap_user_header_t header",
-				"cap_user_data_t dataptr"
-			],
-			"symbol": "__arm64_sys_capget"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 91,
-			"kconfig": "MULTIUSER",
-			"line": 216,
-			"name": "capset",
-			"number": 91,
-			"origname": "capset",
-			"signature": [
-				"cap_user_header_t header",
-				"const cap_user_data_t data"
-			],
-			"symbol": "__arm64_sys_capset"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/arm64/kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 92,
-			"kconfig": null,
-			"line": 31,
-			"name": "personality",
-			"number": 92,
-			"origname": "arm64_personality",
-			"signature": [
-				"unsigned int personality"
-			],
-			"symbol": "__arm64_sys_arm64_personality"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 93,
-			"kconfig": null,
-			"line": 1052,
-			"name": "exit",
-			"number": 93,
-			"origname": "exit",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__arm64_sys_exit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 94,
-			"kconfig": null,
-			"line": 1096,
-			"name": "exit_group",
-			"number": 94,
-			"origname": "exit_group",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__arm64_sys_exit_group"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 95,
-			"kconfig": null,
-			"line": 1782,
-			"name": "waitid",
-			"number": 95,
-			"origname": "waitid",
-			"signature": [
-				"int which",
-				"pid_t upid",
-				"struct siginfo *infop",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__arm64_sys_waitid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 96,
-			"kconfig": null,
-			"line": 1949,
-			"name": "set_tid_address",
-			"number": 96,
-			"origname": "set_tid_address",
-			"signature": [
-				"int *tidptr"
-			],
-			"symbol": "__arm64_sys_set_tid_address"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 97,
-			"kconfig": null,
-			"line": 3411,
-			"name": "unshare",
-			"number": 97,
-			"origname": "unshare",
-			"signature": [
-				"unsigned long unshare_flags"
-			],
-			"symbol": "__arm64_sys_unshare"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 98,
-			"kconfig": "FUTEX",
-			"line": 160,
-			"name": "futex",
-			"number": 98,
-			"origname": "futex",
-			"signature": [
-				"u32 *uaddr",
-				"int op",
-				"u32 val",
-				"const struct __kernel_timespec *utime",
-				"u32 *uaddr2",
-				"u32 val3"
-			],
-			"symbol": "__arm64_sys_futex"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 99,
-			"kconfig": "FUTEX",
-			"line": 28,
-			"name": "set_robust_list",
-			"number": 99,
-			"origname": "set_robust_list",
-			"signature": [
-				"struct robust_list_head *head",
-				"size_t len"
-			],
-			"symbol": "__arm64_sys_set_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 100,
-			"kconfig": "FUTEX",
-			"line": 48,
-			"name": "get_robust_list",
-			"number": 100,
-			"origname": "get_robust_list",
-			"signature": [
-				"int pid",
-				"struct robust_list_head **head_ptr",
-				"size_t *len_ptr"
-			],
-			"symbol": "__arm64_sys_get_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/hrtimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 101,
-			"kconfig": null,
-			"line": 2209,
-			"name": "nanosleep",
-			"number": 101,
-			"origname": "nanosleep",
-			"signature": [
-				"struct __kernel_timespec *rqtp",
-				"struct __kernel_timespec *rmtp"
-			],
-			"symbol": "__arm64_sys_nanosleep"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 102,
-			"kconfig": null,
-			"line": 113,
-			"name": "getitimer",
-			"number": 102,
-			"origname": "getitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value"
-			],
-			"symbol": "__arm64_sys_getitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 103,
-			"kconfig": null,
-			"line": 352,
-			"name": "setitimer",
-			"number": 103,
-			"origname": "setitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value",
-				"struct __kernel_old_itimerval *ovalue"
-			],
-			"symbol": "__arm64_sys_setitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kexec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 104,
-			"kconfig": "KEXEC",
-			"line": 242,
-			"name": "kexec_load",
-			"number": 104,
-			"origname": "kexec_load",
-			"signature": [
-				"unsigned long entry",
-				"unsigned long nr_segments",
-				"struct kexec_segment *segments",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_kexec_load"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 105,
-			"kconfig": "MODULES",
-			"line": 3515,
-			"name": "init_module",
-			"number": 105,
-			"origname": "init_module",
-			"signature": [
-				"void *umod",
-				"unsigned long len",
-				"const char *uargs"
-			],
-			"symbol": "__arm64_sys_init_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 106,
-			"kconfig": "MODULE_UNLOAD",
-			"line": 732,
-			"name": "delete_module",
-			"number": 106,
-			"origname": "delete_module",
-			"signature": [
-				"const char *name_user",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_delete_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 107,
-			"kconfig": "POSIX_TIMERS",
-			"line": 480,
-			"name": "timer_create",
-			"number": 107,
-			"origname": "timer_create",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct sigevent *timer_event_spec",
-				"timer_t *created_timer_id"
-			],
-			"symbol": "__arm64_sys_timer_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 108,
-			"kconfig": "POSIX_TIMERS",
-			"line": 676,
-			"name": "timer_gettime",
-			"number": 108,
-			"origname": "timer_gettime",
-			"signature": [
-				"timer_t timer_id",
-				"struct __kernel_itimerspec *setting"
-			],
-			"symbol": "__arm64_sys_timer_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 109,
-			"kconfig": "POSIX_TIMERS",
-			"line": 724,
-			"name": "timer_getoverrun",
-			"number": 109,
-			"origname": "timer_getoverrun",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__arm64_sys_timer_getoverrun"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 110,
-			"kconfig": "POSIX_TIMERS",
-			"line": 914,
-			"name": "timer_settime",
-			"number": 110,
-			"origname": "timer_settime",
-			"signature": [
-				"timer_t timer_id",
-				"int flags",
-				"const struct __kernel_itimerspec *new_setting",
-				"struct __kernel_itimerspec *old_setting"
-			],
-			"symbol": "__arm64_sys_timer_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 111,
-			"kconfig": "POSIX_TIMERS",
-			"line": 994,
-			"name": "timer_delete",
-			"number": 111,
-			"origname": "timer_delete",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__arm64_sys_timer_delete"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 112,
-			"kconfig": null,
-			"line": 1119,
-			"name": "clock_settime",
-			"number": 112,
-			"origname": "clock_settime",
-			"signature": [
-				"const clockid_t which_clock",
-				"const struct __kernel_timespec *tp"
-			],
-			"symbol": "__arm64_sys_clock_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 113,
-			"kconfig": null,
-			"line": 1138,
-			"name": "clock_gettime",
-			"number": 113,
-			"origname": "clock_gettime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__arm64_sys_clock_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 114,
-			"kconfig": null,
-			"line": 1258,
-			"name": "clock_getres",
-			"number": 114,
-			"origname": "clock_getres",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__arm64_sys_clock_getres"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 115,
-			"kconfig": null,
-			"line": 1379,
-			"name": "clock_nanosleep",
-			"number": 115,
-			"origname": "clock_nanosleep",
-			"signature": [
-				"const clockid_t which_clock",
-				"int flags",
-				"const struct __kernel_timespec *rqtp",
-				"struct __kernel_timespec *rmtp"
-			],
-			"symbol": "__arm64_sys_clock_nanosleep"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/printk/printk.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 116,
-			"kconfig": null,
-			"line": 1875,
-			"name": "syslog",
-			"number": 116,
-			"origname": "syslog",
-			"signature": [
-				"int type",
-				"char *buf",
-				"int len"
-			],
-			"symbol": "__arm64_sys_syslog"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/ptrace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 117,
-			"kconfig": null,
-			"line": 1258,
-			"name": "ptrace",
-			"number": 117,
-			"origname": "ptrace",
-			"signature": [
-				"long request",
-				"long pid",
-				"unsigned long addr",
-				"unsigned long data"
-			],
-			"symbol": "__arm64_sys_ptrace"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 118,
-			"kconfig": null,
-			"line": 970,
-			"name": "sched_setparam",
-			"number": 118,
-			"origname": "sched_setparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__arm64_sys_sched_setparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 119,
-			"kconfig": null,
-			"line": 955,
-			"name": "sched_setscheduler",
-			"number": 119,
-			"origname": "sched_setscheduler",
-			"signature": [
-				"pid_t pid",
-				"int policy",
-				"struct sched_param *param"
-			],
-			"symbol": "__arm64_sys_sched_setscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 120,
-			"kconfig": null,
-			"line": 1016,
-			"name": "sched_getscheduler",
-			"number": 120,
-			"origname": "sched_getscheduler",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__arm64_sys_sched_getscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 121,
-			"kconfig": null,
-			"line": 1046,
-			"name": "sched_getparam",
-			"number": 121,
-			"origname": "sched_getparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__arm64_sys_sched_getparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 122,
-			"kconfig": null,
-			"line": 1279,
-			"name": "sched_setaffinity",
-			"number": 122,
-			"origname": "sched_setaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__arm64_sys_sched_setaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 123,
-			"kconfig": null,
-			"line": 1324,
-			"name": "sched_getaffinity",
-			"number": 123,
-			"origname": "sched_getaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__arm64_sys_sched_getaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 124,
-			"kconfig": null,
-			"line": 1377,
-			"name": "sched_yield",
-			"number": 124,
-			"origname": "sched_yield",
-			"signature": [],
-			"symbol": "__arm64_sys_sched_yield"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 125,
-			"kconfig": null,
-			"line": 1485,
-			"name": "sched_get_priority_max",
-			"number": 125,
-			"origname": "sched_get_priority_max",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__arm64_sys_sched_get_priority_max"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 126,
-			"kconfig": null,
-			"line": 1513,
-			"name": "sched_get_priority_min",
-			"number": 126,
-			"origname": "sched_get_priority_min",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__arm64_sys_sched_get_priority_min"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 127,
-			"kconfig": null,
-			"line": 1571,
-			"name": "sched_rr_get_interval",
-			"number": 127,
-			"origname": "sched_rr_get_interval",
-			"signature": [
-				"pid_t pid",
-				"struct __kernel_timespec *interval"
-			],
-			"symbol": "__arm64_sys_sched_rr_get_interval"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 128,
-			"kconfig": null,
-			"line": 3177,
-			"name": "restart_syscall",
-			"number": 128,
-			"origname": "restart_syscall",
-			"signature": [],
-			"symbol": "__arm64_sys_restart_syscall"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 129,
-			"kconfig": null,
-			"line": 3951,
-			"name": "kill",
-			"number": 129,
-			"origname": "kill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__arm64_sys_kill"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 130,
-			"kconfig": null,
-			"line": 4160,
-			"name": "tkill",
-			"number": 130,
-			"origname": "tkill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__arm64_sys_tkill"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 131,
-			"kconfig": null,
-			"line": 4144,
-			"name": "tgkill",
-			"number": 131,
-			"origname": "tgkill",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__arm64_sys_tgkill"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 132,
-			"kconfig": null,
-			"line": 4423,
-			"name": "sigaltstack",
-			"number": 132,
-			"origname": "sigaltstack",
-			"signature": [
-				"const stack_t *uss",
-				"stack_t *uoss"
-			],
-			"symbol": "__arm64_sys_sigaltstack"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 133,
-			"kconfig": null,
-			"line": 4829,
-			"name": "rt_sigsuspend",
-			"number": 133,
-			"origname": "rt_sigsuspend",
-			"signature": [
-				"sigset_t *unewset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_rt_sigsuspend"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 134,
-			"kconfig": null,
-			"line": 4606,
-			"name": "rt_sigaction",
-			"number": 134,
-			"origname": "rt_sigaction",
-			"signature": [
-				"int sig",
-				"const struct sigaction *act",
-				"struct sigaction *oact",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_rt_sigaction"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 135,
-			"kconfig": null,
-			"line": 3320,
-			"name": "rt_sigprocmask",
-			"number": 135,
-			"origname": "rt_sigprocmask",
-			"signature": [
-				"int how",
-				"sigset_t *nset",
-				"sigset_t *oset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_rt_sigprocmask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 136,
-			"kconfig": null,
-			"line": 3392,
-			"name": "rt_sigpending",
-			"number": 136,
-			"origname": "rt_sigpending",
-			"signature": [
-				"sigset_t *uset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_rt_sigpending"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 137,
-			"kconfig": null,
-			"line": 3806,
-			"name": "rt_sigtimedwait",
-			"number": 137,
-			"origname": "rt_sigtimedwait",
-			"signature": [
-				"const sigset_t *uthese",
-				"siginfo_t *uinfo",
-				"const struct __kernel_timespec *uts",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_rt_sigtimedwait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 138,
-			"kconfig": null,
-			"line": 4188,
-			"name": "rt_sigqueueinfo",
-			"number": 138,
-			"origname": "rt_sigqueueinfo",
-			"signature": [
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__arm64_sys_rt_sigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/arm64/kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 139,
-			"kconfig": null,
-			"line": 1107,
-			"name": "rt_sigreturn",
-			"number": 139,
-			"origname": "rt_sigreturn",
-			"signature": [],
-			"symbol": "__arm64_sys_rt_sigreturn"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 140,
-			"kconfig": null,
-			"line": 229,
-			"name": "setpriority",
-			"number": 140,
-			"origname": "setpriority",
-			"signature": [
-				"int which",
-				"int who",
-				"int niceval"
-			],
-			"symbol": "__arm64_sys_setpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 141,
-			"kconfig": null,
-			"line": 299,
-			"name": "getpriority",
-			"number": 141,
-			"origname": "getpriority",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__arm64_sys_getpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/reboot.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 142,
-			"kconfig": null,
-			"line": 722,
-			"name": "reboot",
-			"number": 142,
-			"origname": "reboot",
-			"signature": [
-				"int magic1",
-				"int magic2",
-				"unsigned int cmd",
-				"void *arg"
-			],
-			"symbol": "__arm64_sys_reboot"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 143,
-			"kconfig": "MULTIUSER",
-			"line": 439,
-			"name": "setregid",
-			"number": 143,
-			"origname": "setregid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid"
-			],
-			"symbol": "__arm64_sys_setregid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 144,
-			"kconfig": "MULTIUSER",
-			"line": 485,
-			"name": "setgid",
-			"number": 144,
-			"origname": "setgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__arm64_sys_setgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 145,
-			"kconfig": "MULTIUSER",
-			"line": 605,
-			"name": "setreuid",
-			"number": 145,
-			"origname": "setreuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid"
-			],
-			"symbol": "__arm64_sys_setreuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 146,
-			"kconfig": "MULTIUSER",
-			"line": 668,
-			"name": "setuid",
-			"number": 146,
-			"origname": "setuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__arm64_sys_setuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 147,
-			"kconfig": "MULTIUSER",
-			"line": 753,
-			"name": "setresuid",
-			"number": 147,
-			"origname": "setresuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid",
-				"uid_t suid"
-			],
-			"symbol": "__arm64_sys_setresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 148,
-			"kconfig": "MULTIUSER",
-			"line": 758,
-			"name": "getresuid",
-			"number": 148,
-			"origname": "getresuid",
-			"signature": [
-				"uid_t *ruidp",
-				"uid_t *euidp",
-				"uid_t *suidp"
-			],
-			"symbol": "__arm64_sys_getresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 149,
-			"kconfig": "MULTIUSER",
-			"line": 842,
-			"name": "setresgid",
-			"number": 149,
-			"origname": "setresgid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid",
-				"gid_t sgid"
-			],
-			"symbol": "__arm64_sys_setresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 150,
-			"kconfig": "MULTIUSER",
-			"line": 847,
-			"name": "getresgid",
-			"number": 150,
-			"origname": "getresgid",
-			"signature": [
-				"gid_t *rgidp",
-				"gid_t *egidp",
-				"gid_t *sgidp"
-			],
-			"symbol": "__arm64_sys_getresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 151,
-			"kconfig": "MULTIUSER",
-			"line": 910,
-			"name": "setfsuid",
-			"number": 151,
-			"origname": "setfsuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__arm64_sys_setfsuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 152,
-			"kconfig": "MULTIUSER",
-			"line": 954,
-			"name": "setfsgid",
-			"number": 152,
-			"origname": "setfsgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__arm64_sys_setfsgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 153,
-			"kconfig": null,
-			"line": 1034,
-			"name": "times",
-			"number": 153,
-			"origname": "times",
-			"signature": [
-				"struct tms *tbuf"
-			],
-			"symbol": "__arm64_sys_times"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 154,
-			"kconfig": null,
-			"line": 1084,
-			"name": "setpgid",
-			"number": 154,
-			"origname": "setpgid",
-			"signature": [
-				"pid_t pid",
-				"pid_t pgid"
-			],
-			"symbol": "__arm64_sys_setpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 155,
-			"kconfig": null,
-			"line": 1183,
-			"name": "getpgid",
-			"number": 155,
-			"origname": "getpgid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__arm64_sys_getpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 156,
-			"kconfig": null,
-			"line": 1197,
-			"name": "getsid",
-			"number": 156,
-			"origname": "getsid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__arm64_sys_getsid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 157,
-			"kconfig": null,
-			"line": 1269,
-			"name": "setsid",
-			"number": 157,
-			"origname": "setsid",
-			"signature": [],
-			"symbol": "__arm64_sys_setsid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 158,
-			"kconfig": "MULTIUSER",
-			"line": 161,
-			"name": "getgroups",
-			"number": 158,
-			"origname": "getgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__arm64_sys_getgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 159,
-			"kconfig": "MULTIUSER",
-			"line": 198,
-			"name": "setgroups",
-			"number": 159,
-			"origname": "setgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__arm64_sys_setgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 160,
-			"kconfig": null,
-			"line": 1317,
-			"name": "newuname",
-			"number": 160,
-			"origname": "newuname",
-			"signature": [
-				"struct new_utsname *name"
-			],
-			"symbol": "__arm64_sys_newuname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 161,
-			"kconfig": null,
-			"line": 1385,
-			"name": "sethostname",
-			"number": 161,
-			"origname": "sethostname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__arm64_sys_sethostname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 162,
-			"kconfig": null,
-			"line": 1439,
-			"name": "setdomainname",
-			"number": 162,
-			"origname": "setdomainname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__arm64_sys_setdomainname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 163,
-			"kconfig": null,
-			"line": 1529,
-			"name": "getrlimit",
-			"number": 163,
-			"origname": "getrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__arm64_sys_getrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 164,
-			"kconfig": null,
-			"line": 1742,
-			"name": "setrlimit",
-			"number": 164,
-			"origname": "setrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__arm64_sys_setrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 165,
-			"kconfig": null,
-			"line": 1882,
-			"name": "getrusage",
-			"number": 165,
-			"origname": "getrusage",
-			"signature": [
-				"int who",
-				"struct rusage *ru"
-			],
-			"symbol": "__arm64_sys_getrusage"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 166,
-			"kconfig": null,
-			"line": 1908,
-			"name": "umask",
-			"number": 166,
-			"origname": "umask",
-			"signature": [
-				"int mask"
-			],
-			"symbol": "__arm64_sys_umask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 167,
-			"kconfig": null,
-			"line": 2469,
-			"name": "prctl",
-			"number": 167,
-			"origname": "prctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__arm64_sys_prctl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 168,
-			"kconfig": null,
-			"line": 2822,
-			"name": "getcpu",
-			"number": 168,
-			"origname": "getcpu",
-			"signature": [
-				"unsigned *cpup",
-				"unsigned *nodep",
-				"struct getcpu_cache *unused"
-			],
-			"symbol": "__arm64_sys_getcpu"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 169,
-			"kconfig": null,
-			"line": 140,
-			"name": "gettimeofday",
-			"number": 169,
-			"origname": "gettimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__arm64_sys_gettimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 170,
-			"kconfig": null,
-			"line": 199,
-			"name": "settimeofday",
-			"number": 170,
-			"origname": "settimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__arm64_sys_settimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 171,
-			"kconfig": null,
-			"line": 269,
-			"name": "adjtimex",
-			"number": 171,
-			"origname": "adjtimex",
-			"signature": [
-				"struct __kernel_timex *txc_p"
-			],
-			"symbol": "__arm64_sys_adjtimex"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 172,
-			"kconfig": null,
-			"line": 969,
-			"name": "getpid",
-			"number": 172,
-			"origname": "getpid",
-			"signature": [],
-			"symbol": "__arm64_sys_getpid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 173,
-			"kconfig": null,
-			"line": 986,
-			"name": "getppid",
-			"number": 173,
-			"origname": "getppid",
-			"signature": [],
-			"symbol": "__arm64_sys_getppid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 174,
-			"kconfig": null,
-			"line": 997,
-			"name": "getuid",
-			"number": 174,
-			"origname": "getuid",
-			"signature": [],
-			"symbol": "__arm64_sys_getuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 175,
-			"kconfig": null,
-			"line": 1003,
-			"name": "geteuid",
-			"number": 175,
-			"origname": "geteuid",
-			"signature": [],
-			"symbol": "__arm64_sys_geteuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 176,
-			"kconfig": null,
-			"line": 1009,
-			"name": "getgid",
-			"number": 176,
-			"origname": "getgid",
-			"signature": [],
-			"symbol": "__arm64_sys_getgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 177,
-			"kconfig": null,
-			"line": 1015,
-			"name": "getegid",
-			"number": 177,
-			"origname": "getegid",
-			"signature": [],
-			"symbol": "__arm64_sys_getegid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 178,
-			"kconfig": null,
-			"line": 975,
-			"name": "gettid",
-			"number": 178,
-			"origname": "gettid",
-			"signature": [],
-			"symbol": "__arm64_sys_gettid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 179,
-			"kconfig": null,
-			"line": 2902,
-			"name": "sysinfo",
-			"number": 179,
-			"origname": "sysinfo",
-			"signature": [
-				"struct sysinfo *info"
-			],
-			"symbol": "__arm64_sys_sysinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 180,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 944,
-			"name": "mq_open",
-			"number": 180,
-			"origname": "mq_open",
-			"signature": [
-				"const char *u_name",
-				"int oflag",
-				"umode_t mode",
-				"struct mq_attr *u_attr"
-			],
-			"symbol": "__arm64_sys_mq_open"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 181,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 954,
-			"name": "mq_unlink",
-			"number": 181,
-			"origname": "mq_unlink",
-			"signature": [
-				"const char *u_name"
-			],
-			"symbol": "__arm64_sys_mq_unlink"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 182,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1258,
-			"name": "mq_timedsend",
-			"number": 182,
-			"origname": "mq_timedsend",
-			"signature": [
-				"mqd_t mqdes",
-				"const char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__arm64_sys_mq_timedsend"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 183,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1272,
-			"name": "mq_timedreceive",
-			"number": 183,
-			"origname": "mq_timedreceive",
-			"signature": [
-				"mqd_t mqdes",
-				"char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int *u_msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__arm64_sys_mq_timedreceive"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 184,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1400,
-			"name": "mq_notify",
-			"number": 184,
-			"origname": "mq_notify",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct sigevent *u_notification"
-			],
-			"symbol": "__arm64_sys_mq_notify"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 185,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1452,
-			"name": "mq_getsetattr",
-			"number": 185,
-			"origname": "mq_getsetattr",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct mq_attr *u_mqstat",
-				"struct mq_attr *u_omqstat"
-			],
-			"symbol": "__arm64_sys_mq_getsetattr"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 186,
-			"kconfig": "SYSVIPC",
-			"line": 315,
-			"name": "msgget",
-			"number": 186,
-			"origname": "msgget",
-			"signature": [
-				"key_t key",
-				"int msgflg"
-			],
-			"symbol": "__arm64_sys_msgget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 187,
-			"kconfig": "SYSVIPC",
-			"line": 640,
-			"name": "msgctl",
-			"number": 187,
-			"origname": "msgctl",
-			"signature": [
-				"int msqid",
-				"int cmd",
-				"struct msqid_ds *buf"
-			],
-			"symbol": "__arm64_sys_msgctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 188,
-			"kconfig": "SYSVIPC",
-			"line": 1270,
-			"name": "msgrcv",
-			"number": 188,
-			"origname": "msgrcv",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"long msgtyp",
-				"int msgflg"
-			],
-			"symbol": "__arm64_sys_msgrcv"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 189,
-			"kconfig": "SYSVIPC",
-			"line": 971,
-			"name": "msgsnd",
-			"number": 189,
-			"origname": "msgsnd",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"int msgflg"
-			],
-			"symbol": "__arm64_sys_msgsnd"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 190,
-			"kconfig": "SYSVIPC",
-			"line": 624,
-			"name": "semget",
-			"number": 190,
-			"origname": "semget",
-			"signature": [
-				"key_t key",
-				"int nsems",
-				"int semflg"
-			],
-			"symbol": "__arm64_sys_semget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 191,
-			"kconfig": "SYSVIPC",
-			"line": 1705,
-			"name": "semctl",
-			"number": 191,
-			"origname": "semctl",
-			"signature": [
-				"int semid",
-				"int semnum",
-				"int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__arm64_sys_semctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 192,
-			"kconfig": "SYSVIPC",
-			"line": 2268,
-			"name": "semtimedop",
-			"number": 192,
-			"origname": "semtimedop",
-			"signature": [
-				"int semid",
-				"struct sembuf *tsops",
-				"unsigned int nsops",
-				"const struct __kernel_timespec *timeout"
-			],
-			"symbol": "__arm64_sys_semtimedop"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 193,
-			"kconfig": "SYSVIPC",
-			"line": 2296,
-			"name": "semop",
-			"number": 193,
-			"origname": "semop",
-			"signature": [
-				"int semid",
-				"struct sembuf *tsops",
-				"unsigned nsops"
-			],
-			"symbol": "__arm64_sys_semop"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 194,
-			"kconfig": "SYSVIPC",
-			"line": 842,
-			"name": "shmget",
-			"number": 194,
-			"origname": "shmget",
-			"signature": [
-				"key_t key",
-				"size_t size",
-				"int shmflg"
-			],
-			"symbol": "__arm64_sys_shmget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 195,
-			"kconfig": "SYSVIPC",
-			"line": 1291,
-			"name": "shmctl",
-			"number": 195,
-			"origname": "shmctl",
-			"signature": [
-				"int shmid",
-				"int cmd",
-				"struct shmid_ds *buf"
-			],
-			"symbol": "__arm64_sys_shmctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 196,
-			"kconfig": "SYSVIPC",
-			"line": 1688,
-			"name": "shmat",
-			"number": 196,
-			"origname": "shmat",
-			"signature": [
-				"int shmid",
-				"char *shmaddr",
-				"int shmflg"
-			],
-			"symbol": "__arm64_sys_shmat"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 197,
-			"kconfig": "SYSVIPC",
-			"line": 1829,
-			"name": "shmdt",
-			"number": 197,
-			"origname": "shmdt",
-			"signature": [
-				"char *shmaddr"
-			],
-			"symbol": "__arm64_sys_shmdt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 198,
-			"kconfig": "NET",
-			"line": 1702,
-			"name": "socket",
-			"number": 198,
-			"origname": "socket",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol"
-			],
-			"symbol": "__arm64_sys_socket"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 199,
-			"kconfig": "NET",
-			"line": 1803,
-			"name": "socketpair",
-			"number": 199,
-			"origname": "socketpair",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol",
-				"int *usockvec"
-			],
-			"symbol": "__arm64_sys_socketpair"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 200,
-			"kconfig": "NET",
-			"line": 1851,
-			"name": "bind",
-			"number": 200,
-			"origname": "bind",
-			"signature": [
-				"int fd",
-				"struct sockaddr *umyaddr",
-				"int addrlen"
-			],
-			"symbol": "__arm64_sys_bind"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 201,
-			"kconfig": "NET",
-			"line": 1889,
-			"name": "listen",
-			"number": 201,
-			"origname": "listen",
-			"signature": [
-				"int fd",
-				"int backlog"
-			],
-			"symbol": "__arm64_sys_listen"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 202,
-			"kconfig": "NET",
-			"line": 2010,
-			"name": "accept",
-			"number": 202,
-			"origname": "accept",
-			"signature": [
-				"int fd",
-				"struct sockaddr *upeer_sockaddr",
-				"int *upeer_addrlen"
-			],
-			"symbol": "__arm64_sys_accept"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 203,
-			"kconfig": "NET",
-			"line": 2067,
-			"name": "connect",
-			"number": 203,
-			"origname": "connect",
-			"signature": [
-				"int fd",
-				"struct sockaddr *uservaddr",
-				"int addrlen"
-			],
-			"symbol": "__arm64_sys_connect"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 204,
-			"kconfig": "NET",
-			"line": 2104,
-			"name": "getsockname",
-			"number": 204,
-			"origname": "getsockname",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__arm64_sys_getsockname"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 205,
-			"kconfig": "NET",
-			"line": 2141,
-			"name": "getpeername",
-			"number": 205,
-			"origname": "getpeername",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__arm64_sys_getpeername"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 206,
-			"kconfig": "NET",
-			"line": 2190,
-			"name": "sendto",
-			"number": 206,
-			"origname": "sendto",
-			"signature": [
-				"int fd",
-				"void *buff",
-				"size_t len",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int addr_len"
-			],
-			"symbol": "__arm64_sys_sendto"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 207,
-			"kconfig": "NET",
-			"line": 2248,
-			"name": "recvfrom",
-			"number": 207,
-			"origname": "recvfrom",
-			"signature": [
-				"int fd",
-				"void *ubuf",
-				"size_t size",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int *addr_len"
-			],
-			"symbol": "__arm64_sys_recvfrom"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 208,
-			"kconfig": "NET",
-			"line": 2331,
-			"name": "setsockopt",
-			"number": 208,
-			"origname": "setsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int optlen"
-			],
-			"symbol": "__arm64_sys_setsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 209,
-			"kconfig": "NET",
-			"line": 2397,
-			"name": "getsockopt",
-			"number": 209,
-			"origname": "getsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int *optlen"
-			],
-			"symbol": "__arm64_sys_getsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 210,
-			"kconfig": "NET",
-			"line": 2432,
-			"name": "shutdown",
-			"number": 210,
-			"origname": "shutdown",
-			"signature": [
-				"int fd",
-				"int how"
-			],
-			"symbol": "__arm64_sys_shutdown"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 211,
-			"kconfig": "NET",
-			"line": 2662,
-			"name": "sendmsg",
-			"number": 211,
-			"origname": "sendmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_sendmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 212,
-			"kconfig": "NET",
-			"line": 2871,
-			"name": "recvmsg",
-			"number": 212,
-			"origname": "recvmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_recvmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/readahead.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 213,
-			"kconfig": null,
-			"line": 711,
-			"name": "readahead",
-			"number": 213,
-			"origname": "readahead",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"size_t count"
-			],
-			"symbol": "__arm64_sys_readahead"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 214,
-			"kconfig": null,
-			"line": 115,
-			"name": "brk",
-			"number": 214,
-			"origname": "brk",
-			"signature": [
-				"unsigned long brk"
-			],
-			"symbol": "__arm64_sys_brk"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 215,
-			"kconfig": null,
-			"line": 1081,
-			"name": "munmap",
-			"number": 215,
-			"origname": "munmap",
-			"signature": [
-				"unsigned long addr",
-				"size_t len"
-			],
-			"symbol": "__arm64_sys_munmap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mremap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 216,
-			"kconfig": null,
-			"line": 1045,
-			"name": "mremap",
-			"number": 216,
-			"origname": "mremap",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long old_len",
-				"unsigned long new_len",
-				"unsigned long flags",
-				"unsigned long new_addr"
-			],
-			"symbol": "__arm64_sys_mremap"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 217,
-			"kconfig": "KEYS",
-			"line": 74,
-			"name": "add_key",
-			"number": 217,
-			"origname": "add_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const void *_payload",
-				"size_t plen",
-				"key_serial_t ringid"
-			],
-			"symbol": "__arm64_sys_add_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 218,
-			"kconfig": "KEYS",
-			"line": 167,
-			"name": "request_key",
-			"number": 218,
-			"origname": "request_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const char *_callout_info",
-				"key_serial_t destringid"
-			],
-			"symbol": "__arm64_sys_request_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 219,
-			"kconfig": "KEYS",
-			"line": 1874,
-			"name": "keyctl",
-			"number": 219,
-			"origname": "keyctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__arm64_sys_keyctl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 220,
-			"kconfig": null,
-			"line": 2926,
-			"name": "clone",
-			"number": 220,
-			"origname": "clone",
-			"signature": [
-				"unsigned long clone_flags",
-				"unsigned long newsp",
-				"int *parent_tidptr",
-				"unsigned long tls",
-				"int *child_tidptr"
-			],
-			"symbol": "__arm64_sys_clone"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 221,
-			"kconfig": null,
-			"line": 2111,
-			"name": "execve",
-			"number": 221,
-			"origname": "execve",
-			"signature": [
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp"
-			],
-			"symbol": "__arm64_sys_execve"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/arm64/kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 222,
-			"kconfig": null,
-			"line": 21,
-			"name": "mmap",
-			"number": 222,
-			"origname": "mmap",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long len",
-				"unsigned long prot",
-				"unsigned long flags",
-				"unsigned long fd",
-				"unsigned long off"
-			],
-			"symbol": "__arm64_sys_mmap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/fadvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 223,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 201,
-			"name": "fadvise64_64",
-			"number": 223,
-			"origname": "fadvise64_64",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"loff_t len",
-				"int advice"
-			],
-			"symbol": "__arm64_sys_fadvise64_64"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 224,
-			"kconfig": "SWAP",
-			"line": 3266,
-			"name": "swapon",
-			"number": 224,
-			"origname": "swapon",
-			"signature": [
-				"const char *specialfile",
-				"int swap_flags"
-			],
-			"symbol": "__arm64_sys_swapon"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 225,
-			"kconfig": "SWAP",
-			"line": 2652,
-			"name": "swapoff",
-			"number": 225,
-			"origname": "swapoff",
-			"signature": [
-				"const char *specialfile"
-			],
-			"symbol": "__arm64_sys_swapoff"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 226,
-			"kconfig": "MMU",
-			"line": 858,
-			"name": "mprotect",
-			"number": 226,
-			"origname": "mprotect",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long prot"
-			],
-			"symbol": "__arm64_sys_mprotect"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/msync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 227,
-			"kconfig": "MMU",
-			"line": 32,
-			"name": "msync",
-			"number": 227,
-			"origname": "msync",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_msync"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 228,
-			"kconfig": "MMU",
-			"line": 659,
-			"name": "mlock",
-			"number": 228,
-			"origname": "mlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__arm64_sys_mlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 229,
-			"kconfig": "MMU",
-			"line": 677,
-			"name": "munlock",
-			"number": 229,
-			"origname": "munlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__arm64_sys_munlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 230,
-			"kconfig": "MMU",
-			"line": 745,
-			"name": "mlockall",
-			"number": 230,
-			"origname": "mlockall",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__arm64_sys_mlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 231,
-			"kconfig": "MMU",
-			"line": 774,
-			"name": "munlockall",
-			"number": 231,
-			"origname": "munlockall",
-			"signature": [],
-			"symbol": "__arm64_sys_munlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mincore.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 232,
-			"kconfig": "MMU",
-			"line": 232,
-			"name": "mincore",
-			"number": 232,
-			"origname": "mincore",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned char *vec"
-			],
-			"symbol": "__arm64_sys_mincore"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 233,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1712,
-			"name": "madvise",
-			"number": 233,
-			"origname": "madvise",
-			"signature": [
-				"unsigned long start",
-				"size_t len_in",
-				"int behavior"
-			],
-			"symbol": "__arm64_sys_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 234,
-			"kconfig": "MMU",
-			"line": 1091,
-			"name": "remap_file_pages",
-			"number": 234,
-			"origname": "remap_file_pages",
-			"signature": [
-				"unsigned long start",
-				"unsigned long size",
-				"unsigned long prot",
-				"unsigned long pgoff",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_remap_file_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 235,
-			"kconfig": "NUMA",
-			"line": 1607,
-			"name": "mbind",
-			"number": 235,
-			"origname": "mbind",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_mbind"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 236,
-			"kconfig": "NUMA",
-			"line": 1764,
-			"name": "get_mempolicy",
-			"number": 236,
-			"origname": "get_mempolicy",
-			"signature": [
-				"int *policy",
-				"unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned long addr",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_get_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 237,
-			"kconfig": "NUMA",
-			"line": 1634,
-			"name": "set_mempolicy",
-			"number": 237,
-			"origname": "set_mempolicy",
-			"signature": [
-				"int mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode"
-			],
-			"symbol": "__arm64_sys_set_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 238,
-			"kconfig": "MIGRATION",
-			"line": 1727,
-			"name": "migrate_pages",
-			"number": 238,
-			"origname": "migrate_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long maxnode",
-				"const unsigned long *old_nodes",
-				"const unsigned long *new_nodes"
-			],
-			"symbol": "__arm64_sys_migrate_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/migrate.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 239,
-			"kconfig": "MIGRATION",
-			"line": 2586,
-			"name": "move_pages",
-			"number": 239,
-			"origname": "move_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long nr_pages",
-				"const void **pages",
-				"const int *nodes",
-				"int *status",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_move_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 240,
-			"kconfig": null,
-			"line": 4228,
-			"name": "rt_tgsigqueueinfo",
-			"number": 240,
-			"origname": "rt_tgsigqueueinfo",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__arm64_sys_rt_tgsigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/events/core.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 241,
-			"kconfig": "PERF_EVENTS",
-			"line": 12798,
-			"name": "perf_event_open",
-			"number": 241,
-			"origname": "perf_event_open",
-			"signature": [
-				"struct perf_event_attr *attr_uptr",
-				"pid_t pid",
-				"int cpu",
-				"int group_fd",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_perf_event_open"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 242,
-			"kconfig": "NET",
-			"line": 2004,
-			"name": "accept4",
-			"number": 242,
-			"origname": "accept4",
-			"signature": [
-				"int fd",
-				"struct sockaddr *upeer_sockaddr",
-				"int *upeer_addrlen",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_accept4"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 243,
-			"kconfig": "NET",
-			"line": 3020,
-			"name": "recvmmsg",
-			"number": 243,
-			"origname": "recvmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout"
-			],
-			"symbol": "__arm64_sys_recvmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 260,
-			"kconfig": null,
-			"line": 1874,
-			"name": "wait4",
-			"number": 260,
-			"origname": "wait4",
-			"signature": [
-				"pid_t upid",
-				"int *stat_addr",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__arm64_sys_wait4"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 261,
-			"kconfig": null,
-			"line": 1695,
-			"name": "prlimit64",
-			"number": 261,
-			"origname": "prlimit64",
-			"signature": [
-				"pid_t pid",
-				"unsigned int resource",
-				"const struct rlimit64 *new_rlim",
-				"struct rlimit64 *old_rlim"
-			],
-			"symbol": "__arm64_sys_prlimit64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 262,
-			"kconfig": "FANOTIFY",
-			"line": 1466,
-			"name": "fanotify_init",
-			"number": 262,
-			"origname": "fanotify_init",
-			"signature": [
-				"unsigned int flags",
-				"unsigned int event_f_flags"
-			],
-			"symbol": "__arm64_sys_fanotify_init"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 263,
-			"kconfig": "FANOTIFY",
-			"line": 2003,
-			"name": "fanotify_mark",
-			"number": 263,
-			"origname": "fanotify_mark",
-			"signature": [
-				"int fanotify_fd",
-				"unsigned int flags",
-				"__u64 mask",
-				"int dfd",
-				"const char *pathname"
-			],
-			"symbol": "__arm64_sys_fanotify_mark"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 264,
-			"kconfig": "FHANDLE",
-			"line": 129,
-			"name": "name_to_handle_at",
-			"number": 264,
-			"origname": "name_to_handle_at",
-			"signature": [
-				"int dfd",
-				"const char *name",
-				"struct file_handle *handle",
-				"void *mnt_id",
-				"int flag"
-			],
-			"symbol": "__arm64_sys_name_to_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 265,
-			"kconfig": "FHANDLE",
-			"line": 434,
-			"name": "open_by_handle_at",
-			"number": 265,
-			"origname": "open_by_handle_at",
-			"signature": [
-				"int mountdirfd",
-				"struct file_handle *handle",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_open_by_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 266,
-			"kconfig": null,
-			"line": 1168,
-			"name": "clock_adjtime",
-			"number": 266,
-			"origname": "clock_adjtime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timex *utx"
-			],
-			"symbol": "__arm64_sys_clock_adjtime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 267,
-			"kconfig": null,
-			"line": 149,
-			"name": "syncfs",
-			"number": 267,
-			"origname": "syncfs",
-			"signature": [
-				"int fd"
-			],
-			"symbol": "__arm64_sys_syncfs"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/nsproxy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 268,
-			"kconfig": null,
-			"line": 546,
-			"name": "setns",
-			"number": 268,
-			"origname": "setns",
-			"signature": [
-				"int fd",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_setns"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 269,
-			"kconfig": "NET",
-			"line": 2740,
-			"name": "sendmmsg",
-			"number": 269,
-			"origname": "sendmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_sendmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 270,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 292,
-			"name": "process_vm_readv",
-			"number": 270,
-			"origname": "process_vm_readv",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_process_vm_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 271,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 299,
-			"name": "process_vm_writev",
-			"number": 271,
-			"origname": "process_vm_writev",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_process_vm_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kcmp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 272,
-			"kconfig": "KCMP",
-			"line": 135,
-			"name": "kcmp",
-			"number": 272,
-			"origname": "kcmp",
-			"signature": [
-				"pid_t pid1",
-				"pid_t pid2",
-				"int type",
-				"unsigned long idx1",
-				"unsigned long idx2"
-			],
-			"symbol": "__arm64_sys_kcmp"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 273,
-			"kconfig": "MODULES",
-			"line": 3669,
-			"name": "finit_module",
-			"number": 273,
-			"origname": "finit_module",
-			"signature": [
-				"int fd",
-				"const char *uargs",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_finit_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 274,
-			"kconfig": null,
-			"line": 981,
-			"name": "sched_setattr",
-			"number": 274,
-			"origname": "sched_setattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_sched_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 275,
-			"kconfig": null,
-			"line": 1081,
-			"name": "sched_getattr",
-			"number": 275,
-			"origname": "sched_getattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int usize",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_sched_getattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 276,
-			"kconfig": null,
-			"line": 5257,
-			"name": "renameat2",
-			"number": 276,
-			"origname": "renameat2",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_renameat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/seccomp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 277,
-			"kconfig": "SECCOMP",
-			"line": 2101,
-			"name": "seccomp",
-			"number": 277,
-			"origname": "seccomp",
-			"signature": [
-				"unsigned int op",
-				"unsigned int flags",
-				"void *uargs"
-			],
-			"symbol": "__arm64_sys_seccomp"
-		},
-		{
-			"esoteric": false,
-			"file": "drivers/char/random.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 278,
-			"kconfig": null,
-			"line": 1388,
-			"name": "getrandom",
-			"number": 278,
-			"origname": "getrandom",
-			"signature": [
-				"char *ubuf",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_getrandom"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/memfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 279,
-			"kconfig": "MEMFD_CREATE",
-			"line": 458,
-			"name": "memfd_create",
-			"number": 279,
-			"origname": "memfd_create",
-			"signature": [
-				"const char *uname",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_memfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/bpf/syscall.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 280,
-			"kconfig": "BPF_SYSCALL",
-			"line": 5900,
-			"name": "bpf",
-			"number": 280,
-			"origname": "bpf",
-			"signature": [
-				"int cmd",
-				"union bpf_attr *uattr",
-				"unsigned int size"
-			],
-			"symbol": "__arm64_sys_bpf"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 281,
-			"kconfig": null,
-			"line": 2119,
-			"name": "execveat",
-			"number": 281,
-			"origname": "execveat",
-			"signature": [
-				"int fd",
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_execveat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/userfaultfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 282,
-			"kconfig": "USERFAULTFD",
-			"line": 2155,
-			"name": "userfaultfd",
-			"number": 282,
-			"origname": "userfaultfd",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__arm64_sys_userfaultfd"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/membarrier.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 283,
-			"kconfig": "MEMBARRIER",
-			"line": 625,
-			"name": "membarrier",
-			"number": 283,
-			"origname": "membarrier",
-			"signature": [
-				"int cmd",
-				"unsigned int flags",
-				"int cpu_id"
-			],
-			"symbol": "__arm64_sys_membarrier"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 284,
-			"kconfig": "MMU",
-			"line": 664,
-			"name": "mlock2",
-			"number": 284,
-			"origname": "mlock2",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_mlock2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 285,
-			"kconfig": null,
-			"line": 1637,
-			"name": "copy_file_range",
-			"number": 285,
-			"origname": "copy_file_range",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_copy_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 286,
-			"kconfig": null,
-			"line": 1175,
-			"name": "preadv2",
-			"number": 286,
-			"origname": "preadv2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__arm64_sys_preadv2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 287,
-			"kconfig": null,
-			"line": 1195,
-			"name": "pwritev2",
-			"number": 287,
-			"origname": "pwritev2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__arm64_sys_pwritev2"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 288,
-			"kconfig": null,
-			"line": 866,
-			"name": "pkey_mprotect",
-			"number": 288,
-			"origname": "pkey_mprotect",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long prot",
-				"int pkey"
-			],
-			"symbol": "__arm64_sys_pkey_mprotect"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 289,
-			"kconfig": null,
-			"line": 872,
-			"name": "pkey_alloc",
-			"number": 289,
-			"origname": "pkey_alloc",
-			"signature": [
-				"unsigned long flags",
-				"unsigned long init_val"
-			],
-			"symbol": "__arm64_sys_pkey_alloc"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 290,
-			"kconfig": null,
-			"line": 902,
-			"name": "pkey_free",
-			"number": 290,
-			"origname": "pkey_free",
-			"signature": [
-				"int pkey"
-			],
-			"symbol": "__arm64_sys_pkey_free"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 291,
-			"kconfig": null,
-			"line": 799,
-			"name": "statx",
-			"number": 291,
-			"origname": "statx",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags",
-				"unsigned int mask",
-				"struct statx *buffer"
-			],
-			"symbol": "__arm64_sys_statx"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 292,
-			"kconfig": "AIO",
-			"line": 2275,
-			"name": "io_pgetevents",
-			"number": 292,
-			"origname": "io_pgetevents",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct __kernel_timespec *timeout",
-				"const struct __aio_sigset *usig"
-			],
-			"symbol": "__arm64_sys_io_pgetevents"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/rseq.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 293,
-			"kconfig": "RSEQ",
-			"line": 452,
-			"name": "rseq",
-			"number": 293,
-			"origname": "rseq",
-			"signature": [
-				"struct rseq *rseq",
-				"u32 rseq_len",
-				"int flags",
-				"u32 sig"
-			],
-			"symbol": "__arm64_sys_rseq"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kexec_file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 294,
-			"kconfig": "KEXEC_FILE",
-			"line": 332,
-			"name": "kexec_file_load",
-			"number": 294,
-			"origname": "kexec_file_load",
-			"signature": [
-				"int kernel_fd",
-				"int initrd_fd",
-				"unsigned long cmdline_len",
-				"const char *cmdline_ptr",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_kexec_file_load"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 424,
-			"kconfig": null,
-			"line": 4026,
-			"name": "pidfd_send_signal",
-			"number": 424,
-			"origname": "pidfd_send_signal",
-			"signature": [
-				"int pidfd",
-				"int sig",
-				"siginfo_t *info",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_pidfd_send_signal"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 425,
-			"kconfig": "IO_URING",
-			"line": 3814,
-			"name": "io_uring_setup",
-			"number": 425,
-			"origname": "io_uring_setup",
-			"signature": [
-				"u32 entries",
-				"struct io_uring_params *params"
-			],
-			"symbol": "__arm64_sys_io_uring_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 426,
-			"kconfig": "IO_URING",
-			"line": 3307,
-			"name": "io_uring_enter",
-			"number": 426,
-			"origname": "io_uring_enter",
-			"signature": [
-				"unsigned int fd",
-				"u32 to_submit",
-				"u32 min_complete",
-				"u32 flags",
-				"const void *argp",
-				"size_t argsz"
-			],
-			"symbol": "__arm64_sys_io_uring_enter"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/register.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 427,
-			"kconfig": "IO_URING",
-			"line": 896,
-			"name": "io_uring_register",
-			"number": 427,
-			"origname": "io_uring_register",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int opcode",
-				"void *arg",
-				"unsigned int nr_args"
-			],
-			"symbol": "__arm64_sys_io_uring_register"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 428,
-			"kconfig": null,
-			"line": 2892,
-			"name": "open_tree",
-			"number": 428,
-			"origname": "open_tree",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags"
-			],
-			"symbol": "__arm64_sys_open_tree"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 429,
-			"kconfig": null,
-			"line": 4280,
-			"name": "move_mount",
-			"number": 429,
-			"origname": "move_mount",
-			"signature": [
-				"int from_dfd",
-				"const char *from_pathname",
-				"int to_dfd",
-				"const char *to_pathname",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_move_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 430,
-			"kconfig": null,
-			"line": 114,
-			"name": "fsopen",
-			"number": 430,
-			"origname": "fsopen",
-			"signature": [
-				"const char *_fs_name",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_fsopen"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 431,
-			"kconfig": null,
-			"line": 344,
-			"name": "fsconfig",
-			"number": 431,
-			"origname": "fsconfig",
-			"signature": [
-				"int fd",
-				"unsigned int cmd",
-				"const char *_key",
-				"const void *_value",
-				"int aux"
-			],
-			"symbol": "__arm64_sys_fsconfig"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 432,
-			"kconfig": null,
-			"line": 4156,
-			"name": "fsmount",
-			"number": 432,
-			"origname": "fsmount",
-			"signature": [
-				"int fs_fd",
-				"unsigned int flags",
-				"unsigned int attr_flags"
-			],
-			"symbol": "__arm64_sys_fsmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 433,
-			"kconfig": null,
-			"line": 157,
-			"name": "fspick",
-			"number": 433,
-			"origname": "fspick",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_fspick"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 434,
-			"kconfig": null,
-			"line": 626,
-			"name": "pidfd_open",
-			"number": 434,
-			"origname": "pidfd_open",
-			"signature": [
-				"pid_t pid",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_pidfd_open"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 435,
-			"kconfig": null,
-			"line": 3098,
-			"name": "clone3",
-			"number": 435,
-			"origname": "clone3",
-			"signature": [
-				"struct clone_args *uargs",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_clone3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 436,
-			"kconfig": null,
-			"line": 769,
-			"name": "close_range",
-			"number": 436,
-			"origname": "close_range",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int max_fd",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_close_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 437,
-			"kconfig": null,
-			"line": 1462,
-			"name": "openat2",
-			"number": 437,
-			"origname": "openat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct open_how *how",
-				"size_t usize"
-			],
-			"symbol": "__arm64_sys_openat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 438,
-			"kconfig": null,
-			"line": 854,
-			"name": "pidfd_getfd",
-			"number": 438,
-			"origname": "pidfd_getfd",
-			"signature": [
-				"int pidfd",
-				"int fd",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_pidfd_getfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 439,
-			"kconfig": null,
-			"line": 540,
-			"name": "faccessat2",
-			"number": 439,
-			"origname": "faccessat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode",
-				"int flags"
-			],
-			"symbol": "__arm64_sys_faccessat2"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 440,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1756,
-			"name": "process_madvise",
-			"number": 440,
-			"origname": "process_madvise",
-			"signature": [
-				"int pidfd",
-				"const struct iovec *vec",
-				"size_t vlen",
-				"int behavior",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_process_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 441,
-			"kconfig": "EPOLL",
-			"line": 2532,
-			"name": "epoll_pwait2",
-			"number": 441,
-			"origname": "epoll_pwait2",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"const struct __kernel_timespec *timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__arm64_sys_epoll_pwait2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 442,
-			"kconfig": null,
-			"line": 4847,
-			"name": "mount_setattr",
-			"number": 442,
-			"origname": "mount_setattr",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags",
-				"struct mount_attr *uattr",
-				"size_t usize"
-			],
-			"symbol": "__arm64_sys_mount_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 443,
-			"kconfig": "QUOTACTL",
-			"line": 973,
-			"name": "quotactl_fd",
-			"number": 443,
-			"origname": "quotactl_fd",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__arm64_sys_quotactl_fd"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 444,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 180,
-			"name": "landlock_create_ruleset",
-			"number": 444,
-			"origname": "landlock_create_ruleset",
-			"signature": [
-				"const struct landlock_ruleset_attr *const attr",
-				"const size_t size",
-				"const __u32 flags"
-			],
-			"symbol": "__arm64_sys_landlock_create_ruleset"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 445,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 398,
-			"name": "landlock_add_rule",
-			"number": 445,
-			"origname": "landlock_add_rule",
-			"signature": [
-				"const int ruleset_fd",
-				"const enum landlock_rule_type rule_type",
-				"const void *const rule_attr",
-				"const __u32 flags"
-			],
-			"symbol": "__arm64_sys_landlock_add_rule"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 446,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 451,
-			"name": "landlock_restrict_self",
-			"number": 446,
-			"origname": "landlock_restrict_self",
-			"signature": [
-				"const int ruleset_fd",
-				"const __u32 flags"
-			],
-			"symbol": "__arm64_sys_landlock_restrict_self"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/secretmem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 447,
-			"kconfig": "SECRETMEM",
-			"line": 232,
-			"name": "memfd_secret",
-			"number": 447,
-			"origname": "memfd_secret",
-			"signature": [
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_memfd_secret"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/oom_kill.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 448,
-			"kconfig": "MMU",
-			"line": 1204,
-			"name": "process_mrelease",
-			"number": 448,
-			"origname": "process_mrelease",
-			"signature": [
-				"int pidfd",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_process_mrelease"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 449,
-			"kconfig": "FUTEX",
-			"line": 290,
-			"name": "futex_waitv",
-			"number": 449,
-			"origname": "futex_waitv",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int nr_futexes",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__arm64_sys_futex_waitv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 450,
-			"kconfig": "NUMA",
-			"line": 1540,
-			"name": "set_mempolicy_home_node",
-			"number": 450,
-			"origname": "set_mempolicy_home_node",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long home_node",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_set_mempolicy_home_node"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/filemap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 451,
-			"kconfig": "CACHESTAT_SYSCALL",
-			"line": 4498,
-			"name": "cachestat",
-			"number": 451,
-			"origname": "cachestat",
-			"signature": [
-				"unsigned int fd",
-				"struct cachestat_range *cstat_range",
-				"struct cachestat *cstat",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_cachestat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 452,
-			"kconfig": null,
-			"line": 700,
-			"name": "fchmodat2",
-			"number": 452,
-			"origname": "fchmodat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_fchmodat2"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/arm64/mm/gcs.c",
-			"good_location": true,
-			"grepped_location": true,
-			"index": 453,
-			"kconfig": "X86_USER_SHADOW_STACK",
-			"line": 71,
-			"name": "map_shadow_stack",
-			"number": 453,
-			"origname": "map_shadow_stack",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long size",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_map_shadow_stack"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 454,
-			"kconfig": "FUTEX",
-			"line": 338,
-			"name": "futex_wake",
-			"number": 454,
-			"origname": "futex_wake",
-			"signature": [
-				"void *uaddr",
-				"unsigned long mask",
-				"int nr",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_futex_wake"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 455,
-			"kconfig": "FUTEX",
-			"line": 370,
-			"name": "futex_wait",
-			"number": 455,
-			"origname": "futex_wait",
-			"signature": [
-				"void *uaddr",
-				"unsigned long val",
-				"unsigned long mask",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__arm64_sys_futex_wait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 456,
-			"kconfig": "FUTEX",
-			"line": 414,
-			"name": "futex_requeue",
-			"number": 456,
-			"origname": "futex_requeue",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int flags",
-				"int nr_wake",
-				"int nr_requeue"
-			],
-			"symbol": "__arm64_sys_futex_requeue"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 457,
-			"kconfig": null,
-			"line": 5508,
-			"name": "statmount",
-			"number": 457,
-			"origname": "statmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"struct statmount *buf",
-				"size_t bufsize",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_statmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 458,
-			"kconfig": null,
-			"line": 5615,
-			"name": "listmount",
-			"number": 458,
-			"origname": "listmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"u64 *mnt_ids",
-				"size_t nr_mnt_ids",
-				"unsigned int flags"
-			],
-			"symbol": "__arm64_sys_listmount"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 459,
-			"kconfig": "SECURITY",
-			"line": 77,
-			"name": "lsm_get_self_attr",
-			"number": 459,
-			"origname": "lsm_get_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__arm64_sys_lsm_get_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 460,
-			"kconfig": "SECURITY",
-			"line": 55,
-			"name": "lsm_set_self_attr",
-			"number": 460,
-			"origname": "lsm_set_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 size",
-				"u32 flags"
-			],
-			"symbol": "__arm64_sys_lsm_set_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 461,
-			"kconfig": "SECURITY",
-			"line": 96,
-			"name": "lsm_list_modules",
-			"number": 461,
-			"origname": "lsm_list_modules",
-			"signature": [
-				"u64 *ids",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__arm64_sys_lsm_list_modules"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mseal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 462,
-			"kconfig": null,
-			"line": 265,
-			"name": "mseal",
-			"number": 462,
-			"origname": "mseal",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long flags"
-			],
-			"symbol": "__arm64_sys_mseal"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 463,
-			"kconfig": null,
-			"line": 719,
-			"name": "setxattrat",
-			"number": 463,
-			"origname": "setxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"const struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__arm64_sys_setxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 464,
-			"kconfig": null,
-			"line": 863,
-			"name": "getxattrat",
-			"number": 464,
-			"origname": "getxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__arm64_sys_getxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 465,
-			"kconfig": null,
-			"line": 991,
-			"name": "listxattrat",
-			"number": 465,
-			"origname": "listxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__arm64_sys_listxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 466,
-			"kconfig": null,
-			"line": 1091,
-			"name": "removexattrat",
-			"number": 466,
-			"origname": "removexattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name"
-			],
-			"symbol": "__arm64_sys_removexattrat"
-		}
-	],
-	"systrack_version": "0.7"
+    "syscalls": [
+        {
+            "name": "io_setup",
+            "number": 0,
+            "signature": [
+                "unsigned nr_events",
+                "aio_context_t *ctxp"
+            ]
+        },
+        {
+            "name": "io_destroy",
+            "number": 1,
+            "signature": [
+                "aio_context_t ctx"
+            ]
+        },
+        {
+            "name": "io_submit",
+            "number": 2,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long nr",
+                "struct iocb **iocbpp"
+            ]
+        },
+        {
+            "name": "io_cancel",
+            "number": 3,
+            "signature": [
+                "aio_context_t ctx_id",
+                "struct iocb *iocb",
+                "struct io_event *result"
+            ]
+        },
+        {
+            "name": "io_getevents",
+            "number": 4,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "setxattr",
+            "number": 5,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "lsetxattr",
+            "number": 6,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "fsetxattr",
+            "number": 7,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getxattr",
+            "number": 8,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "lgetxattr",
+            "number": 9,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "fgetxattr",
+            "number": 10,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "listxattr",
+            "number": 11,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "llistxattr",
+            "number": 12,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "flistxattr",
+            "number": 13,
+            "signature": [
+                "int fd",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattr",
+            "number": 14,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "lremovexattr",
+            "number": 15,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "fremovexattr",
+            "number": 16,
+            "signature": [
+                "int fd",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "getcwd",
+            "number": 17,
+            "signature": [
+                "char *buf",
+                "unsigned long size"
+            ]
+        },
+        {
+            "name": "eventfd2",
+            "number": 19,
+            "signature": [
+                "unsigned int count",
+                "int flags"
+            ]
+        },
+        {
+            "name": "epoll_create1",
+            "number": 20,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "epoll_ctl",
+            "number": 21,
+            "signature": [
+                "int epfd",
+                "int op",
+                "int fd",
+                "struct epoll_event *event"
+            ]
+        },
+        {
+            "name": "epoll_pwait",
+            "number": 22,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "int timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "dup",
+            "number": 23,
+            "signature": [
+                "unsigned int fildes"
+            ]
+        },
+        {
+            "name": "dup3",
+            "number": 24,
+            "signature": [
+                "unsigned int oldfd",
+                "unsigned int newfd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "fcntl",
+            "number": 25,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "inotify_init1",
+            "number": 26,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "inotify_add_watch",
+            "number": 27,
+            "signature": [
+                "int fd",
+                "const char *pathname",
+                "u32 mask"
+            ]
+        },
+        {
+            "name": "inotify_rm_watch",
+            "number": 28,
+            "signature": [
+                "int fd",
+                "__s32 wd"
+            ]
+        },
+        {
+            "name": "ioctl",
+            "number": 29,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "ioprio_set",
+            "number": 30,
+            "signature": [
+                "int which",
+                "int who",
+                "int ioprio"
+            ]
+        },
+        {
+            "name": "ioprio_get",
+            "number": 31,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "flock",
+            "number": 32,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd"
+            ]
+        },
+        {
+            "name": "mknodat",
+            "number": 33,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int dev"
+            ]
+        },
+        {
+            "name": "mkdirat",
+            "number": 34,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "unlinkat",
+            "number": 35,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "int flag"
+            ]
+        },
+        {
+            "name": "symlinkat",
+            "number": 36,
+            "signature": [
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "linkat",
+            "number": 37,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "int flags"
+            ]
+        },
+        {
+            "name": "renameat",
+            "number": 38,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "umount",
+            "number": 39,
+            "signature": [
+                "char *name",
+                "int flags"
+            ]
+        },
+        {
+            "name": "mount",
+            "number": 40,
+            "signature": [
+                "char *dev_name",
+                "char *dir_name",
+                "char *type",
+                "unsigned long flags",
+                "void *data"
+            ]
+        },
+        {
+            "name": "pivot_root",
+            "number": 41,
+            "signature": [
+                "const char *new_root",
+                "const char *put_old"
+            ]
+        },
+        {
+            "name": "statfs",
+            "number": 43,
+            "signature": [
+                "const char *pathname",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "fstatfs",
+            "number": 44,
+            "signature": [
+                "unsigned int fd",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "truncate",
+            "number": 45,
+            "signature": [
+                "const char *path",
+                "long length"
+            ]
+        },
+        {
+            "name": "ftruncate",
+            "number": 46,
+            "signature": [
+                "unsigned int fd",
+                "off_t length"
+            ]
+        },
+        {
+            "name": "fallocate",
+            "number": 47,
+            "signature": [
+                "int fd",
+                "int mode",
+                "loff_t offset",
+                "loff_t len"
+            ]
+        },
+        {
+            "name": "faccessat",
+            "number": 48,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode"
+            ]
+        },
+        {
+            "name": "chdir",
+            "number": 49,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "fchdir",
+            "number": 50,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "chroot",
+            "number": 51,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "fchmod",
+            "number": 52,
+            "signature": [
+                "unsigned int fd",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "fchmodat",
+            "number": 53,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "fchownat",
+            "number": 54,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "uid_t user",
+                "gid_t group",
+                "int flag"
+            ]
+        },
+        {
+            "name": "fchown",
+            "number": 55,
+            "signature": [
+                "unsigned int fd",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "openat",
+            "number": 56,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int flags",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "close",
+            "number": 57,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "vhangup",
+            "number": 58,
+            "signature": []
+        },
+        {
+            "name": "pipe2",
+            "number": 59,
+            "signature": [
+                "int *fildes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "quotactl",
+            "number": 60,
+            "signature": [
+                "unsigned int cmd",
+                "const char *special",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "getdents64",
+            "number": 61,
+            "signature": [
+                "unsigned int fd",
+                "struct linux_dirent64 *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "lseek",
+            "number": 62,
+            "signature": [
+                "unsigned int fd",
+                "off_t offset",
+                "unsigned int whence"
+            ]
+        },
+        {
+            "name": "read",
+            "number": 63,
+            "signature": [
+                "unsigned int fd",
+                "char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "write",
+            "number": 64,
+            "signature": [
+                "unsigned int fd",
+                "const char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "readv",
+            "number": 65,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "writev",
+            "number": 66,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "pread64",
+            "number": 67,
+            "signature": [
+                "unsigned int fd",
+                "char *buf",
+                "size_t count",
+                "loff_t pos"
+            ]
+        },
+        {
+            "name": "pwrite64",
+            "number": 68,
+            "signature": [
+                "unsigned int fd",
+                "const char *buf",
+                "size_t count",
+                "loff_t pos"
+            ]
+        },
+        {
+            "name": "preadv",
+            "number": 69,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "pwritev",
+            "number": 70,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "sendfile64",
+            "number": 71,
+            "signature": [
+                "int out_fd",
+                "int in_fd",
+                "loff_t *offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "pselect6",
+            "number": 72,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct __kernel_timespec *tsp",
+                "void *sig"
+            ]
+        },
+        {
+            "name": "ppoll",
+            "number": 73,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "struct __kernel_timespec *tsp",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "signalfd4",
+            "number": 74,
+            "signature": [
+                "int ufd",
+                "sigset_t *user_mask",
+                "size_t sizemask",
+                "int flags"
+            ]
+        },
+        {
+            "name": "vmsplice",
+            "number": 75,
+            "signature": [
+                "int fd",
+                "const struct iovec *uiov",
+                "unsigned long nr_segs",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "splice",
+            "number": 76,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "tee",
+            "number": 77,
+            "signature": [
+                "int fdin",
+                "int fdout",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "readlinkat",
+            "number": 78,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "char *buf",
+                "int bufsiz"
+            ]
+        },
+        {
+            "name": "newfstatat",
+            "number": 79,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct stat *statbuf",
+                "int flag"
+            ]
+        },
+        {
+            "name": "newfstat",
+            "number": 80,
+            "signature": [
+                "unsigned int fd",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "sync",
+            "number": 81,
+            "signature": []
+        },
+        {
+            "name": "fsync",
+            "number": 82,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "fdatasync",
+            "number": 83,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "sync_file_range",
+            "number": 84,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "loff_t nbytes",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "timerfd_create",
+            "number": 85,
+            "signature": [
+                "int clockid",
+                "int flags"
+            ]
+        },
+        {
+            "name": "timerfd_settime",
+            "number": 86,
+            "signature": [
+                "int ufd",
+                "int flags",
+                "const struct __kernel_itimerspec *utmr",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "timerfd_gettime",
+            "number": 87,
+            "signature": [
+                "int ufd",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "utimensat",
+            "number": 88,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct __kernel_timespec *utimes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "acct",
+            "number": 89,
+            "signature": [
+                "const char *name"
+            ]
+        },
+        {
+            "name": "capget",
+            "number": 90,
+            "signature": [
+                "cap_user_header_t header",
+                "cap_user_data_t dataptr"
+            ]
+        },
+        {
+            "name": "capset",
+            "number": 91,
+            "signature": [
+                "cap_user_header_t header",
+                "const cap_user_data_t data"
+            ]
+        },
+        {
+            "name": "personality",
+            "number": 92,
+            "signature": [
+                "unsigned int personality"
+            ]
+        },
+        {
+            "name": "exit",
+            "number": 93,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "exit_group",
+            "number": 94,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "waitid",
+            "number": 95,
+            "signature": [
+                "int which",
+                "pid_t upid",
+                "struct siginfo *infop",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "set_tid_address",
+            "number": 96,
+            "signature": [
+                "int *tidptr"
+            ]
+        },
+        {
+            "name": "unshare",
+            "number": 97,
+            "signature": [
+                "unsigned long unshare_flags"
+            ]
+        },
+        {
+            "name": "futex",
+            "number": 98,
+            "signature": [
+                "u32 *uaddr",
+                "int op",
+                "u32 val",
+                "const struct __kernel_timespec *utime",
+                "u32 *uaddr2",
+                "u32 val3"
+            ]
+        },
+        {
+            "name": "set_robust_list",
+            "number": 99,
+            "signature": [
+                "struct robust_list_head *head",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "get_robust_list",
+            "number": 100,
+            "signature": [
+                "int pid",
+                "struct robust_list_head **head_ptr",
+                "size_t *len_ptr"
+            ]
+        },
+        {
+            "name": "nanosleep",
+            "number": 101,
+            "signature": [
+                "struct __kernel_timespec *rqtp",
+                "struct __kernel_timespec *rmtp"
+            ]
+        },
+        {
+            "name": "getitimer",
+            "number": 102,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value"
+            ]
+        },
+        {
+            "name": "setitimer",
+            "number": 103,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value",
+                "struct __kernel_old_itimerval *ovalue"
+            ]
+        },
+        {
+            "name": "kexec_load",
+            "number": 104,
+            "signature": [
+                "unsigned long entry",
+                "unsigned long nr_segments",
+                "struct kexec_segment *segments",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "init_module",
+            "number": 105,
+            "signature": [
+                "void *umod",
+                "unsigned long len",
+                "const char *uargs"
+            ]
+        },
+        {
+            "name": "delete_module",
+            "number": 106,
+            "signature": [
+                "const char *name_user",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "timer_create",
+            "number": 107,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct sigevent *timer_event_spec",
+                "timer_t *created_timer_id"
+            ]
+        },
+        {
+            "name": "timer_gettime",
+            "number": 108,
+            "signature": [
+                "timer_t timer_id",
+                "struct __kernel_itimerspec *setting"
+            ]
+        },
+        {
+            "name": "timer_getoverrun",
+            "number": 109,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "timer_settime",
+            "number": 110,
+            "signature": [
+                "timer_t timer_id",
+                "int flags",
+                "const struct __kernel_itimerspec *new_setting",
+                "struct __kernel_itimerspec *old_setting"
+            ]
+        },
+        {
+            "name": "timer_delete",
+            "number": 111,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "clock_settime",
+            "number": 112,
+            "signature": [
+                "const clockid_t which_clock",
+                "const struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_gettime",
+            "number": 113,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_getres",
+            "number": 114,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_nanosleep",
+            "number": 115,
+            "signature": [
+                "const clockid_t which_clock",
+                "int flags",
+                "const struct __kernel_timespec *rqtp",
+                "struct __kernel_timespec *rmtp"
+            ]
+        },
+        {
+            "name": "syslog",
+            "number": 116,
+            "signature": [
+                "int type",
+                "char *buf",
+                "int len"
+            ]
+        },
+        {
+            "name": "ptrace",
+            "number": 117,
+            "signature": [
+                "long request",
+                "long pid",
+                "unsigned long addr",
+                "unsigned long data"
+            ]
+        },
+        {
+            "name": "sched_setparam",
+            "number": 118,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_setscheduler",
+            "number": 119,
+            "signature": [
+                "pid_t pid",
+                "int policy",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_getscheduler",
+            "number": 120,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "sched_getparam",
+            "number": 121,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_setaffinity",
+            "number": 122,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "sched_getaffinity",
+            "number": 123,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "sched_yield",
+            "number": 124,
+            "signature": []
+        },
+        {
+            "name": "sched_get_priority_max",
+            "number": 125,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_get_priority_min",
+            "number": 126,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "number": 127,
+            "signature": [
+                "pid_t pid",
+                "struct __kernel_timespec *interval"
+            ]
+        },
+        {
+            "name": "restart_syscall",
+            "number": 128,
+            "signature": []
+        },
+        {
+            "name": "kill",
+            "number": 129,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "tkill",
+            "number": 130,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "tgkill",
+            "number": 131,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "sigaltstack",
+            "number": 132,
+            "signature": [
+                "const stack_t *uss",
+                "stack_t *uoss"
+            ]
+        },
+        {
+            "name": "rt_sigsuspend",
+            "number": 133,
+            "signature": [
+                "sigset_t *unewset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigaction",
+            "number": 134,
+            "signature": [
+                "int sig",
+                "const struct sigaction *act",
+                "struct sigaction *oact",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigprocmask",
+            "number": 135,
+            "signature": [
+                "int how",
+                "sigset_t *nset",
+                "sigset_t *oset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigpending",
+            "number": 136,
+            "signature": [
+                "sigset_t *uset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "number": 137,
+            "signature": [
+                "const sigset_t *uthese",
+                "siginfo_t *uinfo",
+                "const struct __kernel_timespec *uts",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigqueueinfo",
+            "number": 138,
+            "signature": [
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "rt_sigreturn",
+            "number": 139,
+            "signature": []
+        },
+        {
+            "name": "setpriority",
+            "number": 140,
+            "signature": [
+                "int which",
+                "int who",
+                "int niceval"
+            ]
+        },
+        {
+            "name": "getpriority",
+            "number": 141,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "reboot",
+            "number": 142,
+            "signature": [
+                "int magic1",
+                "int magic2",
+                "unsigned int cmd",
+                "void *arg"
+            ]
+        },
+        {
+            "name": "setregid",
+            "number": 143,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid"
+            ]
+        },
+        {
+            "name": "setgid",
+            "number": 144,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "setreuid",
+            "number": 145,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid"
+            ]
+        },
+        {
+            "name": "setuid",
+            "number": 146,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setresuid",
+            "number": 147,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid",
+                "uid_t suid"
+            ]
+        },
+        {
+            "name": "getresuid",
+            "number": 148,
+            "signature": [
+                "uid_t *ruidp",
+                "uid_t *euidp",
+                "uid_t *suidp"
+            ]
+        },
+        {
+            "name": "setresgid",
+            "number": 149,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid",
+                "gid_t sgid"
+            ]
+        },
+        {
+            "name": "getresgid",
+            "number": 150,
+            "signature": [
+                "gid_t *rgidp",
+                "gid_t *egidp",
+                "gid_t *sgidp"
+            ]
+        },
+        {
+            "name": "setfsuid",
+            "number": 151,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setfsgid",
+            "number": 152,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "times",
+            "number": 153,
+            "signature": [
+                "struct tms *tbuf"
+            ]
+        },
+        {
+            "name": "setpgid",
+            "number": 154,
+            "signature": [
+                "pid_t pid",
+                "pid_t pgid"
+            ]
+        },
+        {
+            "name": "getpgid",
+            "number": 155,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "getsid",
+            "number": 156,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "setsid",
+            "number": 157,
+            "signature": []
+        },
+        {
+            "name": "getgroups",
+            "number": 158,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "setgroups",
+            "number": 159,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "newuname",
+            "number": 160,
+            "signature": [
+                "struct new_utsname *name"
+            ]
+        },
+        {
+            "name": "sethostname",
+            "number": 161,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "setdomainname",
+            "number": 162,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "getrlimit",
+            "number": 163,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "setrlimit",
+            "number": 164,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "getrusage",
+            "number": 165,
+            "signature": [
+                "int who",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "umask",
+            "number": 166,
+            "signature": [
+                "int mask"
+            ]
+        },
+        {
+            "name": "prctl",
+            "number": 167,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "getcpu",
+            "number": 168,
+            "signature": [
+                "unsigned *cpup",
+                "unsigned *nodep",
+                "struct getcpu_cache *unused"
+            ]
+        },
+        {
+            "name": "gettimeofday",
+            "number": 169,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "settimeofday",
+            "number": 170,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "adjtimex",
+            "number": 171,
+            "signature": [
+                "struct __kernel_timex *txc_p"
+            ]
+        },
+        {
+            "name": "getpid",
+            "number": 172,
+            "signature": []
+        },
+        {
+            "name": "getppid",
+            "number": 173,
+            "signature": []
+        },
+        {
+            "name": "getuid",
+            "number": 174,
+            "signature": []
+        },
+        {
+            "name": "geteuid",
+            "number": 175,
+            "signature": []
+        },
+        {
+            "name": "getgid",
+            "number": 176,
+            "signature": []
+        },
+        {
+            "name": "getegid",
+            "number": 177,
+            "signature": []
+        },
+        {
+            "name": "gettid",
+            "number": 178,
+            "signature": []
+        },
+        {
+            "name": "sysinfo",
+            "number": 179,
+            "signature": [
+                "struct sysinfo *info"
+            ]
+        },
+        {
+            "name": "mq_open",
+            "number": 180,
+            "signature": [
+                "const char *u_name",
+                "int oflag",
+                "umode_t mode",
+                "struct mq_attr *u_attr"
+            ]
+        },
+        {
+            "name": "mq_unlink",
+            "number": 181,
+            "signature": [
+                "const char *u_name"
+            ]
+        },
+        {
+            "name": "mq_timedsend",
+            "number": 182,
+            "signature": [
+                "mqd_t mqdes",
+                "const char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_timedreceive",
+            "number": 183,
+            "signature": [
+                "mqd_t mqdes",
+                "char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int *u_msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_notify",
+            "number": 184,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct sigevent *u_notification"
+            ]
+        },
+        {
+            "name": "mq_getsetattr",
+            "number": 185,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct mq_attr *u_mqstat",
+                "struct mq_attr *u_omqstat"
+            ]
+        },
+        {
+            "name": "msgget",
+            "number": 186,
+            "signature": [
+                "key_t key",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgctl",
+            "number": 187,
+            "signature": [
+                "int msqid",
+                "int cmd",
+                "struct msqid_ds *buf"
+            ]
+        },
+        {
+            "name": "msgrcv",
+            "number": 188,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "long msgtyp",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgsnd",
+            "number": 189,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "semget",
+            "number": 190,
+            "signature": [
+                "key_t key",
+                "int nsems",
+                "int semflg"
+            ]
+        },
+        {
+            "name": "semctl",
+            "number": 191,
+            "signature": [
+                "int semid",
+                "int semnum",
+                "int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "semtimedop",
+            "number": 192,
+            "signature": [
+                "int semid",
+                "struct sembuf *tsops",
+                "unsigned int nsops",
+                "const struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "semop",
+            "number": 193,
+            "signature": [
+                "int semid",
+                "struct sembuf *tsops",
+                "unsigned nsops"
+            ]
+        },
+        {
+            "name": "shmget",
+            "number": 194,
+            "signature": [
+                "key_t key",
+                "size_t size",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmctl",
+            "number": 195,
+            "signature": [
+                "int shmid",
+                "int cmd",
+                "struct shmid_ds *buf"
+            ]
+        },
+        {
+            "name": "shmat",
+            "number": 196,
+            "signature": [
+                "int shmid",
+                "char *shmaddr",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmdt",
+            "number": 197,
+            "signature": [
+                "char *shmaddr"
+            ]
+        },
+        {
+            "name": "socket",
+            "number": 198,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol"
+            ]
+        },
+        {
+            "name": "socketpair",
+            "number": 199,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol",
+                "int *usockvec"
+            ]
+        },
+        {
+            "name": "bind",
+            "number": 200,
+            "signature": [
+                "int fd",
+                "struct sockaddr *umyaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "listen",
+            "number": 201,
+            "signature": [
+                "int fd",
+                "int backlog"
+            ]
+        },
+        {
+            "name": "accept",
+            "number": 202,
+            "signature": [
+                "int fd",
+                "struct sockaddr *upeer_sockaddr",
+                "int *upeer_addrlen"
+            ]
+        },
+        {
+            "name": "connect",
+            "number": 203,
+            "signature": [
+                "int fd",
+                "struct sockaddr *uservaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "getsockname",
+            "number": 204,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "getpeername",
+            "number": 205,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "sendto",
+            "number": 206,
+            "signature": [
+                "int fd",
+                "void *buff",
+                "size_t len",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int addr_len"
+            ]
+        },
+        {
+            "name": "recvfrom",
+            "number": 207,
+            "signature": [
+                "int fd",
+                "void *ubuf",
+                "size_t size",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int *addr_len"
+            ]
+        },
+        {
+            "name": "setsockopt",
+            "number": 208,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int optlen"
+            ]
+        },
+        {
+            "name": "getsockopt",
+            "number": 209,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int *optlen"
+            ]
+        },
+        {
+            "name": "shutdown",
+            "number": 210,
+            "signature": [
+                "int fd",
+                "int how"
+            ]
+        },
+        {
+            "name": "sendmsg",
+            "number": 211,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "recvmsg",
+            "number": 212,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "readahead",
+            "number": 213,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "brk",
+            "number": 214,
+            "signature": [
+                "unsigned long brk"
+            ]
+        },
+        {
+            "name": "munmap",
+            "number": 215,
+            "signature": [
+                "unsigned long addr",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "mremap",
+            "number": 216,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long old_len",
+                "unsigned long new_len",
+                "unsigned long flags",
+                "unsigned long new_addr"
+            ]
+        },
+        {
+            "name": "add_key",
+            "number": 217,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const void *_payload",
+                "size_t plen",
+                "key_serial_t ringid"
+            ]
+        },
+        {
+            "name": "request_key",
+            "number": 218,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const char *_callout_info",
+                "key_serial_t destringid"
+            ]
+        },
+        {
+            "name": "keyctl",
+            "number": 219,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "clone",
+            "number": 220,
+            "signature": [
+                "unsigned long clone_flags",
+                "unsigned long newsp",
+                "int *parent_tidptr",
+                "unsigned long tls",
+                "int *child_tidptr"
+            ]
+        },
+        {
+            "name": "execve",
+            "number": 221,
+            "signature": [
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp"
+            ]
+        },
+        {
+            "name": "mmap",
+            "number": 222,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long len",
+                "unsigned long prot",
+                "unsigned long flags",
+                "unsigned long fd",
+                "unsigned long off"
+            ]
+        },
+        {
+            "name": "fadvise64_64",
+            "number": 223,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "loff_t len",
+                "int advice"
+            ]
+        },
+        {
+            "name": "swapon",
+            "number": 224,
+            "signature": [
+                "const char *specialfile",
+                "int swap_flags"
+            ]
+        },
+        {
+            "name": "swapoff",
+            "number": 225,
+            "signature": [
+                "const char *specialfile"
+            ]
+        },
+        {
+            "name": "mprotect",
+            "number": 226,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long prot"
+            ]
+        },
+        {
+            "name": "msync",
+            "number": 227,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "mlock",
+            "number": 228,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "munlock",
+            "number": 229,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "mlockall",
+            "number": 230,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "munlockall",
+            "number": 231,
+            "signature": []
+        },
+        {
+            "name": "mincore",
+            "number": 232,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned char *vec"
+            ]
+        },
+        {
+            "name": "madvise",
+            "number": 233,
+            "signature": [
+                "unsigned long start",
+                "size_t len_in",
+                "int behavior"
+            ]
+        },
+        {
+            "name": "remap_file_pages",
+            "number": 234,
+            "signature": [
+                "unsigned long start",
+                "unsigned long size",
+                "unsigned long prot",
+                "unsigned long pgoff",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "mbind",
+            "number": 235,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "get_mempolicy",
+            "number": 236,
+            "signature": [
+                "int *policy",
+                "unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned long addr",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "set_mempolicy",
+            "number": 237,
+            "signature": [
+                "int mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode"
+            ]
+        },
+        {
+            "name": "migrate_pages",
+            "number": 238,
+            "signature": [
+                "pid_t pid",
+                "unsigned long maxnode",
+                "const unsigned long *old_nodes",
+                "const unsigned long *new_nodes"
+            ]
+        },
+        {
+            "name": "move_pages",
+            "number": 239,
+            "signature": [
+                "pid_t pid",
+                "unsigned long nr_pages",
+                "const void **pages",
+                "const int *nodes",
+                "int *status",
+                "int flags"
+            ]
+        },
+        {
+            "name": "rt_tgsigqueueinfo",
+            "number": 240,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "perf_event_open",
+            "number": 241,
+            "signature": [
+                "struct perf_event_attr *attr_uptr",
+                "pid_t pid",
+                "int cpu",
+                "int group_fd",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "accept4",
+            "number": 242,
+            "signature": [
+                "int fd",
+                "struct sockaddr *upeer_sockaddr",
+                "int *upeer_addrlen",
+                "int flags"
+            ]
+        },
+        {
+            "name": "recvmmsg",
+            "number": 243,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "wait4",
+            "number": 260,
+            "signature": [
+                "pid_t upid",
+                "int *stat_addr",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "prlimit64",
+            "number": 261,
+            "signature": [
+                "pid_t pid",
+                "unsigned int resource",
+                "const struct rlimit64 *new_rlim",
+                "struct rlimit64 *old_rlim"
+            ]
+        },
+        {
+            "name": "fanotify_init",
+            "number": 262,
+            "signature": [
+                "unsigned int flags",
+                "unsigned int event_f_flags"
+            ]
+        },
+        {
+            "name": "fanotify_mark",
+            "number": 263,
+            "signature": [
+                "int fanotify_fd",
+                "unsigned int flags",
+                "__u64 mask",
+                "int dfd",
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "name_to_handle_at",
+            "number": 264,
+            "signature": [
+                "int dfd",
+                "const char *name",
+                "struct file_handle *handle",
+                "void *mnt_id",
+                "int flag"
+            ]
+        },
+        {
+            "name": "open_by_handle_at",
+            "number": 265,
+            "signature": [
+                "int mountdirfd",
+                "struct file_handle *handle",
+                "int flags"
+            ]
+        },
+        {
+            "name": "clock_adjtime",
+            "number": 266,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timex *utx"
+            ]
+        },
+        {
+            "name": "syncfs",
+            "number": 267,
+            "signature": [
+                "int fd"
+            ]
+        },
+        {
+            "name": "setns",
+            "number": 268,
+            "signature": [
+                "int fd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "sendmmsg",
+            "number": 269,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "process_vm_readv",
+            "number": 270,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "process_vm_writev",
+            "number": 271,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "kcmp",
+            "number": 272,
+            "signature": [
+                "pid_t pid1",
+                "pid_t pid2",
+                "int type",
+                "unsigned long idx1",
+                "unsigned long idx2"
+            ]
+        },
+        {
+            "name": "finit_module",
+            "number": 273,
+            "signature": [
+                "int fd",
+                "const char *uargs",
+                "int flags"
+            ]
+        },
+        {
+            "name": "sched_setattr",
+            "number": 274,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "sched_getattr",
+            "number": 275,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int usize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "renameat2",
+            "number": 276,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "seccomp",
+            "number": 277,
+            "signature": [
+                "unsigned int op",
+                "unsigned int flags",
+                "void *uargs"
+            ]
+        },
+        {
+            "name": "getrandom",
+            "number": 278,
+            "signature": [
+                "char *ubuf",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "memfd_create",
+            "number": 279,
+            "signature": [
+                "const char *uname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "bpf",
+            "number": 280,
+            "signature": [
+                "int cmd",
+                "union bpf_attr *uattr",
+                "unsigned int size"
+            ]
+        },
+        {
+            "name": "execveat",
+            "number": 281,
+            "signature": [
+                "int fd",
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp",
+                "int flags"
+            ]
+        },
+        {
+            "name": "userfaultfd",
+            "number": 282,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "membarrier",
+            "number": 283,
+            "signature": [
+                "int cmd",
+                "unsigned int flags",
+                "int cpu_id"
+            ]
+        },
+        {
+            "name": "mlock2",
+            "number": 284,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "copy_file_range",
+            "number": 285,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "preadv2",
+            "number": 286,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "pwritev2",
+            "number": 287,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "pkey_mprotect",
+            "number": 288,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long prot",
+                "int pkey"
+            ]
+        },
+        {
+            "name": "pkey_alloc",
+            "number": 289,
+            "signature": [
+                "unsigned long flags",
+                "unsigned long init_val"
+            ]
+        },
+        {
+            "name": "pkey_free",
+            "number": 290,
+            "signature": [
+                "int pkey"
+            ]
+        },
+        {
+            "name": "statx",
+            "number": 291,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags",
+                "unsigned int mask",
+                "struct statx *buffer"
+            ]
+        },
+        {
+            "name": "io_pgetevents",
+            "number": 292,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct __kernel_timespec *timeout",
+                "const struct __aio_sigset *usig"
+            ]
+        },
+        {
+            "name": "rseq",
+            "number": 293,
+            "signature": [
+                "struct rseq *rseq",
+                "u32 rseq_len",
+                "int flags",
+                "u32 sig"
+            ]
+        },
+        {
+            "name": "kexec_file_load",
+            "number": 294,
+            "signature": [
+                "int kernel_fd",
+                "int initrd_fd",
+                "unsigned long cmdline_len",
+                "const char *cmdline_ptr",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "pidfd_send_signal",
+            "number": 424,
+            "signature": [
+                "int pidfd",
+                "int sig",
+                "siginfo_t *info",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "io_uring_setup",
+            "number": 425,
+            "signature": [
+                "u32 entries",
+                "struct io_uring_params *params"
+            ]
+        },
+        {
+            "name": "io_uring_enter",
+            "number": 426,
+            "signature": [
+                "unsigned int fd",
+                "u32 to_submit",
+                "u32 min_complete",
+                "u32 flags",
+                "const void *argp",
+                "size_t argsz"
+            ]
+        },
+        {
+            "name": "io_uring_register",
+            "number": 427,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int opcode",
+                "void *arg",
+                "unsigned int nr_args"
+            ]
+        },
+        {
+            "name": "open_tree",
+            "number": 428,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags"
+            ]
+        },
+        {
+            "name": "move_mount",
+            "number": 429,
+            "signature": [
+                "int from_dfd",
+                "const char *from_pathname",
+                "int to_dfd",
+                "const char *to_pathname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsopen",
+            "number": 430,
+            "signature": [
+                "const char *_fs_name",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsconfig",
+            "number": 431,
+            "signature": [
+                "int fd",
+                "unsigned int cmd",
+                "const char *_key",
+                "const void *_value",
+                "int aux"
+            ]
+        },
+        {
+            "name": "fsmount",
+            "number": 432,
+            "signature": [
+                "int fs_fd",
+                "unsigned int flags",
+                "unsigned int attr_flags"
+            ]
+        },
+        {
+            "name": "fspick",
+            "number": 433,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "pidfd_open",
+            "number": 434,
+            "signature": [
+                "pid_t pid",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "clone3",
+            "number": 435,
+            "signature": [
+                "struct clone_args *uargs",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "close_range",
+            "number": 436,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int max_fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "openat2",
+            "number": 437,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct open_how *how",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "pidfd_getfd",
+            "number": 438,
+            "signature": [
+                "int pidfd",
+                "int fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "faccessat2",
+            "number": 439,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode",
+                "int flags"
+            ]
+        },
+        {
+            "name": "process_madvise",
+            "number": 440,
+            "signature": [
+                "int pidfd",
+                "const struct iovec *vec",
+                "size_t vlen",
+                "int behavior",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "epoll_pwait2",
+            "number": 441,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "const struct __kernel_timespec *timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "mount_setattr",
+            "number": 442,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags",
+                "struct mount_attr *uattr",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "quotactl_fd",
+            "number": 443,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "landlock_create_ruleset",
+            "number": 444,
+            "signature": [
+                "const struct landlock_ruleset_attr *const attr",
+                "const size_t size",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_add_rule",
+            "number": 445,
+            "signature": [
+                "const int ruleset_fd",
+                "const enum landlock_rule_type rule_type",
+                "const void *const rule_attr",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_restrict_self",
+            "number": 446,
+            "signature": [
+                "const int ruleset_fd",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "memfd_secret",
+            "number": 447,
+            "signature": [
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "process_mrelease",
+            "number": 448,
+            "signature": [
+                "int pidfd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_waitv",
+            "number": 449,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int nr_futexes",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "set_mempolicy_home_node",
+            "number": 450,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long home_node",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "cachestat",
+            "number": 451,
+            "signature": [
+                "unsigned int fd",
+                "struct cachestat_range *cstat_range",
+                "struct cachestat *cstat",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fchmodat2",
+            "number": 452,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "map_shadow_stack",
+            "number": 453,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long size",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wake",
+            "number": 454,
+            "signature": [
+                "void *uaddr",
+                "unsigned long mask",
+                "int nr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wait",
+            "number": 455,
+            "signature": [
+                "void *uaddr",
+                "unsigned long val",
+                "unsigned long mask",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "futex_requeue",
+            "number": 456,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int flags",
+                "int nr_wake",
+                "int nr_requeue"
+            ]
+        },
+        {
+            "name": "statmount",
+            "number": 457,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "struct statmount *buf",
+                "size_t bufsize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "listmount",
+            "number": 458,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "u64 *mnt_ids",
+                "size_t nr_mnt_ids",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "lsm_get_self_attr",
+            "number": 459,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_set_self_attr",
+            "number": 460,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_list_modules",
+            "number": 461,
+            "signature": [
+                "u64 *ids",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "mseal",
+            "number": 462,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "setxattrat",
+            "number": 463,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "const struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "getxattrat",
+            "number": 464,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "listxattrat",
+            "number": 465,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattrat",
+            "number": 466,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name"
+            ]
+        }
+    ]
 }

--- a/libdebug/utils/syscall_data/amd64.json
+++ b/libdebug/utils/syscall_data/amd64.json
@@ -1,6483 +1,3199 @@
 {
-	"kernel": {
-		"abi": {
-			"bits": 64,
-			"calling_convention": {
-				"parameters": [
-					"rdi",
-					"rsi",
-					"rdx",
-					"r10",
-					"r8",
-					"r9"
-				],
-				"syscall_nr": "rax"
-			},
-			"compat": false,
-			"name": "x64"
-		},
-		"architecture": {
-			"bits": 64,
-			"name": "x86"
-		},
-		"syscall_table_symbol": "sys_call_table",
-		"version": "v6.14",
-		"version_source": "vmlinux"
-	},
-	"syscalls": [
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 0,
-			"kconfig": null,
-			"line": 715,
-			"name": "read",
-			"number": 0,
-			"origname": "read",
-			"signature": [
-				"unsigned int fd",
-				"char *buf",
-				"size_t count"
-			],
-			"symbol": "__x64_sys_read"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 1,
-			"kconfig": null,
-			"line": 739,
-			"name": "write",
-			"number": 1,
-			"origname": "write",
-			"signature": [
-				"unsigned int fd",
-				"const char *buf",
-				"size_t count"
-			],
-			"symbol": "__x64_sys_write"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 2,
-			"kconfig": null,
-			"line": 1447,
-			"name": "open",
-			"number": 2,
-			"origname": "open",
-			"signature": [
-				"const char *filename",
-				"int flags",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_open"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 3,
-			"kconfig": null,
-			"line": 1565,
-			"name": "close",
-			"number": 3,
-			"origname": "close",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__x64_sys_close"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 4,
-			"kconfig": null,
-			"line": 501,
-			"name": "newstat",
-			"number": 4,
-			"origname": "newstat",
-			"signature": [
-				"const char *filename",
-				"struct stat *statbuf"
-			],
-			"symbol": "__x64_sys_newstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 5,
-			"kconfig": null,
-			"line": 539,
-			"name": "newfstat",
-			"number": 5,
-			"origname": "newfstat",
-			"signature": [
-				"unsigned int fd",
-				"struct stat *statbuf"
-			],
-			"symbol": "__x64_sys_newfstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 6,
-			"kconfig": null,
-			"line": 512,
-			"name": "newlstat",
-			"number": 6,
-			"origname": "newlstat",
-			"signature": [
-				"const char *filename",
-				"struct stat *statbuf"
-			],
-			"symbol": "__x64_sys_newlstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 7,
-			"kconfig": null,
-			"line": 1062,
-			"name": "poll",
-			"number": 7,
-			"origname": "poll",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"int timeout_msecs"
-			],
-			"symbol": "__x64_sys_poll"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 8,
-			"kconfig": null,
-			"line": 403,
-			"name": "lseek",
-			"number": 8,
-			"origname": "lseek",
-			"signature": [
-				"unsigned int fd",
-				"off_t offset",
-				"unsigned int whence"
-			],
-			"symbol": "__x64_sys_lseek"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_x86_64.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 9,
-			"kconfig": null,
-			"line": 82,
-			"name": "mmap",
-			"number": 9,
-			"origname": "mmap",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long len",
-				"unsigned long prot",
-				"unsigned long flags",
-				"unsigned long fd",
-				"unsigned long off"
-			],
-			"symbol": "__x64_sys_mmap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 10,
-			"kconfig": "MMU",
-			"line": 858,
-			"name": "mprotect",
-			"number": 10,
-			"origname": "mprotect",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long prot"
-			],
-			"symbol": "__x64_sys_mprotect"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 11,
-			"kconfig": null,
-			"line": 1081,
-			"name": "munmap",
-			"number": 11,
-			"origname": "munmap",
-			"signature": [
-				"unsigned long addr",
-				"size_t len"
-			],
-			"symbol": "__x64_sys_munmap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 12,
-			"kconfig": null,
-			"line": 115,
-			"name": "brk",
-			"number": 12,
-			"origname": "brk",
-			"signature": [
-				"unsigned long brk"
-			],
-			"symbol": "__x64_sys_brk"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 13,
-			"kconfig": null,
-			"line": 4606,
-			"name": "rt_sigaction",
-			"number": 13,
-			"origname": "rt_sigaction",
-			"signature": [
-				"int sig",
-				"const struct sigaction *act",
-				"struct sigaction *oact",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_rt_sigaction"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 14,
-			"kconfig": null,
-			"line": 3320,
-			"name": "rt_sigprocmask",
-			"number": 14,
-			"origname": "rt_sigprocmask",
-			"signature": [
-				"int how",
-				"sigset_t *nset",
-				"sigset_t *oset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_rt_sigprocmask"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/signal_64.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 15,
-			"kconfig": null,
-			"line": 246,
-			"name": "rt_sigreturn",
-			"number": 15,
-			"origname": "rt_sigreturn",
-			"signature": [],
-			"symbol": "__x64_sys_rt_sigreturn"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/ioctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 16,
-			"kconfig": null,
-			"line": 892,
-			"name": "ioctl",
-			"number": 16,
-			"origname": "ioctl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__x64_sys_ioctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 17,
-			"kconfig": null,
-			"line": 761,
-			"name": "pread64",
-			"number": 17,
-			"origname": "pread64",
-			"signature": [
-				"unsigned int fd",
-				"char *buf",
-				"size_t count",
-				"loff_t pos"
-			],
-			"symbol": "__x64_sys_pread64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 18,
-			"kconfig": null,
-			"line": 791,
-			"name": "pwrite64",
-			"number": 18,
-			"origname": "pwrite64",
-			"signature": [
-				"unsigned int fd",
-				"const char *buf",
-				"size_t count",
-				"loff_t pos"
-			],
-			"symbol": "__x64_sys_pwrite64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 19,
-			"kconfig": null,
-			"line": 1155,
-			"name": "readv",
-			"number": 19,
-			"origname": "readv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__x64_sys_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 20,
-			"kconfig": null,
-			"line": 1161,
-			"name": "writev",
-			"number": 20,
-			"origname": "writev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__x64_sys_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 21,
-			"kconfig": null,
-			"line": 546,
-			"name": "access",
-			"number": 21,
-			"origname": "access",
-			"signature": [
-				"const char *filename",
-				"int mode"
-			],
-			"symbol": "__x64_sys_access"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/pipe.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 22,
-			"kconfig": null,
-			"line": 1048,
-			"name": "pipe",
-			"number": 22,
-			"origname": "pipe",
-			"signature": [
-				"int *fildes"
-			],
-			"symbol": "__x64_sys_pipe"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 23,
-			"kconfig": null,
-			"line": 722,
-			"name": "select",
-			"number": 23,
-			"origname": "select",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct __kernel_old_timeval *tvp"
-			],
-			"symbol": "__x64_sys_select"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 24,
-			"kconfig": null,
-			"line": 1377,
-			"name": "sched_yield",
-			"number": 24,
-			"origname": "sched_yield",
-			"signature": [],
-			"symbol": "__x64_sys_sched_yield"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mremap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 25,
-			"kconfig": null,
-			"line": 1045,
-			"name": "mremap",
-			"number": 25,
-			"origname": "mremap",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long old_len",
-				"unsigned long new_len",
-				"unsigned long flags",
-				"unsigned long new_addr"
-			],
-			"symbol": "__x64_sys_mremap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/msync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 26,
-			"kconfig": "MMU",
-			"line": 32,
-			"name": "msync",
-			"number": 26,
-			"origname": "msync",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__x64_sys_msync"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mincore.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 27,
-			"kconfig": "MMU",
-			"line": 232,
-			"name": "mincore",
-			"number": 27,
-			"origname": "mincore",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned char *vec"
-			],
-			"symbol": "__x64_sys_mincore"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 28,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1712,
-			"name": "madvise",
-			"number": 28,
-			"origname": "madvise",
-			"signature": [
-				"unsigned long start",
-				"size_t len_in",
-				"int behavior"
-			],
-			"symbol": "__x64_sys_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 29,
-			"kconfig": "SYSVIPC",
-			"line": 842,
-			"name": "shmget",
-			"number": 29,
-			"origname": "shmget",
-			"signature": [
-				"key_t key",
-				"size_t size",
-				"int shmflg"
-			],
-			"symbol": "__x64_sys_shmget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 30,
-			"kconfig": "SYSVIPC",
-			"line": 1688,
-			"name": "shmat",
-			"number": 30,
-			"origname": "shmat",
-			"signature": [
-				"int shmid",
-				"char *shmaddr",
-				"int shmflg"
-			],
-			"symbol": "__x64_sys_shmat"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 31,
-			"kconfig": "SYSVIPC",
-			"line": 1291,
-			"name": "shmctl",
-			"number": 31,
-			"origname": "shmctl",
-			"signature": [
-				"int shmid",
-				"int cmd",
-				"struct shmid_ds *buf"
-			],
-			"symbol": "__x64_sys_shmctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 32,
-			"kconfig": null,
-			"line": 1394,
-			"name": "dup",
-			"number": 32,
-			"origname": "dup",
-			"signature": [
-				"unsigned int fildes"
-			],
-			"symbol": "__x64_sys_dup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 33,
-			"kconfig": null,
-			"line": 1375,
-			"name": "dup2",
-			"number": 33,
-			"origname": "dup2",
-			"signature": [
-				"unsigned int oldfd",
-				"unsigned int newfd"
-			],
-			"symbol": "__x64_sys_dup2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 34,
-			"kconfig": null,
-			"line": 4799,
-			"name": "pause",
-			"number": 34,
-			"origname": "pause",
-			"signature": [],
-			"symbol": "__x64_sys_pause"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/hrtimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 35,
-			"kconfig": null,
-			"line": 2209,
-			"name": "nanosleep",
-			"number": 35,
-			"origname": "nanosleep",
-			"signature": [
-				"struct __kernel_timespec *rqtp",
-				"struct __kernel_timespec *rmtp"
-			],
-			"symbol": "__x64_sys_nanosleep"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 36,
-			"kconfig": null,
-			"line": 113,
-			"name": "getitimer",
-			"number": 36,
-			"origname": "getitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value"
-			],
-			"symbol": "__x64_sys_getitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 37,
-			"kconfig": null,
-			"line": 326,
-			"name": "alarm",
-			"number": 37,
-			"origname": "alarm",
-			"signature": [
-				"unsigned int seconds"
-			],
-			"symbol": "__x64_sys_alarm"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 38,
-			"kconfig": null,
-			"line": 352,
-			"name": "setitimer",
-			"number": 38,
-			"origname": "setitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value",
-				"struct __kernel_old_itimerval *ovalue"
-			],
-			"symbol": "__x64_sys_setitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 39,
-			"kconfig": null,
-			"line": 969,
-			"name": "getpid",
-			"number": 39,
-			"origname": "getpid",
-			"signature": [],
-			"symbol": "__x64_sys_getpid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 40,
-			"kconfig": null,
-			"line": 1410,
-			"name": "sendfile64",
-			"number": 40,
-			"origname": "sendfile64",
-			"signature": [
-				"int out_fd",
-				"int in_fd",
-				"loff_t *offset",
-				"size_t count"
-			],
-			"symbol": "__x64_sys_sendfile64"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 41,
-			"kconfig": "NET",
-			"line": 1702,
-			"name": "socket",
-			"number": 41,
-			"origname": "socket",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol"
-			],
-			"symbol": "__x64_sys_socket"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 42,
-			"kconfig": "NET",
-			"line": 2067,
-			"name": "connect",
-			"number": 42,
-			"origname": "connect",
-			"signature": [
-				"int fd",
-				"struct sockaddr *uservaddr",
-				"int addrlen"
-			],
-			"symbol": "__x64_sys_connect"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 43,
-			"kconfig": "NET",
-			"line": 2010,
-			"name": "accept",
-			"number": 43,
-			"origname": "accept",
-			"signature": [
-				"int fd",
-				"struct sockaddr *upeer_sockaddr",
-				"int *upeer_addrlen"
-			],
-			"symbol": "__x64_sys_accept"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 44,
-			"kconfig": "NET",
-			"line": 2190,
-			"name": "sendto",
-			"number": 44,
-			"origname": "sendto",
-			"signature": [
-				"int fd",
-				"void *buff",
-				"size_t len",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int addr_len"
-			],
-			"symbol": "__x64_sys_sendto"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 45,
-			"kconfig": "NET",
-			"line": 2248,
-			"name": "recvfrom",
-			"number": 45,
-			"origname": "recvfrom",
-			"signature": [
-				"int fd",
-				"void *ubuf",
-				"size_t size",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int *addr_len"
-			],
-			"symbol": "__x64_sys_recvfrom"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 46,
-			"kconfig": "NET",
-			"line": 2662,
-			"name": "sendmsg",
-			"number": 46,
-			"origname": "sendmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_sendmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 47,
-			"kconfig": "NET",
-			"line": 2871,
-			"name": "recvmsg",
-			"number": 47,
-			"origname": "recvmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_recvmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 48,
-			"kconfig": "NET",
-			"line": 2432,
-			"name": "shutdown",
-			"number": 48,
-			"origname": "shutdown",
-			"signature": [
-				"int fd",
-				"int how"
-			],
-			"symbol": "__x64_sys_shutdown"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 49,
-			"kconfig": "NET",
-			"line": 1851,
-			"name": "bind",
-			"number": 49,
-			"origname": "bind",
-			"signature": [
-				"int fd",
-				"struct sockaddr *umyaddr",
-				"int addrlen"
-			],
-			"symbol": "__x64_sys_bind"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 50,
-			"kconfig": "NET",
-			"line": 1889,
-			"name": "listen",
-			"number": 50,
-			"origname": "listen",
-			"signature": [
-				"int fd",
-				"int backlog"
-			],
-			"symbol": "__x64_sys_listen"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 51,
-			"kconfig": "NET",
-			"line": 2104,
-			"name": "getsockname",
-			"number": 51,
-			"origname": "getsockname",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__x64_sys_getsockname"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 52,
-			"kconfig": "NET",
-			"line": 2141,
-			"name": "getpeername",
-			"number": 52,
-			"origname": "getpeername",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__x64_sys_getpeername"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 53,
-			"kconfig": "NET",
-			"line": 1803,
-			"name": "socketpair",
-			"number": 53,
-			"origname": "socketpair",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol",
-				"int *usockvec"
-			],
-			"symbol": "__x64_sys_socketpair"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 54,
-			"kconfig": "NET",
-			"line": 2331,
-			"name": "setsockopt",
-			"number": 54,
-			"origname": "setsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int optlen"
-			],
-			"symbol": "__x64_sys_setsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 55,
-			"kconfig": "NET",
-			"line": 2397,
-			"name": "getsockopt",
-			"number": 55,
-			"origname": "getsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int *optlen"
-			],
-			"symbol": "__x64_sys_getsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 56,
-			"kconfig": null,
-			"line": 2942,
-			"name": "clone",
-			"number": 56,
-			"origname": "clone",
-			"signature": [
-				"unsigned long clone_flags",
-				"unsigned long newsp",
-				"int *parent_tidptr",
-				"int *child_tidptr",
-				"unsigned long tls"
-			],
-			"symbol": "__x64_sys_clone"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 57,
-			"kconfig": "MMU",
-			"line": 2897,
-			"name": "fork",
-			"number": 57,
-			"origname": "fork",
-			"signature": [],
-			"symbol": "__x64_sys_fork"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 58,
-			"kconfig": null,
-			"line": 2913,
-			"name": "vfork",
-			"number": 58,
-			"origname": "vfork",
-			"signature": [],
-			"symbol": "__x64_sys_vfork"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 59,
-			"kconfig": null,
-			"line": 2111,
-			"name": "execve",
-			"number": 59,
-			"origname": "execve",
-			"signature": [
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp"
-			],
-			"symbol": "__x64_sys_execve"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 60,
-			"kconfig": null,
-			"line": 1052,
-			"name": "exit",
-			"number": 60,
-			"origname": "exit",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__x64_sys_exit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 61,
-			"kconfig": null,
-			"line": 1874,
-			"name": "wait4",
-			"number": 61,
-			"origname": "wait4",
-			"signature": [
-				"pid_t upid",
-				"int *stat_addr",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__x64_sys_wait4"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 62,
-			"kconfig": null,
-			"line": 3951,
-			"name": "kill",
-			"number": 62,
-			"origname": "kill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__x64_sys_kill"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 63,
-			"kconfig": null,
-			"line": 1317,
-			"name": "newuname",
-			"number": 63,
-			"origname": "newuname",
-			"signature": [
-				"struct new_utsname *name"
-			],
-			"symbol": "__x64_sys_newuname"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 64,
-			"kconfig": "SYSVIPC",
-			"line": 624,
-			"name": "semget",
-			"number": 64,
-			"origname": "semget",
-			"signature": [
-				"key_t key",
-				"int nsems",
-				"int semflg"
-			],
-			"symbol": "__x64_sys_semget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 65,
-			"kconfig": "SYSVIPC",
-			"line": 2296,
-			"name": "semop",
-			"number": 65,
-			"origname": "semop",
-			"signature": [
-				"int semid",
-				"struct sembuf *tsops",
-				"unsigned nsops"
-			],
-			"symbol": "__x64_sys_semop"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 66,
-			"kconfig": "SYSVIPC",
-			"line": 1705,
-			"name": "semctl",
-			"number": 66,
-			"origname": "semctl",
-			"signature": [
-				"int semid",
-				"int semnum",
-				"int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__x64_sys_semctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 67,
-			"kconfig": "SYSVIPC",
-			"line": 1829,
-			"name": "shmdt",
-			"number": 67,
-			"origname": "shmdt",
-			"signature": [
-				"char *shmaddr"
-			],
-			"symbol": "__x64_sys_shmdt"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 68,
-			"kconfig": "SYSVIPC",
-			"line": 315,
-			"name": "msgget",
-			"number": 68,
-			"origname": "msgget",
-			"signature": [
-				"key_t key",
-				"int msgflg"
-			],
-			"symbol": "__x64_sys_msgget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 69,
-			"kconfig": "SYSVIPC",
-			"line": 971,
-			"name": "msgsnd",
-			"number": 69,
-			"origname": "msgsnd",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"int msgflg"
-			],
-			"symbol": "__x64_sys_msgsnd"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 70,
-			"kconfig": "SYSVIPC",
-			"line": 1270,
-			"name": "msgrcv",
-			"number": 70,
-			"origname": "msgrcv",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"long msgtyp",
-				"int msgflg"
-			],
-			"symbol": "__x64_sys_msgrcv"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 71,
-			"kconfig": "SYSVIPC",
-			"line": 640,
-			"name": "msgctl",
-			"number": 71,
-			"origname": "msgctl",
-			"signature": [
-				"int msqid",
-				"int cmd",
-				"struct msqid_ds *buf"
-			],
-			"symbol": "__x64_sys_msgctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fcntl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 72,
-			"kconfig": null,
-			"line": 576,
-			"name": "fcntl",
-			"number": 72,
-			"origname": "fcntl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__x64_sys_fcntl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/locks.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 73,
-			"kconfig": null,
-			"line": 2135,
-			"name": "flock",
-			"number": 73,
-			"origname": "flock",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd"
-			],
-			"symbol": "__x64_sys_flock"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 74,
-			"kconfig": null,
-			"line": 215,
-			"name": "fsync",
-			"number": 74,
-			"origname": "fsync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__x64_sys_fsync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 75,
-			"kconfig": null,
-			"line": 220,
-			"name": "fdatasync",
-			"number": 75,
-			"origname": "fdatasync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__x64_sys_fdatasync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 76,
-			"kconfig": null,
-			"line": 148,
-			"name": "truncate",
-			"number": 76,
-			"origname": "truncate",
-			"signature": [
-				"const char *path",
-				"long length"
-			],
-			"symbol": "__x64_sys_truncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 77,
-			"kconfig": null,
-			"line": 210,
-			"name": "ftruncate",
-			"number": 77,
-			"origname": "ftruncate",
-			"signature": [
-				"unsigned int fd",
-				"off_t length"
-			],
-			"symbol": "__x64_sys_ftruncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 78,
-			"kconfig": null,
-			"line": 308,
-			"name": "getdents",
-			"number": 78,
-			"origname": "getdents",
-			"signature": [
-				"unsigned int fd",
-				"struct linux_dirent *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__x64_sys_getdents"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/d_path.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 79,
-			"kconfig": null,
-			"line": 412,
-			"name": "getcwd",
-			"number": 79,
-			"origname": "getcwd",
-			"signature": [
-				"char *buf",
-				"unsigned long size"
-			],
-			"symbol": "__x64_sys_getcwd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 80,
-			"kconfig": null,
-			"line": 551,
-			"name": "chdir",
-			"number": 80,
-			"origname": "chdir",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__x64_sys_chdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 81,
-			"kconfig": null,
-			"line": 577,
-			"name": "fchdir",
-			"number": 81,
-			"origname": "fchdir",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__x64_sys_fchdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 82,
-			"kconfig": null,
-			"line": 5271,
-			"name": "rename",
-			"number": 82,
-			"origname": "rename",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__x64_sys_rename"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 83,
-			"kconfig": null,
-			"line": 4354,
-			"name": "mkdir",
-			"number": 83,
-			"origname": "mkdir",
-			"signature": [
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_mkdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 84,
-			"kconfig": null,
-			"line": 4472,
-			"name": "rmdir",
-			"number": 84,
-			"origname": "rmdir",
-			"signature": [
-				"const char *pathname"
-			],
-			"symbol": "__x64_sys_rmdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 85,
-			"kconfig": null,
-			"line": 1515,
-			"name": "creat",
-			"number": 85,
-			"origname": "creat",
-			"signature": [
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_creat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 86,
-			"kconfig": null,
-			"line": 4897,
-			"name": "link",
-			"number": 86,
-			"origname": "link",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__x64_sys_link"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 87,
-			"kconfig": null,
-			"line": 4635,
-			"name": "unlink",
-			"number": 87,
-			"origname": "unlink",
-			"signature": [
-				"const char *pathname"
-			],
-			"symbol": "__x64_sys_unlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 88,
-			"kconfig": null,
-			"line": 4716,
-			"name": "symlink",
-			"number": 88,
-			"origname": "symlink",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__x64_sys_symlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 89,
-			"kconfig": null,
-			"line": 598,
-			"name": "readlink",
-			"number": 89,
-			"origname": "readlink",
-			"signature": [
-				"const char *path",
-				"char *buf",
-				"int bufsiz"
-			],
-			"symbol": "__x64_sys_readlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 90,
-			"kconfig": null,
-			"line": 712,
-			"name": "chmod",
-			"number": 90,
-			"origname": "chmod",
-			"signature": [
-				"const char *filename",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_chmod"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 91,
-			"kconfig": null,
-			"line": 663,
-			"name": "fchmod",
-			"number": 91,
-			"origname": "fchmod",
-			"signature": [
-				"unsigned int fd",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_fchmod"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 92,
-			"kconfig": null,
-			"line": 831,
-			"name": "chown",
-			"number": 92,
-			"origname": "chown",
-			"signature": [
-				"const char *filename",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__x64_sys_chown"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 93,
-			"kconfig": null,
-			"line": 865,
-			"name": "fchown",
-			"number": 93,
-			"origname": "fchown",
-			"signature": [
-				"unsigned int fd",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__x64_sys_fchown"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 94,
-			"kconfig": null,
-			"line": 836,
-			"name": "lchown",
-			"number": 94,
-			"origname": "lchown",
-			"signature": [
-				"const char *filename",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__x64_sys_lchown"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 95,
-			"kconfig": null,
-			"line": 1908,
-			"name": "umask",
-			"number": 95,
-			"origname": "umask",
-			"signature": [
-				"int mask"
-			],
-			"symbol": "__x64_sys_umask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 96,
-			"kconfig": null,
-			"line": 140,
-			"name": "gettimeofday",
-			"number": 96,
-			"origname": "gettimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__x64_sys_gettimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 97,
-			"kconfig": null,
-			"line": 1529,
-			"name": "getrlimit",
-			"number": 97,
-			"origname": "getrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__x64_sys_getrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 98,
-			"kconfig": null,
-			"line": 1882,
-			"name": "getrusage",
-			"number": 98,
-			"origname": "getrusage",
-			"signature": [
-				"int who",
-				"struct rusage *ru"
-			],
-			"symbol": "__x64_sys_getrusage"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 99,
-			"kconfig": null,
-			"line": 2902,
-			"name": "sysinfo",
-			"number": 99,
-			"origname": "sysinfo",
-			"signature": [
-				"struct sysinfo *info"
-			],
-			"symbol": "__x64_sys_sysinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 100,
-			"kconfig": null,
-			"line": 1034,
-			"name": "times",
-			"number": 100,
-			"origname": "times",
-			"signature": [
-				"struct tms *tbuf"
-			],
-			"symbol": "__x64_sys_times"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/ptrace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 101,
-			"kconfig": null,
-			"line": 1258,
-			"name": "ptrace",
-			"number": 101,
-			"origname": "ptrace",
-			"signature": [
-				"long request",
-				"long pid",
-				"unsigned long addr",
-				"unsigned long data"
-			],
-			"symbol": "__x64_sys_ptrace"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 102,
-			"kconfig": null,
-			"line": 997,
-			"name": "getuid",
-			"number": 102,
-			"origname": "getuid",
-			"signature": [],
-			"symbol": "__x64_sys_getuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/printk/printk.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 103,
-			"kconfig": null,
-			"line": 1875,
-			"name": "syslog",
-			"number": 103,
-			"origname": "syslog",
-			"signature": [
-				"int type",
-				"char *buf",
-				"int len"
-			],
-			"symbol": "__x64_sys_syslog"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 104,
-			"kconfig": null,
-			"line": 1009,
-			"name": "getgid",
-			"number": 104,
-			"origname": "getgid",
-			"signature": [],
-			"symbol": "__x64_sys_getgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 105,
-			"kconfig": "MULTIUSER",
-			"line": 668,
-			"name": "setuid",
-			"number": 105,
-			"origname": "setuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__x64_sys_setuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 106,
-			"kconfig": "MULTIUSER",
-			"line": 485,
-			"name": "setgid",
-			"number": 106,
-			"origname": "setgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__x64_sys_setgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 107,
-			"kconfig": null,
-			"line": 1003,
-			"name": "geteuid",
-			"number": 107,
-			"origname": "geteuid",
-			"signature": [],
-			"symbol": "__x64_sys_geteuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 108,
-			"kconfig": null,
-			"line": 1015,
-			"name": "getegid",
-			"number": 108,
-			"origname": "getegid",
-			"signature": [],
-			"symbol": "__x64_sys_getegid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 109,
-			"kconfig": null,
-			"line": 1084,
-			"name": "setpgid",
-			"number": 109,
-			"origname": "setpgid",
-			"signature": [
-				"pid_t pid",
-				"pid_t pgid"
-			],
-			"symbol": "__x64_sys_setpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 110,
-			"kconfig": null,
-			"line": 986,
-			"name": "getppid",
-			"number": 110,
-			"origname": "getppid",
-			"signature": [],
-			"symbol": "__x64_sys_getppid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 111,
-			"kconfig": null,
-			"line": 1190,
-			"name": "getpgrp",
-			"number": 111,
-			"origname": "getpgrp",
-			"signature": [],
-			"symbol": "__x64_sys_getpgrp"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 112,
-			"kconfig": null,
-			"line": 1269,
-			"name": "setsid",
-			"number": 112,
-			"origname": "setsid",
-			"signature": [],
-			"symbol": "__x64_sys_setsid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 113,
-			"kconfig": "MULTIUSER",
-			"line": 605,
-			"name": "setreuid",
-			"number": 113,
-			"origname": "setreuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid"
-			],
-			"symbol": "__x64_sys_setreuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 114,
-			"kconfig": "MULTIUSER",
-			"line": 439,
-			"name": "setregid",
-			"number": 114,
-			"origname": "setregid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid"
-			],
-			"symbol": "__x64_sys_setregid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 115,
-			"kconfig": "MULTIUSER",
-			"line": 161,
-			"name": "getgroups",
-			"number": 115,
-			"origname": "getgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__x64_sys_getgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 116,
-			"kconfig": "MULTIUSER",
-			"line": 198,
-			"name": "setgroups",
-			"number": 116,
-			"origname": "setgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__x64_sys_setgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 117,
-			"kconfig": "MULTIUSER",
-			"line": 753,
-			"name": "setresuid",
-			"number": 117,
-			"origname": "setresuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid",
-				"uid_t suid"
-			],
-			"symbol": "__x64_sys_setresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 118,
-			"kconfig": "MULTIUSER",
-			"line": 758,
-			"name": "getresuid",
-			"number": 118,
-			"origname": "getresuid",
-			"signature": [
-				"uid_t *ruidp",
-				"uid_t *euidp",
-				"uid_t *suidp"
-			],
-			"symbol": "__x64_sys_getresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 119,
-			"kconfig": "MULTIUSER",
-			"line": 842,
-			"name": "setresgid",
-			"number": 119,
-			"origname": "setresgid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid",
-				"gid_t sgid"
-			],
-			"symbol": "__x64_sys_setresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 120,
-			"kconfig": "MULTIUSER",
-			"line": 847,
-			"name": "getresgid",
-			"number": 120,
-			"origname": "getresgid",
-			"signature": [
-				"gid_t *rgidp",
-				"gid_t *egidp",
-				"gid_t *sgidp"
-			],
-			"symbol": "__x64_sys_getresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 121,
-			"kconfig": null,
-			"line": 1183,
-			"name": "getpgid",
-			"number": 121,
-			"origname": "getpgid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__x64_sys_getpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 122,
-			"kconfig": "MULTIUSER",
-			"line": 910,
-			"name": "setfsuid",
-			"number": 122,
-			"origname": "setfsuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__x64_sys_setfsuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 123,
-			"kconfig": "MULTIUSER",
-			"line": 954,
-			"name": "setfsgid",
-			"number": 123,
-			"origname": "setfsgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__x64_sys_setfsgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 124,
-			"kconfig": null,
-			"line": 1197,
-			"name": "getsid",
-			"number": 124,
-			"origname": "getsid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__x64_sys_getsid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 125,
-			"kconfig": "MULTIUSER",
-			"line": 137,
-			"name": "capget",
-			"number": 125,
-			"origname": "capget",
-			"signature": [
-				"cap_user_header_t header",
-				"cap_user_data_t dataptr"
-			],
-			"symbol": "__x64_sys_capget"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 126,
-			"kconfig": "MULTIUSER",
-			"line": 216,
-			"name": "capset",
-			"number": 126,
-			"origname": "capset",
-			"signature": [
-				"cap_user_header_t header",
-				"const cap_user_data_t data"
-			],
-			"symbol": "__x64_sys_capset"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 127,
-			"kconfig": null,
-			"line": 3392,
-			"name": "rt_sigpending",
-			"number": 127,
-			"origname": "rt_sigpending",
-			"signature": [
-				"sigset_t *uset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_rt_sigpending"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 128,
-			"kconfig": null,
-			"line": 3806,
-			"name": "rt_sigtimedwait",
-			"number": 128,
-			"origname": "rt_sigtimedwait",
-			"signature": [
-				"const sigset_t *uthese",
-				"siginfo_t *uinfo",
-				"const struct __kernel_timespec *uts",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_rt_sigtimedwait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 129,
-			"kconfig": null,
-			"line": 4188,
-			"name": "rt_sigqueueinfo",
-			"number": 129,
-			"origname": "rt_sigqueueinfo",
-			"signature": [
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__x64_sys_rt_sigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 130,
-			"kconfig": null,
-			"line": 4829,
-			"name": "rt_sigsuspend",
-			"number": 130,
-			"origname": "rt_sigsuspend",
-			"signature": [
-				"sigset_t *unewset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_rt_sigsuspend"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 131,
-			"kconfig": null,
-			"line": 4423,
-			"name": "sigaltstack",
-			"number": 131,
-			"origname": "sigaltstack",
-			"signature": [
-				"const stack_t *uss",
-				"stack_t *uoss"
-			],
-			"symbol": "__x64_sys_sigaltstack"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 132,
-			"kconfig": null,
-			"line": 210,
-			"name": "utime",
-			"number": 132,
-			"origname": "utime",
-			"signature": [
-				"char *filename",
-				"struct utimbuf *times"
-			],
-			"symbol": "__x64_sys_utime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 133,
-			"kconfig": null,
-			"line": 4272,
-			"name": "mknod",
-			"number": 133,
-			"origname": "mknod",
-			"signature": [
-				"const char *filename",
-				"umode_t mode",
-				"unsigned dev"
-			],
-			"symbol": "__x64_sys_mknod"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exec_domain.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 135,
-			"kconfig": null,
-			"line": 38,
-			"name": "personality",
-			"number": 135,
-			"origname": "personality",
-			"signature": [
-				"unsigned int personality"
-			],
-			"symbol": "__x64_sys_personality"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 136,
-			"kconfig": null,
-			"line": 246,
-			"name": "ustat",
-			"number": 136,
-			"origname": "ustat",
-			"signature": [
-				"unsigned dev",
-				"struct ustat *ubuf"
-			],
-			"symbol": "__x64_sys_ustat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 137,
-			"kconfig": null,
-			"line": 190,
-			"name": "statfs",
-			"number": 137,
-			"origname": "statfs",
-			"signature": [
-				"const char *pathname",
-				"struct statfs *buf"
-			],
-			"symbol": "__x64_sys_statfs"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 138,
-			"kconfig": null,
-			"line": 211,
-			"name": "fstatfs",
-			"number": 138,
-			"origname": "fstatfs",
-			"signature": [
-				"unsigned int fd",
-				"struct statfs *buf"
-			],
-			"symbol": "__x64_sys_fstatfs"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/filesystems.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 139,
-			"kconfig": "SYSFS_SYSCALL",
-			"line": 191,
-			"name": "sysfs",
-			"number": 139,
-			"origname": "sysfs",
-			"signature": [
-				"int option",
-				"unsigned long arg1",
-				"unsigned long arg2"
-			],
-			"symbol": "__x64_sys_sysfs"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 140,
-			"kconfig": null,
-			"line": 299,
-			"name": "getpriority",
-			"number": 140,
-			"origname": "getpriority",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__x64_sys_getpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 141,
-			"kconfig": null,
-			"line": 229,
-			"name": "setpriority",
-			"number": 141,
-			"origname": "setpriority",
-			"signature": [
-				"int which",
-				"int who",
-				"int niceval"
-			],
-			"symbol": "__x64_sys_setpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 142,
-			"kconfig": null,
-			"line": 970,
-			"name": "sched_setparam",
-			"number": 142,
-			"origname": "sched_setparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__x64_sys_sched_setparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 143,
-			"kconfig": null,
-			"line": 1046,
-			"name": "sched_getparam",
-			"number": 143,
-			"origname": "sched_getparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__x64_sys_sched_getparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 144,
-			"kconfig": null,
-			"line": 955,
-			"name": "sched_setscheduler",
-			"number": 144,
-			"origname": "sched_setscheduler",
-			"signature": [
-				"pid_t pid",
-				"int policy",
-				"struct sched_param *param"
-			],
-			"symbol": "__x64_sys_sched_setscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 145,
-			"kconfig": null,
-			"line": 1016,
-			"name": "sched_getscheduler",
-			"number": 145,
-			"origname": "sched_getscheduler",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__x64_sys_sched_getscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 146,
-			"kconfig": null,
-			"line": 1485,
-			"name": "sched_get_priority_max",
-			"number": 146,
-			"origname": "sched_get_priority_max",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__x64_sys_sched_get_priority_max"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 147,
-			"kconfig": null,
-			"line": 1513,
-			"name": "sched_get_priority_min",
-			"number": 147,
-			"origname": "sched_get_priority_min",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__x64_sys_sched_get_priority_min"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 148,
-			"kconfig": null,
-			"line": 1571,
-			"name": "sched_rr_get_interval",
-			"number": 148,
-			"origname": "sched_rr_get_interval",
-			"signature": [
-				"pid_t pid",
-				"struct __kernel_timespec *interval"
-			],
-			"symbol": "__x64_sys_sched_rr_get_interval"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 149,
-			"kconfig": "MMU",
-			"line": 659,
-			"name": "mlock",
-			"number": 149,
-			"origname": "mlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__x64_sys_mlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 150,
-			"kconfig": "MMU",
-			"line": 677,
-			"name": "munlock",
-			"number": 150,
-			"origname": "munlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__x64_sys_munlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 151,
-			"kconfig": "MMU",
-			"line": 745,
-			"name": "mlockall",
-			"number": 151,
-			"origname": "mlockall",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__x64_sys_mlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 152,
-			"kconfig": "MMU",
-			"line": 774,
-			"name": "munlockall",
-			"number": 152,
-			"origname": "munlockall",
-			"signature": [],
-			"symbol": "__x64_sys_munlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 153,
-			"kconfig": null,
-			"line": 1596,
-			"name": "vhangup",
-			"number": 153,
-			"origname": "vhangup",
-			"signature": [],
-			"symbol": "__x64_sys_vhangup"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ldt.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 154,
-			"kconfig": "MODIFY_LDT_SYSCALL",
-			"line": 667,
-			"name": "modify_ldt",
-			"number": 154,
-			"origname": "modify_ldt",
-			"signature": [
-				"int func",
-				"void *ptr",
-				"unsigned long bytecount"
-			],
-			"symbol": "__x64_sys_modify_ldt"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 155,
-			"kconfig": null,
-			"line": 4388,
-			"name": "pivot_root",
-			"number": 155,
-			"origname": "pivot_root",
-			"signature": [
-				"const char *new_root",
-				"const char *put_old"
-			],
-			"symbol": "__x64_sys_pivot_root"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 157,
-			"kconfig": null,
-			"line": 2469,
-			"name": "prctl",
-			"number": 157,
-			"origname": "prctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__x64_sys_prctl"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/process_64.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 158,
-			"kconfig": null,
-			"line": 983,
-			"name": "arch_prctl",
-			"number": 158,
-			"origname": "arch_prctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2"
-			],
-			"symbol": "__x64_sys_arch_prctl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 159,
-			"kconfig": null,
-			"line": 269,
-			"name": "adjtimex",
-			"number": 159,
-			"origname": "adjtimex",
-			"signature": [
-				"struct __kernel_timex *txc_p"
-			],
-			"symbol": "__x64_sys_adjtimex"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 160,
-			"kconfig": null,
-			"line": 1742,
-			"name": "setrlimit",
-			"number": 160,
-			"origname": "setrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__x64_sys_setrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 161,
-			"kconfig": null,
-			"line": 594,
-			"name": "chroot",
-			"number": 161,
-			"origname": "chroot",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__x64_sys_chroot"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 162,
-			"kconfig": null,
-			"line": 111,
-			"name": "sync",
-			"number": 162,
-			"origname": "sync",
-			"signature": [],
-			"symbol": "__x64_sys_sync"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/acct.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 163,
-			"kconfig": "BSD_PROCESS_ACCT",
-			"line": 314,
-			"name": "acct",
-			"number": 163,
-			"origname": "acct",
-			"signature": [
-				"const char *name"
-			],
-			"symbol": "__x64_sys_acct"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 164,
-			"kconfig": null,
-			"line": 199,
-			"name": "settimeofday",
-			"number": 164,
-			"origname": "settimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__x64_sys_settimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 165,
-			"kconfig": null,
-			"line": 4088,
-			"name": "mount",
-			"number": 165,
-			"origname": "mount",
-			"signature": [
-				"char *dev_name",
-				"char *dir_name",
-				"char *type",
-				"unsigned long flags",
-				"void *data"
-			],
-			"symbol": "__x64_sys_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 166,
-			"kconfig": null,
-			"line": 2077,
-			"name": "umount",
-			"number": 166,
-			"origname": "umount",
-			"signature": [
-				"char *name",
-				"int flags"
-			],
-			"symbol": "__x64_sys_umount"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 167,
-			"kconfig": "SWAP",
-			"line": 3266,
-			"name": "swapon",
-			"number": 167,
-			"origname": "swapon",
-			"signature": [
-				"const char *specialfile",
-				"int swap_flags"
-			],
-			"symbol": "__x64_sys_swapon"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 168,
-			"kconfig": "SWAP",
-			"line": 2652,
-			"name": "swapoff",
-			"number": 168,
-			"origname": "swapoff",
-			"signature": [
-				"const char *specialfile"
-			],
-			"symbol": "__x64_sys_swapoff"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/reboot.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 169,
-			"kconfig": null,
-			"line": 722,
-			"name": "reboot",
-			"number": 169,
-			"origname": "reboot",
-			"signature": [
-				"int magic1",
-				"int magic2",
-				"unsigned int cmd",
-				"void *arg"
-			],
-			"symbol": "__x64_sys_reboot"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 170,
-			"kconfig": null,
-			"line": 1385,
-			"name": "sethostname",
-			"number": 170,
-			"origname": "sethostname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__x64_sys_sethostname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 171,
-			"kconfig": null,
-			"line": 1439,
-			"name": "setdomainname",
-			"number": 171,
-			"origname": "setdomainname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__x64_sys_setdomainname"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ioport.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 172,
-			"kconfig": "X86_IOPL_IOPERM",
-			"line": 173,
-			"name": "iopl",
-			"number": 172,
-			"origname": "iopl",
-			"signature": [
-				"unsigned int level"
-			],
-			"symbol": "__x64_sys_iopl"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ioport.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 173,
-			"kconfig": "X86_IOPL_IOPERM",
-			"line": 152,
-			"name": "ioperm",
-			"number": 173,
-			"origname": "ioperm",
-			"signature": [
-				"unsigned long from",
-				"unsigned long num",
-				"int turn_on"
-			],
-			"symbol": "__x64_sys_ioperm"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 175,
-			"kconfig": "MODULES",
-			"line": 3515,
-			"name": "init_module",
-			"number": 175,
-			"origname": "init_module",
-			"signature": [
-				"void *umod",
-				"unsigned long len",
-				"const char *uargs"
-			],
-			"symbol": "__x64_sys_init_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 176,
-			"kconfig": "MODULE_UNLOAD",
-			"line": 732,
-			"name": "delete_module",
-			"number": 176,
-			"origname": "delete_module",
-			"signature": [
-				"const char *name_user",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_delete_module"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 179,
-			"kconfig": "QUOTACTL",
-			"line": 917,
-			"name": "quotactl",
-			"number": 179,
-			"origname": "quotactl",
-			"signature": [
-				"unsigned int cmd",
-				"const char *special",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__x64_sys_quotactl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 186,
-			"kconfig": null,
-			"line": 975,
-			"name": "gettid",
-			"number": 186,
-			"origname": "gettid",
-			"signature": [],
-			"symbol": "__x64_sys_gettid"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/readahead.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 187,
-			"kconfig": null,
-			"line": 711,
-			"name": "readahead",
-			"number": 187,
-			"origname": "readahead",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"size_t count"
-			],
-			"symbol": "__x64_sys_readahead"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 188,
-			"kconfig": null,
-			"line": 743,
-			"name": "setxattr",
-			"number": 188,
-			"origname": "setxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__x64_sys_setxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 189,
-			"kconfig": null,
-			"line": 750,
-			"name": "lsetxattr",
-			"number": 189,
-			"origname": "lsetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__x64_sys_lsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 190,
-			"kconfig": null,
-			"line": 758,
-			"name": "fsetxattr",
-			"number": 190,
-			"origname": "fsetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__x64_sys_fsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 191,
-			"kconfig": null,
-			"line": 888,
-			"name": "getxattr",
-			"number": 191,
-			"origname": "getxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_getxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 192,
-			"kconfig": null,
-			"line": 894,
-			"name": "lgetxattr",
-			"number": 192,
-			"origname": "lgetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_lgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 193,
-			"kconfig": null,
-			"line": 901,
-			"name": "fgetxattr",
-			"number": 193,
-			"origname": "fgetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_fgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 194,
-			"kconfig": null,
-			"line": 998,
-			"name": "listxattr",
-			"number": 194,
-			"origname": "listxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_listxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 195,
-			"kconfig": null,
-			"line": 1004,
-			"name": "llistxattr",
-			"number": 195,
-			"origname": "llistxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_llistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 196,
-			"kconfig": null,
-			"line": 1010,
-			"name": "flistxattr",
-			"number": 196,
-			"origname": "flistxattr",
-			"signature": [
-				"int fd",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_flistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 197,
-			"kconfig": null,
-			"line": 1097,
-			"name": "removexattr",
-			"number": 197,
-			"origname": "removexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__x64_sys_removexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 198,
-			"kconfig": null,
-			"line": 1103,
-			"name": "lremovexattr",
-			"number": 198,
-			"origname": "lremovexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__x64_sys_lremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 199,
-			"kconfig": null,
-			"line": 1109,
-			"name": "fremovexattr",
-			"number": 199,
-			"origname": "fremovexattr",
-			"signature": [
-				"int fd",
-				"const char *name"
-			],
-			"symbol": "__x64_sys_fremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 200,
-			"kconfig": null,
-			"line": 4160,
-			"name": "tkill",
-			"number": 200,
-			"origname": "tkill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__x64_sys_tkill"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 201,
-			"kconfig": null,
-			"line": 62,
-			"name": "time",
-			"number": 201,
-			"origname": "time",
-			"signature": [
-				"__kernel_old_time_t *tloc"
-			],
-			"symbol": "__x64_sys_time"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 202,
-			"kconfig": "FUTEX",
-			"line": 160,
-			"name": "futex",
-			"number": 202,
-			"origname": "futex",
-			"signature": [
-				"u32 *uaddr",
-				"int op",
-				"u32 val",
-				"const struct __kernel_timespec *utime",
-				"u32 *uaddr2",
-				"u32 val3"
-			],
-			"symbol": "__x64_sys_futex"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 203,
-			"kconfig": null,
-			"line": 1279,
-			"name": "sched_setaffinity",
-			"number": 203,
-			"origname": "sched_setaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__x64_sys_sched_setaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 204,
-			"kconfig": null,
-			"line": 1324,
-			"name": "sched_getaffinity",
-			"number": 204,
-			"origname": "sched_getaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__x64_sys_sched_getaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 206,
-			"kconfig": "AIO",
-			"line": 1382,
-			"name": "io_setup",
-			"number": 206,
-			"origname": "io_setup",
-			"signature": [
-				"unsigned nr_events",
-				"aio_context_t *ctxp"
-			],
-			"symbol": "__x64_sys_io_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 207,
-			"kconfig": "AIO",
-			"line": 1451,
-			"name": "io_destroy",
-			"number": 207,
-			"origname": "io_destroy",
-			"signature": [
-				"aio_context_t ctx"
-			],
-			"symbol": "__x64_sys_io_destroy"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 208,
-			"kconfig": "AIO",
-			"line": 2250,
-			"name": "io_getevents",
-			"number": 208,
-			"origname": "io_getevents",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct __kernel_timespec *timeout"
-			],
-			"symbol": "__x64_sys_io_getevents"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 209,
-			"kconfig": "AIO",
-			"line": 2081,
-			"name": "io_submit",
-			"number": 209,
-			"origname": "io_submit",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long nr",
-				"struct iocb **iocbpp"
-			],
-			"symbol": "__x64_sys_io_submit"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 210,
-			"kconfig": "AIO",
-			"line": 2175,
-			"name": "io_cancel",
-			"number": 210,
-			"origname": "io_cancel",
-			"signature": [
-				"aio_context_t ctx_id",
-				"struct iocb *iocb",
-				"struct io_event *result"
-			],
-			"symbol": "__x64_sys_io_cancel"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 213,
-			"kconfig": "EPOLL",
-			"line": 2256,
-			"name": "epoll_create",
-			"number": 213,
-			"origname": "epoll_create",
-			"signature": [
-				"int size"
-			],
-			"symbol": "__x64_sys_epoll_create"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 216,
-			"kconfig": "MMU",
-			"line": 1091,
-			"name": "remap_file_pages",
-			"number": 216,
-			"origname": "remap_file_pages",
-			"signature": [
-				"unsigned long start",
-				"unsigned long size",
-				"unsigned long prot",
-				"unsigned long pgoff",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_remap_file_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 217,
-			"kconfig": null,
-			"line": 389,
-			"name": "getdents64",
-			"number": 217,
-			"origname": "getdents64",
-			"signature": [
-				"unsigned int fd",
-				"struct linux_dirent64 *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__x64_sys_getdents64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 218,
-			"kconfig": null,
-			"line": 1949,
-			"name": "set_tid_address",
-			"number": 218,
-			"origname": "set_tid_address",
-			"signature": [
-				"int *tidptr"
-			],
-			"symbol": "__x64_sys_set_tid_address"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 219,
-			"kconfig": null,
-			"line": 3177,
-			"name": "restart_syscall",
-			"number": 219,
-			"origname": "restart_syscall",
-			"signature": [],
-			"symbol": "__x64_sys_restart_syscall"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 220,
-			"kconfig": "SYSVIPC",
-			"line": 2268,
-			"name": "semtimedop",
-			"number": 220,
-			"origname": "semtimedop",
-			"signature": [
-				"int semid",
-				"struct sembuf *tsops",
-				"unsigned int nsops",
-				"const struct __kernel_timespec *timeout"
-			],
-			"symbol": "__x64_sys_semtimedop"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/fadvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 221,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 208,
-			"name": "fadvise64",
-			"number": 221,
-			"origname": "fadvise64",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"size_t len",
-				"int advice"
-			],
-			"symbol": "__x64_sys_fadvise64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 222,
-			"kconfig": "POSIX_TIMERS",
-			"line": 480,
-			"name": "timer_create",
-			"number": 222,
-			"origname": "timer_create",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct sigevent *timer_event_spec",
-				"timer_t *created_timer_id"
-			],
-			"symbol": "__x64_sys_timer_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 223,
-			"kconfig": "POSIX_TIMERS",
-			"line": 914,
-			"name": "timer_settime",
-			"number": 223,
-			"origname": "timer_settime",
-			"signature": [
-				"timer_t timer_id",
-				"int flags",
-				"const struct __kernel_itimerspec *new_setting",
-				"struct __kernel_itimerspec *old_setting"
-			],
-			"symbol": "__x64_sys_timer_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 224,
-			"kconfig": "POSIX_TIMERS",
-			"line": 676,
-			"name": "timer_gettime",
-			"number": 224,
-			"origname": "timer_gettime",
-			"signature": [
-				"timer_t timer_id",
-				"struct __kernel_itimerspec *setting"
-			],
-			"symbol": "__x64_sys_timer_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 225,
-			"kconfig": "POSIX_TIMERS",
-			"line": 724,
-			"name": "timer_getoverrun",
-			"number": 225,
-			"origname": "timer_getoverrun",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__x64_sys_timer_getoverrun"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 226,
-			"kconfig": "POSIX_TIMERS",
-			"line": 994,
-			"name": "timer_delete",
-			"number": 226,
-			"origname": "timer_delete",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__x64_sys_timer_delete"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 227,
-			"kconfig": null,
-			"line": 1119,
-			"name": "clock_settime",
-			"number": 227,
-			"origname": "clock_settime",
-			"signature": [
-				"const clockid_t which_clock",
-				"const struct __kernel_timespec *tp"
-			],
-			"symbol": "__x64_sys_clock_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 228,
-			"kconfig": null,
-			"line": 1138,
-			"name": "clock_gettime",
-			"number": 228,
-			"origname": "clock_gettime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__x64_sys_clock_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 229,
-			"kconfig": null,
-			"line": 1258,
-			"name": "clock_getres",
-			"number": 229,
-			"origname": "clock_getres",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__x64_sys_clock_getres"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 230,
-			"kconfig": null,
-			"line": 1379,
-			"name": "clock_nanosleep",
-			"number": 230,
-			"origname": "clock_nanosleep",
-			"signature": [
-				"const clockid_t which_clock",
-				"int flags",
-				"const struct __kernel_timespec *rqtp",
-				"struct __kernel_timespec *rmtp"
-			],
-			"symbol": "__x64_sys_clock_nanosleep"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 231,
-			"kconfig": null,
-			"line": 1096,
-			"name": "exit_group",
-			"number": 231,
-			"origname": "exit_group",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__x64_sys_exit_group"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 232,
-			"kconfig": "EPOLL",
-			"line": 2487,
-			"name": "epoll_wait",
-			"number": 232,
-			"origname": "epoll_wait",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"int timeout"
-			],
-			"symbol": "__x64_sys_epoll_wait"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 233,
-			"kconfig": "EPOLL",
-			"line": 2436,
-			"name": "epoll_ctl",
-			"number": 233,
-			"origname": "epoll_ctl",
-			"signature": [
-				"int epfd",
-				"int op",
-				"int fd",
-				"struct epoll_event *event"
-			],
-			"symbol": "__x64_sys_epoll_ctl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 234,
-			"kconfig": null,
-			"line": 4144,
-			"name": "tgkill",
-			"number": 234,
-			"origname": "tgkill",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__x64_sys_tgkill"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 235,
-			"kconfig": null,
-			"line": 204,
-			"name": "utimes",
-			"number": 235,
-			"origname": "utimes",
-			"signature": [
-				"char *filename",
-				"struct __kernel_old_timeval *utimes"
-			],
-			"symbol": "__x64_sys_utimes"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 237,
-			"kconfig": "NUMA",
-			"line": 1607,
-			"name": "mbind",
-			"number": 237,
-			"origname": "mbind",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_mbind"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 238,
-			"kconfig": "NUMA",
-			"line": 1634,
-			"name": "set_mempolicy",
-			"number": 238,
-			"origname": "set_mempolicy",
-			"signature": [
-				"int mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode"
-			],
-			"symbol": "__x64_sys_set_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 239,
-			"kconfig": "NUMA",
-			"line": 1764,
-			"name": "get_mempolicy",
-			"number": 239,
-			"origname": "get_mempolicy",
-			"signature": [
-				"int *policy",
-				"unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned long addr",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_get_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 240,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 944,
-			"name": "mq_open",
-			"number": 240,
-			"origname": "mq_open",
-			"signature": [
-				"const char *u_name",
-				"int oflag",
-				"umode_t mode",
-				"struct mq_attr *u_attr"
-			],
-			"symbol": "__x64_sys_mq_open"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 241,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 954,
-			"name": "mq_unlink",
-			"number": 241,
-			"origname": "mq_unlink",
-			"signature": [
-				"const char *u_name"
-			],
-			"symbol": "__x64_sys_mq_unlink"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 242,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1258,
-			"name": "mq_timedsend",
-			"number": 242,
-			"origname": "mq_timedsend",
-			"signature": [
-				"mqd_t mqdes",
-				"const char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__x64_sys_mq_timedsend"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 243,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1272,
-			"name": "mq_timedreceive",
-			"number": 243,
-			"origname": "mq_timedreceive",
-			"signature": [
-				"mqd_t mqdes",
-				"char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int *u_msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__x64_sys_mq_timedreceive"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 244,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1400,
-			"name": "mq_notify",
-			"number": 244,
-			"origname": "mq_notify",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct sigevent *u_notification"
-			],
-			"symbol": "__x64_sys_mq_notify"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 245,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1452,
-			"name": "mq_getsetattr",
-			"number": 245,
-			"origname": "mq_getsetattr",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct mq_attr *u_mqstat",
-				"struct mq_attr *u_omqstat"
-			],
-			"symbol": "__x64_sys_mq_getsetattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kexec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 246,
-			"kconfig": "KEXEC",
-			"line": 242,
-			"name": "kexec_load",
-			"number": 246,
-			"origname": "kexec_load",
-			"signature": [
-				"unsigned long entry",
-				"unsigned long nr_segments",
-				"struct kexec_segment *segments",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_kexec_load"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 247,
-			"kconfig": null,
-			"line": 1782,
-			"name": "waitid",
-			"number": 247,
-			"origname": "waitid",
-			"signature": [
-				"int which",
-				"pid_t upid",
-				"struct siginfo *infop",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__x64_sys_waitid"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 248,
-			"kconfig": "KEYS",
-			"line": 74,
-			"name": "add_key",
-			"number": 248,
-			"origname": "add_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const void *_payload",
-				"size_t plen",
-				"key_serial_t ringid"
-			],
-			"symbol": "__x64_sys_add_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 249,
-			"kconfig": "KEYS",
-			"line": 167,
-			"name": "request_key",
-			"number": 249,
-			"origname": "request_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const char *_callout_info",
-				"key_serial_t destringid"
-			],
-			"symbol": "__x64_sys_request_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 250,
-			"kconfig": "KEYS",
-			"line": 1874,
-			"name": "keyctl",
-			"number": 250,
-			"origname": "keyctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__x64_sys_keyctl"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 251,
-			"kconfig": "BLOCK",
-			"line": 69,
-			"name": "ioprio_set",
-			"number": 251,
-			"origname": "ioprio_set",
-			"signature": [
-				"int which",
-				"int who",
-				"int ioprio"
-			],
-			"symbol": "__x64_sys_ioprio_set"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 252,
-			"kconfig": "BLOCK",
-			"line": 184,
-			"name": "ioprio_get",
-			"number": 252,
-			"origname": "ioprio_get",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__x64_sys_ioprio_get"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 253,
-			"kconfig": "INOTIFY_USER",
-			"line": 724,
-			"name": "inotify_init",
-			"number": 253,
-			"origname": "inotify_init",
-			"signature": [],
-			"symbol": "__x64_sys_inotify_init"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 254,
-			"kconfig": "INOTIFY_USER",
-			"line": 729,
-			"name": "inotify_add_watch",
-			"number": 254,
-			"origname": "inotify_add_watch",
-			"signature": [
-				"int fd",
-				"const char *pathname",
-				"u32 mask"
-			],
-			"symbol": "__x64_sys_inotify_add_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 255,
-			"kconfig": "INOTIFY_USER",
-			"line": 786,
-			"name": "inotify_rm_watch",
-			"number": 255,
-			"origname": "inotify_rm_watch",
-			"signature": [
-				"int fd",
-				"__s32 wd"
-			],
-			"symbol": "__x64_sys_inotify_rm_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 256,
-			"kconfig": "MIGRATION",
-			"line": 1727,
-			"name": "migrate_pages",
-			"number": 256,
-			"origname": "migrate_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long maxnode",
-				"const unsigned long *old_nodes",
-				"const unsigned long *new_nodes"
-			],
-			"symbol": "__x64_sys_migrate_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 257,
-			"kconfig": null,
-			"line": 1454,
-			"name": "openat",
-			"number": 257,
-			"origname": "openat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int flags",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_openat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 258,
-			"kconfig": null,
-			"line": 4349,
-			"name": "mkdirat",
-			"number": 258,
-			"origname": "mkdirat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_mkdirat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 259,
-			"kconfig": null,
-			"line": 4266,
-			"name": "mknodat",
-			"number": 259,
-			"origname": "mknodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int dev"
-			],
-			"symbol": "__x64_sys_mknodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 260,
-			"kconfig": null,
-			"line": 825,
-			"name": "fchownat",
-			"number": 260,
-			"origname": "fchownat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"uid_t user",
-				"gid_t group",
-				"int flag"
-			],
-			"symbol": "__x64_sys_fchownat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 261,
-			"kconfig": null,
-			"line": 198,
-			"name": "futimesat",
-			"number": 261,
-			"origname": "futimesat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct __kernel_old_timeval *utimes"
-			],
-			"symbol": "__x64_sys_futimesat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 262,
-			"kconfig": null,
-			"line": 526,
-			"name": "newfstatat",
-			"number": 262,
-			"origname": "newfstatat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct stat *statbuf",
-				"int flag"
-			],
-			"symbol": "__x64_sys_newfstatat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 263,
-			"kconfig": null,
-			"line": 4625,
-			"name": "unlinkat",
-			"number": 263,
-			"origname": "unlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"int flag"
-			],
-			"symbol": "__x64_sys_unlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 264,
-			"kconfig": null,
-			"line": 5264,
-			"name": "renameat",
-			"number": 264,
-			"origname": "renameat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__x64_sys_renameat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 265,
-			"kconfig": null,
-			"line": 4890,
-			"name": "linkat",
-			"number": 265,
-			"origname": "linkat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"int flags"
-			],
-			"symbol": "__x64_sys_linkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 266,
-			"kconfig": null,
-			"line": 4710,
-			"name": "symlinkat",
-			"number": 266,
-			"origname": "symlinkat",
-			"signature": [
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__x64_sys_symlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 267,
-			"kconfig": null,
-			"line": 592,
-			"name": "readlinkat",
-			"number": 267,
-			"origname": "readlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"char *buf",
-				"int bufsiz"
-			],
-			"symbol": "__x64_sys_readlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 268,
-			"kconfig": null,
-			"line": 706,
-			"name": "fchmodat",
-			"number": 268,
-			"origname": "fchmodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode"
-			],
-			"symbol": "__x64_sys_fchmodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 269,
-			"kconfig": null,
-			"line": 535,
-			"name": "faccessat",
-			"number": 269,
-			"origname": "faccessat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode"
-			],
-			"symbol": "__x64_sys_faccessat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 270,
-			"kconfig": null,
-			"line": 793,
-			"name": "pselect6",
-			"number": 270,
-			"origname": "pselect6",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct __kernel_timespec *tsp",
-				"void *sig"
-			],
-			"symbol": "__x64_sys_pselect6"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 271,
-			"kconfig": null,
-			"line": 1095,
-			"name": "ppoll",
-			"number": 271,
-			"origname": "ppoll",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"struct __kernel_timespec *tsp",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_ppoll"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 272,
-			"kconfig": null,
-			"line": 3411,
-			"name": "unshare",
-			"number": 272,
-			"origname": "unshare",
-			"signature": [
-				"unsigned long unshare_flags"
-			],
-			"symbol": "__x64_sys_unshare"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 273,
-			"kconfig": "FUTEX",
-			"line": 28,
-			"name": "set_robust_list",
-			"number": 273,
-			"origname": "set_robust_list",
-			"signature": [
-				"struct robust_list_head *head",
-				"size_t len"
-			],
-			"symbol": "__x64_sys_set_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 274,
-			"kconfig": "FUTEX",
-			"line": 48,
-			"name": "get_robust_list",
-			"number": 274,
-			"origname": "get_robust_list",
-			"signature": [
-				"int pid",
-				"struct robust_list_head **head_ptr",
-				"size_t *len_ptr"
-			],
-			"symbol": "__x64_sys_get_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 275,
-			"kconfig": null,
-			"line": 1621,
-			"name": "splice",
-			"number": 275,
-			"origname": "splice",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_splice"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 276,
-			"kconfig": null,
-			"line": 1988,
-			"name": "tee",
-			"number": 276,
-			"origname": "tee",
-			"signature": [
-				"int fdin",
-				"int fdout",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_tee"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 277,
-			"kconfig": null,
-			"line": 363,
-			"name": "sync_file_range",
-			"number": 277,
-			"origname": "sync_file_range",
-			"signature": [
-				"int fd",
-				"loff_t offset",
-				"loff_t nbytes",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_sync_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 278,
-			"kconfig": null,
-			"line": 1583,
-			"name": "vmsplice",
-			"number": 278,
-			"origname": "vmsplice",
-			"signature": [
-				"int fd",
-				"const struct iovec *uiov",
-				"unsigned long nr_segs",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_vmsplice"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/migrate.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 279,
-			"kconfig": "MIGRATION",
-			"line": 2586,
-			"name": "move_pages",
-			"number": 279,
-			"origname": "move_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long nr_pages",
-				"const void **pages",
-				"const int *nodes",
-				"int *status",
-				"int flags"
-			],
-			"symbol": "__x64_sys_move_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 280,
-			"kconfig": null,
-			"line": 143,
-			"name": "utimensat",
-			"number": 280,
-			"origname": "utimensat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct __kernel_timespec *utimes",
-				"int flags"
-			],
-			"symbol": "__x64_sys_utimensat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 281,
-			"kconfig": "EPOLL",
-			"line": 2521,
-			"name": "epoll_pwait",
-			"number": 281,
-			"origname": "epoll_pwait",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"int timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_epoll_pwait"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/signalfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 282,
-			"kconfig": "SIGNALFD",
-			"line": 319,
-			"name": "signalfd",
-			"number": 282,
-			"origname": "signalfd",
-			"signature": [
-				"int ufd",
-				"sigset_t *user_mask",
-				"size_t sizemask"
-			],
-			"symbol": "__x64_sys_signalfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 283,
-			"kconfig": null,
-			"line": 395,
-			"name": "timerfd_create",
-			"number": 283,
-			"origname": "timerfd_create",
-			"signature": [
-				"int clockid",
-				"int flags"
-			],
-			"symbol": "__x64_sys_timerfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 284,
-			"kconfig": null,
-			"line": 429,
-			"name": "eventfd",
-			"number": 284,
-			"origname": "eventfd",
-			"signature": [
-				"unsigned int count"
-			],
-			"symbol": "__x64_sys_eventfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 285,
-			"kconfig": null,
-			"line": 365,
-			"name": "fallocate",
-			"number": 285,
-			"origname": "fallocate",
-			"signature": [
-				"int fd",
-				"int mode",
-				"loff_t offset",
-				"loff_t len"
-			],
-			"symbol": "__x64_sys_fallocate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 286,
-			"kconfig": null,
-			"line": 560,
-			"name": "timerfd_settime",
-			"number": 286,
-			"origname": "timerfd_settime",
-			"signature": [
-				"int ufd",
-				"int flags",
-				"const struct __kernel_itimerspec *utmr",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__x64_sys_timerfd_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 287,
-			"kconfig": null,
-			"line": 578,
-			"name": "timerfd_gettime",
-			"number": 287,
-			"origname": "timerfd_gettime",
-			"signature": [
-				"int ufd",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__x64_sys_timerfd_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 288,
-			"kconfig": "NET",
-			"line": 2004,
-			"name": "accept4",
-			"number": 288,
-			"origname": "accept4",
-			"signature": [
-				"int fd",
-				"struct sockaddr *upeer_sockaddr",
-				"int *upeer_addrlen",
-				"int flags"
-			],
-			"symbol": "__x64_sys_accept4"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/signalfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 289,
-			"kconfig": "SIGNALFD",
-			"line": 307,
-			"name": "signalfd4",
-			"number": 289,
-			"origname": "signalfd4",
-			"signature": [
-				"int ufd",
-				"sigset_t *user_mask",
-				"size_t sizemask",
-				"int flags"
-			],
-			"symbol": "__x64_sys_signalfd4"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 290,
-			"kconfig": null,
-			"line": 424,
-			"name": "eventfd2",
-			"number": 290,
-			"origname": "eventfd2",
-			"signature": [
-				"unsigned int count",
-				"int flags"
-			],
-			"symbol": "__x64_sys_eventfd2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 291,
-			"kconfig": "EPOLL",
-			"line": 2251,
-			"name": "epoll_create1",
-			"number": 291,
-			"origname": "epoll_create1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__x64_sys_epoll_create1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 292,
-			"kconfig": null,
-			"line": 1370,
-			"name": "dup3",
-			"number": 292,
-			"origname": "dup3",
-			"signature": [
-				"unsigned int oldfd",
-				"unsigned int newfd",
-				"int flags"
-			],
-			"symbol": "__x64_sys_dup3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/pipe.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 293,
-			"kconfig": null,
-			"line": 1043,
-			"name": "pipe2",
-			"number": 293,
-			"origname": "pipe2",
-			"signature": [
-				"int *fildes",
-				"int flags"
-			],
-			"symbol": "__x64_sys_pipe2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 294,
-			"kconfig": "INOTIFY_USER",
-			"line": 719,
-			"name": "inotify_init1",
-			"number": 294,
-			"origname": "inotify_init1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__x64_sys_inotify_init1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 295,
-			"kconfig": null,
-			"line": 1167,
-			"name": "preadv",
-			"number": 295,
-			"origname": "preadv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__x64_sys_preadv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 296,
-			"kconfig": null,
-			"line": 1187,
-			"name": "pwritev",
-			"number": 296,
-			"origname": "pwritev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__x64_sys_pwritev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 297,
-			"kconfig": null,
-			"line": 4228,
-			"name": "rt_tgsigqueueinfo",
-			"number": 297,
-			"origname": "rt_tgsigqueueinfo",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__x64_sys_rt_tgsigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/events/core.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 298,
-			"kconfig": "PERF_EVENTS",
-			"line": 12798,
-			"name": "perf_event_open",
-			"number": 298,
-			"origname": "perf_event_open",
-			"signature": [
-				"struct perf_event_attr *attr_uptr",
-				"pid_t pid",
-				"int cpu",
-				"int group_fd",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_perf_event_open"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 299,
-			"kconfig": "NET",
-			"line": 3020,
-			"name": "recvmmsg",
-			"number": 299,
-			"origname": "recvmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout"
-			],
-			"symbol": "__x64_sys_recvmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 300,
-			"kconfig": "FANOTIFY",
-			"line": 1466,
-			"name": "fanotify_init",
-			"number": 300,
-			"origname": "fanotify_init",
-			"signature": [
-				"unsigned int flags",
-				"unsigned int event_f_flags"
-			],
-			"symbol": "__x64_sys_fanotify_init"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 301,
-			"kconfig": "FANOTIFY",
-			"line": 2003,
-			"name": "fanotify_mark",
-			"number": 301,
-			"origname": "fanotify_mark",
-			"signature": [
-				"int fanotify_fd",
-				"unsigned int flags",
-				"__u64 mask",
-				"int dfd",
-				"const char *pathname"
-			],
-			"symbol": "__x64_sys_fanotify_mark"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 302,
-			"kconfig": null,
-			"line": 1695,
-			"name": "prlimit64",
-			"number": 302,
-			"origname": "prlimit64",
-			"signature": [
-				"pid_t pid",
-				"unsigned int resource",
-				"const struct rlimit64 *new_rlim",
-				"struct rlimit64 *old_rlim"
-			],
-			"symbol": "__x64_sys_prlimit64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 303,
-			"kconfig": "FHANDLE",
-			"line": 129,
-			"name": "name_to_handle_at",
-			"number": 303,
-			"origname": "name_to_handle_at",
-			"signature": [
-				"int dfd",
-				"const char *name",
-				"struct file_handle *handle",
-				"void *mnt_id",
-				"int flag"
-			],
-			"symbol": "__x64_sys_name_to_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 304,
-			"kconfig": "FHANDLE",
-			"line": 434,
-			"name": "open_by_handle_at",
-			"number": 304,
-			"origname": "open_by_handle_at",
-			"signature": [
-				"int mountdirfd",
-				"struct file_handle *handle",
-				"int flags"
-			],
-			"symbol": "__x64_sys_open_by_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 305,
-			"kconfig": null,
-			"line": 1168,
-			"name": "clock_adjtime",
-			"number": 305,
-			"origname": "clock_adjtime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timex *utx"
-			],
-			"symbol": "__x64_sys_clock_adjtime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 306,
-			"kconfig": null,
-			"line": 149,
-			"name": "syncfs",
-			"number": 306,
-			"origname": "syncfs",
-			"signature": [
-				"int fd"
-			],
-			"symbol": "__x64_sys_syncfs"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 307,
-			"kconfig": "NET",
-			"line": 2740,
-			"name": "sendmmsg",
-			"number": 307,
-			"origname": "sendmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_sendmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/nsproxy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 308,
-			"kconfig": null,
-			"line": 546,
-			"name": "setns",
-			"number": 308,
-			"origname": "setns",
-			"signature": [
-				"int fd",
-				"int flags"
-			],
-			"symbol": "__x64_sys_setns"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 309,
-			"kconfig": null,
-			"line": 2822,
-			"name": "getcpu",
-			"number": 309,
-			"origname": "getcpu",
-			"signature": [
-				"unsigned *cpup",
-				"unsigned *nodep",
-				"struct getcpu_cache *unused"
-			],
-			"symbol": "__x64_sys_getcpu"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 310,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 292,
-			"name": "process_vm_readv",
-			"number": 310,
-			"origname": "process_vm_readv",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_process_vm_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 311,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 299,
-			"name": "process_vm_writev",
-			"number": 311,
-			"origname": "process_vm_writev",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_process_vm_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kcmp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 312,
-			"kconfig": "KCMP",
-			"line": 135,
-			"name": "kcmp",
-			"number": 312,
-			"origname": "kcmp",
-			"signature": [
-				"pid_t pid1",
-				"pid_t pid2",
-				"int type",
-				"unsigned long idx1",
-				"unsigned long idx2"
-			],
-			"symbol": "__x64_sys_kcmp"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 313,
-			"kconfig": "MODULES",
-			"line": 3669,
-			"name": "finit_module",
-			"number": 313,
-			"origname": "finit_module",
-			"signature": [
-				"int fd",
-				"const char *uargs",
-				"int flags"
-			],
-			"symbol": "__x64_sys_finit_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 314,
-			"kconfig": null,
-			"line": 981,
-			"name": "sched_setattr",
-			"number": 314,
-			"origname": "sched_setattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_sched_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 315,
-			"kconfig": null,
-			"line": 1081,
-			"name": "sched_getattr",
-			"number": 315,
-			"origname": "sched_getattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int usize",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_sched_getattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 316,
-			"kconfig": null,
-			"line": 5257,
-			"name": "renameat2",
-			"number": 316,
-			"origname": "renameat2",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_renameat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/seccomp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 317,
-			"kconfig": "SECCOMP",
-			"line": 2101,
-			"name": "seccomp",
-			"number": 317,
-			"origname": "seccomp",
-			"signature": [
-				"unsigned int op",
-				"unsigned int flags",
-				"void *uargs"
-			],
-			"symbol": "__x64_sys_seccomp"
-		},
-		{
-			"esoteric": false,
-			"file": "drivers/char/random.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 318,
-			"kconfig": null,
-			"line": 1388,
-			"name": "getrandom",
-			"number": 318,
-			"origname": "getrandom",
-			"signature": [
-				"char *ubuf",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_getrandom"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/memfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 319,
-			"kconfig": "MEMFD_CREATE",
-			"line": 458,
-			"name": "memfd_create",
-			"number": 319,
-			"origname": "memfd_create",
-			"signature": [
-				"const char *uname",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_memfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kexec_file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 320,
-			"kconfig": "KEXEC_FILE",
-			"line": 332,
-			"name": "kexec_file_load",
-			"number": 320,
-			"origname": "kexec_file_load",
-			"signature": [
-				"int kernel_fd",
-				"int initrd_fd",
-				"unsigned long cmdline_len",
-				"const char *cmdline_ptr",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_kexec_file_load"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/bpf/syscall.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 321,
-			"kconfig": "BPF_SYSCALL",
-			"line": 5900,
-			"name": "bpf",
-			"number": 321,
-			"origname": "bpf",
-			"signature": [
-				"int cmd",
-				"union bpf_attr *uattr",
-				"unsigned int size"
-			],
-			"symbol": "__x64_sys_bpf"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 322,
-			"kconfig": null,
-			"line": 2119,
-			"name": "execveat",
-			"number": 322,
-			"origname": "execveat",
-			"signature": [
-				"int fd",
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp",
-				"int flags"
-			],
-			"symbol": "__x64_sys_execveat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/userfaultfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 323,
-			"kconfig": "USERFAULTFD",
-			"line": 2155,
-			"name": "userfaultfd",
-			"number": 323,
-			"origname": "userfaultfd",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__x64_sys_userfaultfd"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/membarrier.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 324,
-			"kconfig": "MEMBARRIER",
-			"line": 625,
-			"name": "membarrier",
-			"number": 324,
-			"origname": "membarrier",
-			"signature": [
-				"int cmd",
-				"unsigned int flags",
-				"int cpu_id"
-			],
-			"symbol": "__x64_sys_membarrier"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 325,
-			"kconfig": "MMU",
-			"line": 664,
-			"name": "mlock2",
-			"number": 325,
-			"origname": "mlock2",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__x64_sys_mlock2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 326,
-			"kconfig": null,
-			"line": 1637,
-			"name": "copy_file_range",
-			"number": 326,
-			"origname": "copy_file_range",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_copy_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 327,
-			"kconfig": null,
-			"line": 1175,
-			"name": "preadv2",
-			"number": 327,
-			"origname": "preadv2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__x64_sys_preadv2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 328,
-			"kconfig": null,
-			"line": 1195,
-			"name": "pwritev2",
-			"number": 328,
-			"origname": "pwritev2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__x64_sys_pwritev2"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 329,
-			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
-			"line": 866,
-			"name": "pkey_mprotect",
-			"number": 329,
-			"origname": "pkey_mprotect",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long prot",
-				"int pkey"
-			],
-			"symbol": "__x64_sys_pkey_mprotect"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 330,
-			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
-			"line": 872,
-			"name": "pkey_alloc",
-			"number": 330,
-			"origname": "pkey_alloc",
-			"signature": [
-				"unsigned long flags",
-				"unsigned long init_val"
-			],
-			"symbol": "__x64_sys_pkey_alloc"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 331,
-			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
-			"line": 902,
-			"name": "pkey_free",
-			"number": 331,
-			"origname": "pkey_free",
-			"signature": [
-				"int pkey"
-			],
-			"symbol": "__x64_sys_pkey_free"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 332,
-			"kconfig": null,
-			"line": 799,
-			"name": "statx",
-			"number": 332,
-			"origname": "statx",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags",
-				"unsigned int mask",
-				"struct statx *buffer"
-			],
-			"symbol": "__x64_sys_statx"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 333,
-			"kconfig": "AIO",
-			"line": 2275,
-			"name": "io_pgetevents",
-			"number": 333,
-			"origname": "io_pgetevents",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct __kernel_timespec *timeout",
-				"const struct __aio_sigset *usig"
-			],
-			"symbol": "__x64_sys_io_pgetevents"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/rseq.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 334,
-			"kconfig": "RSEQ",
-			"line": 452,
-			"name": "rseq",
-			"number": 334,
-			"origname": "rseq",
-			"signature": [
-				"struct rseq *rseq",
-				"u32 rseq_len",
-				"int flags",
-				"u32 sig"
-			],
-			"symbol": "__x64_sys_rseq"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/uprobes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 335,
-			"kconfig": null,
-			"line": 367,
-			"name": "uretprobe",
-			"number": 335,
-			"origname": "uretprobe",
-			"signature": [],
-			"symbol": "__x64_sys_uretprobe"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 424,
-			"kconfig": null,
-			"line": 4026,
-			"name": "pidfd_send_signal",
-			"number": 424,
-			"origname": "pidfd_send_signal",
-			"signature": [
-				"int pidfd",
-				"int sig",
-				"siginfo_t *info",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_pidfd_send_signal"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 425,
-			"kconfig": "IO_URING",
-			"line": 3814,
-			"name": "io_uring_setup",
-			"number": 425,
-			"origname": "io_uring_setup",
-			"signature": [
-				"u32 entries",
-				"struct io_uring_params *params"
-			],
-			"symbol": "__x64_sys_io_uring_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 426,
-			"kconfig": "IO_URING",
-			"line": 3307,
-			"name": "io_uring_enter",
-			"number": 426,
-			"origname": "io_uring_enter",
-			"signature": [
-				"unsigned int fd",
-				"u32 to_submit",
-				"u32 min_complete",
-				"u32 flags",
-				"const void *argp",
-				"size_t argsz"
-			],
-			"symbol": "__x64_sys_io_uring_enter"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/register.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 427,
-			"kconfig": "IO_URING",
-			"line": 896,
-			"name": "io_uring_register",
-			"number": 427,
-			"origname": "io_uring_register",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int opcode",
-				"void *arg",
-				"unsigned int nr_args"
-			],
-			"symbol": "__x64_sys_io_uring_register"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 428,
-			"kconfig": null,
-			"line": 2892,
-			"name": "open_tree",
-			"number": 428,
-			"origname": "open_tree",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags"
-			],
-			"symbol": "__x64_sys_open_tree"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 429,
-			"kconfig": null,
-			"line": 4280,
-			"name": "move_mount",
-			"number": 429,
-			"origname": "move_mount",
-			"signature": [
-				"int from_dfd",
-				"const char *from_pathname",
-				"int to_dfd",
-				"const char *to_pathname",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_move_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 430,
-			"kconfig": null,
-			"line": 114,
-			"name": "fsopen",
-			"number": 430,
-			"origname": "fsopen",
-			"signature": [
-				"const char *_fs_name",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_fsopen"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 431,
-			"kconfig": null,
-			"line": 344,
-			"name": "fsconfig",
-			"number": 431,
-			"origname": "fsconfig",
-			"signature": [
-				"int fd",
-				"unsigned int cmd",
-				"const char *_key",
-				"const void *_value",
-				"int aux"
-			],
-			"symbol": "__x64_sys_fsconfig"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 432,
-			"kconfig": null,
-			"line": 4156,
-			"name": "fsmount",
-			"number": 432,
-			"origname": "fsmount",
-			"signature": [
-				"int fs_fd",
-				"unsigned int flags",
-				"unsigned int attr_flags"
-			],
-			"symbol": "__x64_sys_fsmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 433,
-			"kconfig": null,
-			"line": 157,
-			"name": "fspick",
-			"number": 433,
-			"origname": "fspick",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_fspick"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 434,
-			"kconfig": null,
-			"line": 626,
-			"name": "pidfd_open",
-			"number": 434,
-			"origname": "pidfd_open",
-			"signature": [
-				"pid_t pid",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_pidfd_open"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 435,
-			"kconfig": null,
-			"line": 3098,
-			"name": "clone3",
-			"number": 435,
-			"origname": "clone3",
-			"signature": [
-				"struct clone_args *uargs",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_clone3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 436,
-			"kconfig": null,
-			"line": 769,
-			"name": "close_range",
-			"number": 436,
-			"origname": "close_range",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int max_fd",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_close_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 437,
-			"kconfig": null,
-			"line": 1462,
-			"name": "openat2",
-			"number": 437,
-			"origname": "openat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct open_how *how",
-				"size_t usize"
-			],
-			"symbol": "__x64_sys_openat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 438,
-			"kconfig": null,
-			"line": 854,
-			"name": "pidfd_getfd",
-			"number": 438,
-			"origname": "pidfd_getfd",
-			"signature": [
-				"int pidfd",
-				"int fd",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_pidfd_getfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 439,
-			"kconfig": null,
-			"line": 540,
-			"name": "faccessat2",
-			"number": 439,
-			"origname": "faccessat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode",
-				"int flags"
-			],
-			"symbol": "__x64_sys_faccessat2"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 440,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1756,
-			"name": "process_madvise",
-			"number": 440,
-			"origname": "process_madvise",
-			"signature": [
-				"int pidfd",
-				"const struct iovec *vec",
-				"size_t vlen",
-				"int behavior",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_process_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 441,
-			"kconfig": "EPOLL",
-			"line": 2532,
-			"name": "epoll_pwait2",
-			"number": 441,
-			"origname": "epoll_pwait2",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"const struct __kernel_timespec *timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__x64_sys_epoll_pwait2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 442,
-			"kconfig": null,
-			"line": 4847,
-			"name": "mount_setattr",
-			"number": 442,
-			"origname": "mount_setattr",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags",
-				"struct mount_attr *uattr",
-				"size_t usize"
-			],
-			"symbol": "__x64_sys_mount_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 443,
-			"kconfig": "QUOTACTL",
-			"line": 973,
-			"name": "quotactl_fd",
-			"number": 443,
-			"origname": "quotactl_fd",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__x64_sys_quotactl_fd"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 444,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 180,
-			"name": "landlock_create_ruleset",
-			"number": 444,
-			"origname": "landlock_create_ruleset",
-			"signature": [
-				"const struct landlock_ruleset_attr *const attr",
-				"const size_t size",
-				"const __u32 flags"
-			],
-			"symbol": "__x64_sys_landlock_create_ruleset"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 445,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 398,
-			"name": "landlock_add_rule",
-			"number": 445,
-			"origname": "landlock_add_rule",
-			"signature": [
-				"const int ruleset_fd",
-				"const enum landlock_rule_type rule_type",
-				"const void *const rule_attr",
-				"const __u32 flags"
-			],
-			"symbol": "__x64_sys_landlock_add_rule"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 446,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 451,
-			"name": "landlock_restrict_self",
-			"number": 446,
-			"origname": "landlock_restrict_self",
-			"signature": [
-				"const int ruleset_fd",
-				"const __u32 flags"
-			],
-			"symbol": "__x64_sys_landlock_restrict_self"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/secretmem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 447,
-			"kconfig": "SECRETMEM",
-			"line": 232,
-			"name": "memfd_secret",
-			"number": 447,
-			"origname": "memfd_secret",
-			"signature": [
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_memfd_secret"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/oom_kill.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 448,
-			"kconfig": "MMU",
-			"line": 1204,
-			"name": "process_mrelease",
-			"number": 448,
-			"origname": "process_mrelease",
-			"signature": [
-				"int pidfd",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_process_mrelease"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 449,
-			"kconfig": "FUTEX",
-			"line": 290,
-			"name": "futex_waitv",
-			"number": 449,
-			"origname": "futex_waitv",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int nr_futexes",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__x64_sys_futex_waitv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 450,
-			"kconfig": "NUMA",
-			"line": 1540,
-			"name": "set_mempolicy_home_node",
-			"number": 450,
-			"origname": "set_mempolicy_home_node",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long home_node",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_set_mempolicy_home_node"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/filemap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 451,
-			"kconfig": "CACHESTAT_SYSCALL",
-			"line": 4498,
-			"name": "cachestat",
-			"number": 451,
-			"origname": "cachestat",
-			"signature": [
-				"unsigned int fd",
-				"struct cachestat_range *cstat_range",
-				"struct cachestat *cstat",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_cachestat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 452,
-			"kconfig": null,
-			"line": 700,
-			"name": "fchmodat2",
-			"number": 452,
-			"origname": "fchmodat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_fchmodat2"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/shstk.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 453,
-			"kconfig": "X86_USER_SHADOW_STACK",
-			"line": 505,
-			"name": "map_shadow_stack",
-			"number": 453,
-			"origname": "map_shadow_stack",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long size",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_map_shadow_stack"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 454,
-			"kconfig": "FUTEX",
-			"line": 338,
-			"name": "futex_wake",
-			"number": 454,
-			"origname": "futex_wake",
-			"signature": [
-				"void *uaddr",
-				"unsigned long mask",
-				"int nr",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_futex_wake"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 455,
-			"kconfig": "FUTEX",
-			"line": 370,
-			"name": "futex_wait",
-			"number": 455,
-			"origname": "futex_wait",
-			"signature": [
-				"void *uaddr",
-				"unsigned long val",
-				"unsigned long mask",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__x64_sys_futex_wait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 456,
-			"kconfig": "FUTEX",
-			"line": 414,
-			"name": "futex_requeue",
-			"number": 456,
-			"origname": "futex_requeue",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int flags",
-				"int nr_wake",
-				"int nr_requeue"
-			],
-			"symbol": "__x64_sys_futex_requeue"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 457,
-			"kconfig": null,
-			"line": 5508,
-			"name": "statmount",
-			"number": 457,
-			"origname": "statmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"struct statmount *buf",
-				"size_t bufsize",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_statmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 458,
-			"kconfig": null,
-			"line": 5615,
-			"name": "listmount",
-			"number": 458,
-			"origname": "listmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"u64 *mnt_ids",
-				"size_t nr_mnt_ids",
-				"unsigned int flags"
-			],
-			"symbol": "__x64_sys_listmount"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 459,
-			"kconfig": "SECURITY",
-			"line": 77,
-			"name": "lsm_get_self_attr",
-			"number": 459,
-			"origname": "lsm_get_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__x64_sys_lsm_get_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 460,
-			"kconfig": "SECURITY",
-			"line": 55,
-			"name": "lsm_set_self_attr",
-			"number": 460,
-			"origname": "lsm_set_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 size",
-				"u32 flags"
-			],
-			"symbol": "__x64_sys_lsm_set_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 461,
-			"kconfig": "SECURITY",
-			"line": 96,
-			"name": "lsm_list_modules",
-			"number": 461,
-			"origname": "lsm_list_modules",
-			"signature": [
-				"u64 *ids",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__x64_sys_lsm_list_modules"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mseal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 462,
-			"kconfig": null,
-			"line": 265,
-			"name": "mseal",
-			"number": 462,
-			"origname": "mseal",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long flags"
-			],
-			"symbol": "__x64_sys_mseal"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 463,
-			"kconfig": null,
-			"line": 719,
-			"name": "setxattrat",
-			"number": 463,
-			"origname": "setxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"const struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__x64_sys_setxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 464,
-			"kconfig": null,
-			"line": 863,
-			"name": "getxattrat",
-			"number": 464,
-			"origname": "getxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__x64_sys_getxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 465,
-			"kconfig": null,
-			"line": 991,
-			"name": "listxattrat",
-			"number": 465,
-			"origname": "listxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__x64_sys_listxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 466,
-			"kconfig": null,
-			"line": 1091,
-			"name": "removexattrat",
-			"number": 466,
-			"origname": "removexattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name"
-			],
-			"symbol": "__x64_sys_removexattrat"
-		}
-	],
-	"systrack_version": "0.7"
+    "syscalls": [
+        {
+            "name": "read",
+            "number": 0,
+            "signature": [
+                "unsigned int fd",
+                "char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "write",
+            "number": 1,
+            "signature": [
+                "unsigned int fd",
+                "const char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "open",
+            "number": 2,
+            "signature": [
+                "const char *filename",
+                "int flags",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "close",
+            "number": 3,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "newstat",
+            "number": 4,
+            "signature": [
+                "const char *filename",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "newfstat",
+            "number": 5,
+            "signature": [
+                "unsigned int fd",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "newlstat",
+            "number": 6,
+            "signature": [
+                "const char *filename",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "poll",
+            "number": 7,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "int timeout_msecs"
+            ]
+        },
+        {
+            "name": "lseek",
+            "number": 8,
+            "signature": [
+                "unsigned int fd",
+                "off_t offset",
+                "unsigned int whence"
+            ]
+        },
+        {
+            "name": "mmap",
+            "number": 9,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long len",
+                "unsigned long prot",
+                "unsigned long flags",
+                "unsigned long fd",
+                "unsigned long off"
+            ]
+        },
+        {
+            "name": "mprotect",
+            "number": 10,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long prot"
+            ]
+        },
+        {
+            "name": "munmap",
+            "number": 11,
+            "signature": [
+                "unsigned long addr",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "brk",
+            "number": 12,
+            "signature": [
+                "unsigned long brk"
+            ]
+        },
+        {
+            "name": "rt_sigaction",
+            "number": 13,
+            "signature": [
+                "int sig",
+                "const struct sigaction *act",
+                "struct sigaction *oact",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigprocmask",
+            "number": 14,
+            "signature": [
+                "int how",
+                "sigset_t *nset",
+                "sigset_t *oset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigreturn",
+            "number": 15,
+            "signature": []
+        },
+        {
+            "name": "ioctl",
+            "number": 16,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "pread64",
+            "number": 17,
+            "signature": [
+                "unsigned int fd",
+                "char *buf",
+                "size_t count",
+                "loff_t pos"
+            ]
+        },
+        {
+            "name": "pwrite64",
+            "number": 18,
+            "signature": [
+                "unsigned int fd",
+                "const char *buf",
+                "size_t count",
+                "loff_t pos"
+            ]
+        },
+        {
+            "name": "readv",
+            "number": 19,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "writev",
+            "number": 20,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "access",
+            "number": 21,
+            "signature": [
+                "const char *filename",
+                "int mode"
+            ]
+        },
+        {
+            "name": "pipe",
+            "number": 22,
+            "signature": [
+                "int *fildes"
+            ]
+        },
+        {
+            "name": "select",
+            "number": 23,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct __kernel_old_timeval *tvp"
+            ]
+        },
+        {
+            "name": "sched_yield",
+            "number": 24,
+            "signature": []
+        },
+        {
+            "name": "mremap",
+            "number": 25,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long old_len",
+                "unsigned long new_len",
+                "unsigned long flags",
+                "unsigned long new_addr"
+            ]
+        },
+        {
+            "name": "msync",
+            "number": 26,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "mincore",
+            "number": 27,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned char *vec"
+            ]
+        },
+        {
+            "name": "madvise",
+            "number": 28,
+            "signature": [
+                "unsigned long start",
+                "size_t len_in",
+                "int behavior"
+            ]
+        },
+        {
+            "name": "shmget",
+            "number": 29,
+            "signature": [
+                "key_t key",
+                "size_t size",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmat",
+            "number": 30,
+            "signature": [
+                "int shmid",
+                "char *shmaddr",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmctl",
+            "number": 31,
+            "signature": [
+                "int shmid",
+                "int cmd",
+                "struct shmid_ds *buf"
+            ]
+        },
+        {
+            "name": "dup",
+            "number": 32,
+            "signature": [
+                "unsigned int fildes"
+            ]
+        },
+        {
+            "name": "dup2",
+            "number": 33,
+            "signature": [
+                "unsigned int oldfd",
+                "unsigned int newfd"
+            ]
+        },
+        {
+            "name": "pause",
+            "number": 34,
+            "signature": []
+        },
+        {
+            "name": "nanosleep",
+            "number": 35,
+            "signature": [
+                "struct __kernel_timespec *rqtp",
+                "struct __kernel_timespec *rmtp"
+            ]
+        },
+        {
+            "name": "getitimer",
+            "number": 36,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value"
+            ]
+        },
+        {
+            "name": "alarm",
+            "number": 37,
+            "signature": [
+                "unsigned int seconds"
+            ]
+        },
+        {
+            "name": "setitimer",
+            "number": 38,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value",
+                "struct __kernel_old_itimerval *ovalue"
+            ]
+        },
+        {
+            "name": "getpid",
+            "number": 39,
+            "signature": []
+        },
+        {
+            "name": "sendfile64",
+            "number": 40,
+            "signature": [
+                "int out_fd",
+                "int in_fd",
+                "loff_t *offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "socket",
+            "number": 41,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol"
+            ]
+        },
+        {
+            "name": "connect",
+            "number": 42,
+            "signature": [
+                "int fd",
+                "struct sockaddr *uservaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "accept",
+            "number": 43,
+            "signature": [
+                "int fd",
+                "struct sockaddr *upeer_sockaddr",
+                "int *upeer_addrlen"
+            ]
+        },
+        {
+            "name": "sendto",
+            "number": 44,
+            "signature": [
+                "int fd",
+                "void *buff",
+                "size_t len",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int addr_len"
+            ]
+        },
+        {
+            "name": "recvfrom",
+            "number": 45,
+            "signature": [
+                "int fd",
+                "void *ubuf",
+                "size_t size",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int *addr_len"
+            ]
+        },
+        {
+            "name": "sendmsg",
+            "number": 46,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "recvmsg",
+            "number": 47,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "shutdown",
+            "number": 48,
+            "signature": [
+                "int fd",
+                "int how"
+            ]
+        },
+        {
+            "name": "bind",
+            "number": 49,
+            "signature": [
+                "int fd",
+                "struct sockaddr *umyaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "listen",
+            "number": 50,
+            "signature": [
+                "int fd",
+                "int backlog"
+            ]
+        },
+        {
+            "name": "getsockname",
+            "number": 51,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "getpeername",
+            "number": 52,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "socketpair",
+            "number": 53,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol",
+                "int *usockvec"
+            ]
+        },
+        {
+            "name": "setsockopt",
+            "number": 54,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int optlen"
+            ]
+        },
+        {
+            "name": "getsockopt",
+            "number": 55,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int *optlen"
+            ]
+        },
+        {
+            "name": "clone",
+            "number": 56,
+            "signature": [
+                "unsigned long clone_flags",
+                "unsigned long newsp",
+                "int *parent_tidptr",
+                "int *child_tidptr",
+                "unsigned long tls"
+            ]
+        },
+        {
+            "name": "fork",
+            "number": 57,
+            "signature": []
+        },
+        {
+            "name": "vfork",
+            "number": 58,
+            "signature": []
+        },
+        {
+            "name": "execve",
+            "number": 59,
+            "signature": [
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp"
+            ]
+        },
+        {
+            "name": "exit",
+            "number": 60,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "wait4",
+            "number": 61,
+            "signature": [
+                "pid_t upid",
+                "int *stat_addr",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "kill",
+            "number": 62,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "newuname",
+            "number": 63,
+            "signature": [
+                "struct new_utsname *name"
+            ]
+        },
+        {
+            "name": "semget",
+            "number": 64,
+            "signature": [
+                "key_t key",
+                "int nsems",
+                "int semflg"
+            ]
+        },
+        {
+            "name": "semop",
+            "number": 65,
+            "signature": [
+                "int semid",
+                "struct sembuf *tsops",
+                "unsigned nsops"
+            ]
+        },
+        {
+            "name": "semctl",
+            "number": 66,
+            "signature": [
+                "int semid",
+                "int semnum",
+                "int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "shmdt",
+            "number": 67,
+            "signature": [
+                "char *shmaddr"
+            ]
+        },
+        {
+            "name": "msgget",
+            "number": 68,
+            "signature": [
+                "key_t key",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgsnd",
+            "number": 69,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgrcv",
+            "number": 70,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "long msgtyp",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgctl",
+            "number": 71,
+            "signature": [
+                "int msqid",
+                "int cmd",
+                "struct msqid_ds *buf"
+            ]
+        },
+        {
+            "name": "fcntl",
+            "number": 72,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "flock",
+            "number": 73,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd"
+            ]
+        },
+        {
+            "name": "fsync",
+            "number": 74,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "fdatasync",
+            "number": 75,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "truncate",
+            "number": 76,
+            "signature": [
+                "const char *path",
+                "long length"
+            ]
+        },
+        {
+            "name": "ftruncate",
+            "number": 77,
+            "signature": [
+                "unsigned int fd",
+                "off_t length"
+            ]
+        },
+        {
+            "name": "getdents",
+            "number": 78,
+            "signature": [
+                "unsigned int fd",
+                "struct linux_dirent *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "getcwd",
+            "number": 79,
+            "signature": [
+                "char *buf",
+                "unsigned long size"
+            ]
+        },
+        {
+            "name": "chdir",
+            "number": 80,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "fchdir",
+            "number": 81,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "rename",
+            "number": 82,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "mkdir",
+            "number": 83,
+            "signature": [
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "rmdir",
+            "number": 84,
+            "signature": [
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "creat",
+            "number": 85,
+            "signature": [
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "link",
+            "number": 86,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "unlink",
+            "number": 87,
+            "signature": [
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "symlink",
+            "number": 88,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "readlink",
+            "number": 89,
+            "signature": [
+                "const char *path",
+                "char *buf",
+                "int bufsiz"
+            ]
+        },
+        {
+            "name": "chmod",
+            "number": 90,
+            "signature": [
+                "const char *filename",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "fchmod",
+            "number": 91,
+            "signature": [
+                "unsigned int fd",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "chown",
+            "number": 92,
+            "signature": [
+                "const char *filename",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "fchown",
+            "number": 93,
+            "signature": [
+                "unsigned int fd",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "lchown",
+            "number": 94,
+            "signature": [
+                "const char *filename",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "umask",
+            "number": 95,
+            "signature": [
+                "int mask"
+            ]
+        },
+        {
+            "name": "gettimeofday",
+            "number": 96,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "getrlimit",
+            "number": 97,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "getrusage",
+            "number": 98,
+            "signature": [
+                "int who",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "sysinfo",
+            "number": 99,
+            "signature": [
+                "struct sysinfo *info"
+            ]
+        },
+        {
+            "name": "times",
+            "number": 100,
+            "signature": [
+                "struct tms *tbuf"
+            ]
+        },
+        {
+            "name": "ptrace",
+            "number": 101,
+            "signature": [
+                "long request",
+                "long pid",
+                "unsigned long addr",
+                "unsigned long data"
+            ]
+        },
+        {
+            "name": "getuid",
+            "number": 102,
+            "signature": []
+        },
+        {
+            "name": "syslog",
+            "number": 103,
+            "signature": [
+                "int type",
+                "char *buf",
+                "int len"
+            ]
+        },
+        {
+            "name": "getgid",
+            "number": 104,
+            "signature": []
+        },
+        {
+            "name": "setuid",
+            "number": 105,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setgid",
+            "number": 106,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "geteuid",
+            "number": 107,
+            "signature": []
+        },
+        {
+            "name": "getegid",
+            "number": 108,
+            "signature": []
+        },
+        {
+            "name": "setpgid",
+            "number": 109,
+            "signature": [
+                "pid_t pid",
+                "pid_t pgid"
+            ]
+        },
+        {
+            "name": "getppid",
+            "number": 110,
+            "signature": []
+        },
+        {
+            "name": "getpgrp",
+            "number": 111,
+            "signature": []
+        },
+        {
+            "name": "setsid",
+            "number": 112,
+            "signature": []
+        },
+        {
+            "name": "setreuid",
+            "number": 113,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid"
+            ]
+        },
+        {
+            "name": "setregid",
+            "number": 114,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid"
+            ]
+        },
+        {
+            "name": "getgroups",
+            "number": 115,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "setgroups",
+            "number": 116,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "setresuid",
+            "number": 117,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid",
+                "uid_t suid"
+            ]
+        },
+        {
+            "name": "getresuid",
+            "number": 118,
+            "signature": [
+                "uid_t *ruidp",
+                "uid_t *euidp",
+                "uid_t *suidp"
+            ]
+        },
+        {
+            "name": "setresgid",
+            "number": 119,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid",
+                "gid_t sgid"
+            ]
+        },
+        {
+            "name": "getresgid",
+            "number": 120,
+            "signature": [
+                "gid_t *rgidp",
+                "gid_t *egidp",
+                "gid_t *sgidp"
+            ]
+        },
+        {
+            "name": "getpgid",
+            "number": 121,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "setfsuid",
+            "number": 122,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setfsgid",
+            "number": 123,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "getsid",
+            "number": 124,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "capget",
+            "number": 125,
+            "signature": [
+                "cap_user_header_t header",
+                "cap_user_data_t dataptr"
+            ]
+        },
+        {
+            "name": "capset",
+            "number": 126,
+            "signature": [
+                "cap_user_header_t header",
+                "const cap_user_data_t data"
+            ]
+        },
+        {
+            "name": "rt_sigpending",
+            "number": 127,
+            "signature": [
+                "sigset_t *uset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "number": 128,
+            "signature": [
+                "const sigset_t *uthese",
+                "siginfo_t *uinfo",
+                "const struct __kernel_timespec *uts",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigqueueinfo",
+            "number": 129,
+            "signature": [
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "rt_sigsuspend",
+            "number": 130,
+            "signature": [
+                "sigset_t *unewset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "sigaltstack",
+            "number": 131,
+            "signature": [
+                "const stack_t *uss",
+                "stack_t *uoss"
+            ]
+        },
+        {
+            "name": "utime",
+            "number": 132,
+            "signature": [
+                "char *filename",
+                "struct utimbuf *times"
+            ]
+        },
+        {
+            "name": "mknod",
+            "number": 133,
+            "signature": [
+                "const char *filename",
+                "umode_t mode",
+                "unsigned dev"
+            ]
+        },
+        {
+            "name": "personality",
+            "number": 135,
+            "signature": [
+                "unsigned int personality"
+            ]
+        },
+        {
+            "name": "ustat",
+            "number": 136,
+            "signature": [
+                "unsigned dev",
+                "struct ustat *ubuf"
+            ]
+        },
+        {
+            "name": "statfs",
+            "number": 137,
+            "signature": [
+                "const char *pathname",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "fstatfs",
+            "number": 138,
+            "signature": [
+                "unsigned int fd",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "sysfs",
+            "number": 139,
+            "signature": [
+                "int option",
+                "unsigned long arg1",
+                "unsigned long arg2"
+            ]
+        },
+        {
+            "name": "getpriority",
+            "number": 140,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "setpriority",
+            "number": 141,
+            "signature": [
+                "int which",
+                "int who",
+                "int niceval"
+            ]
+        },
+        {
+            "name": "sched_setparam",
+            "number": 142,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_getparam",
+            "number": 143,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_setscheduler",
+            "number": 144,
+            "signature": [
+                "pid_t pid",
+                "int policy",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_getscheduler",
+            "number": 145,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "sched_get_priority_max",
+            "number": 146,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_get_priority_min",
+            "number": 147,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "number": 148,
+            "signature": [
+                "pid_t pid",
+                "struct __kernel_timespec *interval"
+            ]
+        },
+        {
+            "name": "mlock",
+            "number": 149,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "munlock",
+            "number": 150,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "mlockall",
+            "number": 151,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "munlockall",
+            "number": 152,
+            "signature": []
+        },
+        {
+            "name": "vhangup",
+            "number": 153,
+            "signature": []
+        },
+        {
+            "name": "modify_ldt",
+            "number": 154,
+            "signature": [
+                "int func",
+                "void *ptr",
+                "unsigned long bytecount"
+            ]
+        },
+        {
+            "name": "pivot_root",
+            "number": 155,
+            "signature": [
+                "const char *new_root",
+                "const char *put_old"
+            ]
+        },
+        {
+            "name": "prctl",
+            "number": 157,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "arch_prctl",
+            "number": 158,
+            "signature": [
+                "int option",
+                "unsigned long arg2"
+            ]
+        },
+        {
+            "name": "adjtimex",
+            "number": 159,
+            "signature": [
+                "struct __kernel_timex *txc_p"
+            ]
+        },
+        {
+            "name": "setrlimit",
+            "number": 160,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "chroot",
+            "number": 161,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "sync",
+            "number": 162,
+            "signature": []
+        },
+        {
+            "name": "acct",
+            "number": 163,
+            "signature": [
+                "const char *name"
+            ]
+        },
+        {
+            "name": "settimeofday",
+            "number": 164,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "mount",
+            "number": 165,
+            "signature": [
+                "char *dev_name",
+                "char *dir_name",
+                "char *type",
+                "unsigned long flags",
+                "void *data"
+            ]
+        },
+        {
+            "name": "umount",
+            "number": 166,
+            "signature": [
+                "char *name",
+                "int flags"
+            ]
+        },
+        {
+            "name": "swapon",
+            "number": 167,
+            "signature": [
+                "const char *specialfile",
+                "int swap_flags"
+            ]
+        },
+        {
+            "name": "swapoff",
+            "number": 168,
+            "signature": [
+                "const char *specialfile"
+            ]
+        },
+        {
+            "name": "reboot",
+            "number": 169,
+            "signature": [
+                "int magic1",
+                "int magic2",
+                "unsigned int cmd",
+                "void *arg"
+            ]
+        },
+        {
+            "name": "sethostname",
+            "number": 170,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "setdomainname",
+            "number": 171,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "iopl",
+            "number": 172,
+            "signature": [
+                "unsigned int level"
+            ]
+        },
+        {
+            "name": "ioperm",
+            "number": 173,
+            "signature": [
+                "unsigned long from",
+                "unsigned long num",
+                "int turn_on"
+            ]
+        },
+        {
+            "name": "init_module",
+            "number": 175,
+            "signature": [
+                "void *umod",
+                "unsigned long len",
+                "const char *uargs"
+            ]
+        },
+        {
+            "name": "delete_module",
+            "number": 176,
+            "signature": [
+                "const char *name_user",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "quotactl",
+            "number": 179,
+            "signature": [
+                "unsigned int cmd",
+                "const char *special",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "gettid",
+            "number": 186,
+            "signature": []
+        },
+        {
+            "name": "readahead",
+            "number": 187,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "setxattr",
+            "number": 188,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "lsetxattr",
+            "number": 189,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "fsetxattr",
+            "number": 190,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getxattr",
+            "number": 191,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "lgetxattr",
+            "number": 192,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "fgetxattr",
+            "number": 193,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "listxattr",
+            "number": 194,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "llistxattr",
+            "number": 195,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "flistxattr",
+            "number": 196,
+            "signature": [
+                "int fd",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattr",
+            "number": 197,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "lremovexattr",
+            "number": 198,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "fremovexattr",
+            "number": 199,
+            "signature": [
+                "int fd",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "tkill",
+            "number": 200,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "time",
+            "number": 201,
+            "signature": [
+                "__kernel_old_time_t *tloc"
+            ]
+        },
+        {
+            "name": "futex",
+            "number": 202,
+            "signature": [
+                "u32 *uaddr",
+                "int op",
+                "u32 val",
+                "const struct __kernel_timespec *utime",
+                "u32 *uaddr2",
+                "u32 val3"
+            ]
+        },
+        {
+            "name": "sched_setaffinity",
+            "number": 203,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "sched_getaffinity",
+            "number": 204,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "io_setup",
+            "number": 206,
+            "signature": [
+                "unsigned nr_events",
+                "aio_context_t *ctxp"
+            ]
+        },
+        {
+            "name": "io_destroy",
+            "number": 207,
+            "signature": [
+                "aio_context_t ctx"
+            ]
+        },
+        {
+            "name": "io_getevents",
+            "number": 208,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "io_submit",
+            "number": 209,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long nr",
+                "struct iocb **iocbpp"
+            ]
+        },
+        {
+            "name": "io_cancel",
+            "number": 210,
+            "signature": [
+                "aio_context_t ctx_id",
+                "struct iocb *iocb",
+                "struct io_event *result"
+            ]
+        },
+        {
+            "name": "epoll_create",
+            "number": 213,
+            "signature": [
+                "int size"
+            ]
+        },
+        {
+            "name": "remap_file_pages",
+            "number": 216,
+            "signature": [
+                "unsigned long start",
+                "unsigned long size",
+                "unsigned long prot",
+                "unsigned long pgoff",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "getdents64",
+            "number": 217,
+            "signature": [
+                "unsigned int fd",
+                "struct linux_dirent64 *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "set_tid_address",
+            "number": 218,
+            "signature": [
+                "int *tidptr"
+            ]
+        },
+        {
+            "name": "restart_syscall",
+            "number": 219,
+            "signature": []
+        },
+        {
+            "name": "semtimedop",
+            "number": 220,
+            "signature": [
+                "int semid",
+                "struct sembuf *tsops",
+                "unsigned int nsops",
+                "const struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "fadvise64",
+            "number": 221,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "size_t len",
+                "int advice"
+            ]
+        },
+        {
+            "name": "timer_create",
+            "number": 222,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct sigevent *timer_event_spec",
+                "timer_t *created_timer_id"
+            ]
+        },
+        {
+            "name": "timer_settime",
+            "number": 223,
+            "signature": [
+                "timer_t timer_id",
+                "int flags",
+                "const struct __kernel_itimerspec *new_setting",
+                "struct __kernel_itimerspec *old_setting"
+            ]
+        },
+        {
+            "name": "timer_gettime",
+            "number": 224,
+            "signature": [
+                "timer_t timer_id",
+                "struct __kernel_itimerspec *setting"
+            ]
+        },
+        {
+            "name": "timer_getoverrun",
+            "number": 225,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "timer_delete",
+            "number": 226,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "clock_settime",
+            "number": 227,
+            "signature": [
+                "const clockid_t which_clock",
+                "const struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_gettime",
+            "number": 228,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_getres",
+            "number": 229,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_nanosleep",
+            "number": 230,
+            "signature": [
+                "const clockid_t which_clock",
+                "int flags",
+                "const struct __kernel_timespec *rqtp",
+                "struct __kernel_timespec *rmtp"
+            ]
+        },
+        {
+            "name": "exit_group",
+            "number": 231,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "epoll_wait",
+            "number": 232,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "int timeout"
+            ]
+        },
+        {
+            "name": "epoll_ctl",
+            "number": 233,
+            "signature": [
+                "int epfd",
+                "int op",
+                "int fd",
+                "struct epoll_event *event"
+            ]
+        },
+        {
+            "name": "tgkill",
+            "number": 234,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "utimes",
+            "number": 235,
+            "signature": [
+                "char *filename",
+                "struct __kernel_old_timeval *utimes"
+            ]
+        },
+        {
+            "name": "mbind",
+            "number": 237,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "set_mempolicy",
+            "number": 238,
+            "signature": [
+                "int mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode"
+            ]
+        },
+        {
+            "name": "get_mempolicy",
+            "number": 239,
+            "signature": [
+                "int *policy",
+                "unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned long addr",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "mq_open",
+            "number": 240,
+            "signature": [
+                "const char *u_name",
+                "int oflag",
+                "umode_t mode",
+                "struct mq_attr *u_attr"
+            ]
+        },
+        {
+            "name": "mq_unlink",
+            "number": 241,
+            "signature": [
+                "const char *u_name"
+            ]
+        },
+        {
+            "name": "mq_timedsend",
+            "number": 242,
+            "signature": [
+                "mqd_t mqdes",
+                "const char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_timedreceive",
+            "number": 243,
+            "signature": [
+                "mqd_t mqdes",
+                "char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int *u_msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_notify",
+            "number": 244,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct sigevent *u_notification"
+            ]
+        },
+        {
+            "name": "mq_getsetattr",
+            "number": 245,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct mq_attr *u_mqstat",
+                "struct mq_attr *u_omqstat"
+            ]
+        },
+        {
+            "name": "kexec_load",
+            "number": 246,
+            "signature": [
+                "unsigned long entry",
+                "unsigned long nr_segments",
+                "struct kexec_segment *segments",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "waitid",
+            "number": 247,
+            "signature": [
+                "int which",
+                "pid_t upid",
+                "struct siginfo *infop",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "add_key",
+            "number": 248,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const void *_payload",
+                "size_t plen",
+                "key_serial_t ringid"
+            ]
+        },
+        {
+            "name": "request_key",
+            "number": 249,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const char *_callout_info",
+                "key_serial_t destringid"
+            ]
+        },
+        {
+            "name": "keyctl",
+            "number": 250,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "ioprio_set",
+            "number": 251,
+            "signature": [
+                "int which",
+                "int who",
+                "int ioprio"
+            ]
+        },
+        {
+            "name": "ioprio_get",
+            "number": 252,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "inotify_init",
+            "number": 253,
+            "signature": []
+        },
+        {
+            "name": "inotify_add_watch",
+            "number": 254,
+            "signature": [
+                "int fd",
+                "const char *pathname",
+                "u32 mask"
+            ]
+        },
+        {
+            "name": "inotify_rm_watch",
+            "number": 255,
+            "signature": [
+                "int fd",
+                "__s32 wd"
+            ]
+        },
+        {
+            "name": "migrate_pages",
+            "number": 256,
+            "signature": [
+                "pid_t pid",
+                "unsigned long maxnode",
+                "const unsigned long *old_nodes",
+                "const unsigned long *new_nodes"
+            ]
+        },
+        {
+            "name": "openat",
+            "number": 257,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int flags",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "mkdirat",
+            "number": 258,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "mknodat",
+            "number": 259,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int dev"
+            ]
+        },
+        {
+            "name": "fchownat",
+            "number": 260,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "uid_t user",
+                "gid_t group",
+                "int flag"
+            ]
+        },
+        {
+            "name": "futimesat",
+            "number": 261,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct __kernel_old_timeval *utimes"
+            ]
+        },
+        {
+            "name": "newfstatat",
+            "number": 262,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct stat *statbuf",
+                "int flag"
+            ]
+        },
+        {
+            "name": "unlinkat",
+            "number": 263,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "int flag"
+            ]
+        },
+        {
+            "name": "renameat",
+            "number": 264,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "linkat",
+            "number": 265,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "int flags"
+            ]
+        },
+        {
+            "name": "symlinkat",
+            "number": 266,
+            "signature": [
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "readlinkat",
+            "number": 267,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "char *buf",
+                "int bufsiz"
+            ]
+        },
+        {
+            "name": "fchmodat",
+            "number": 268,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "faccessat",
+            "number": 269,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode"
+            ]
+        },
+        {
+            "name": "pselect6",
+            "number": 270,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct __kernel_timespec *tsp",
+                "void *sig"
+            ]
+        },
+        {
+            "name": "ppoll",
+            "number": 271,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "struct __kernel_timespec *tsp",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "unshare",
+            "number": 272,
+            "signature": [
+                "unsigned long unshare_flags"
+            ]
+        },
+        {
+            "name": "set_robust_list",
+            "number": 273,
+            "signature": [
+                "struct robust_list_head *head",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "get_robust_list",
+            "number": 274,
+            "signature": [
+                "int pid",
+                "struct robust_list_head **head_ptr",
+                "size_t *len_ptr"
+            ]
+        },
+        {
+            "name": "splice",
+            "number": 275,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "tee",
+            "number": 276,
+            "signature": [
+                "int fdin",
+                "int fdout",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "sync_file_range",
+            "number": 277,
+            "signature": [
+                "int fd",
+                "loff_t offset",
+                "loff_t nbytes",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "vmsplice",
+            "number": 278,
+            "signature": [
+                "int fd",
+                "const struct iovec *uiov",
+                "unsigned long nr_segs",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "move_pages",
+            "number": 279,
+            "signature": [
+                "pid_t pid",
+                "unsigned long nr_pages",
+                "const void **pages",
+                "const int *nodes",
+                "int *status",
+                "int flags"
+            ]
+        },
+        {
+            "name": "utimensat",
+            "number": 280,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct __kernel_timespec *utimes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "epoll_pwait",
+            "number": 281,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "int timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "signalfd",
+            "number": 282,
+            "signature": [
+                "int ufd",
+                "sigset_t *user_mask",
+                "size_t sizemask"
+            ]
+        },
+        {
+            "name": "timerfd_create",
+            "number": 283,
+            "signature": [
+                "int clockid",
+                "int flags"
+            ]
+        },
+        {
+            "name": "eventfd",
+            "number": 284,
+            "signature": [
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "fallocate",
+            "number": 285,
+            "signature": [
+                "int fd",
+                "int mode",
+                "loff_t offset",
+                "loff_t len"
+            ]
+        },
+        {
+            "name": "timerfd_settime",
+            "number": 286,
+            "signature": [
+                "int ufd",
+                "int flags",
+                "const struct __kernel_itimerspec *utmr",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "timerfd_gettime",
+            "number": 287,
+            "signature": [
+                "int ufd",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "accept4",
+            "number": 288,
+            "signature": [
+                "int fd",
+                "struct sockaddr *upeer_sockaddr",
+                "int *upeer_addrlen",
+                "int flags"
+            ]
+        },
+        {
+            "name": "signalfd4",
+            "number": 289,
+            "signature": [
+                "int ufd",
+                "sigset_t *user_mask",
+                "size_t sizemask",
+                "int flags"
+            ]
+        },
+        {
+            "name": "eventfd2",
+            "number": 290,
+            "signature": [
+                "unsigned int count",
+                "int flags"
+            ]
+        },
+        {
+            "name": "epoll_create1",
+            "number": 291,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "dup3",
+            "number": 292,
+            "signature": [
+                "unsigned int oldfd",
+                "unsigned int newfd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "pipe2",
+            "number": 293,
+            "signature": [
+                "int *fildes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "inotify_init1",
+            "number": 294,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "preadv",
+            "number": 295,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "pwritev",
+            "number": 296,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "rt_tgsigqueueinfo",
+            "number": 297,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "perf_event_open",
+            "number": 298,
+            "signature": [
+                "struct perf_event_attr *attr_uptr",
+                "pid_t pid",
+                "int cpu",
+                "int group_fd",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "recvmmsg",
+            "number": 299,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "fanotify_init",
+            "number": 300,
+            "signature": [
+                "unsigned int flags",
+                "unsigned int event_f_flags"
+            ]
+        },
+        {
+            "name": "fanotify_mark",
+            "number": 301,
+            "signature": [
+                "int fanotify_fd",
+                "unsigned int flags",
+                "__u64 mask",
+                "int dfd",
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "prlimit64",
+            "number": 302,
+            "signature": [
+                "pid_t pid",
+                "unsigned int resource",
+                "const struct rlimit64 *new_rlim",
+                "struct rlimit64 *old_rlim"
+            ]
+        },
+        {
+            "name": "name_to_handle_at",
+            "number": 303,
+            "signature": [
+                "int dfd",
+                "const char *name",
+                "struct file_handle *handle",
+                "void *mnt_id",
+                "int flag"
+            ]
+        },
+        {
+            "name": "open_by_handle_at",
+            "number": 304,
+            "signature": [
+                "int mountdirfd",
+                "struct file_handle *handle",
+                "int flags"
+            ]
+        },
+        {
+            "name": "clock_adjtime",
+            "number": 305,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timex *utx"
+            ]
+        },
+        {
+            "name": "syncfs",
+            "number": 306,
+            "signature": [
+                "int fd"
+            ]
+        },
+        {
+            "name": "sendmmsg",
+            "number": 307,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "setns",
+            "number": 308,
+            "signature": [
+                "int fd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getcpu",
+            "number": 309,
+            "signature": [
+                "unsigned *cpup",
+                "unsigned *nodep",
+                "struct getcpu_cache *unused"
+            ]
+        },
+        {
+            "name": "process_vm_readv",
+            "number": 310,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "process_vm_writev",
+            "number": 311,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "kcmp",
+            "number": 312,
+            "signature": [
+                "pid_t pid1",
+                "pid_t pid2",
+                "int type",
+                "unsigned long idx1",
+                "unsigned long idx2"
+            ]
+        },
+        {
+            "name": "finit_module",
+            "number": 313,
+            "signature": [
+                "int fd",
+                "const char *uargs",
+                "int flags"
+            ]
+        },
+        {
+            "name": "sched_setattr",
+            "number": 314,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "sched_getattr",
+            "number": 315,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int usize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "renameat2",
+            "number": 316,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "seccomp",
+            "number": 317,
+            "signature": [
+                "unsigned int op",
+                "unsigned int flags",
+                "void *uargs"
+            ]
+        },
+        {
+            "name": "getrandom",
+            "number": 318,
+            "signature": [
+                "char *ubuf",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "memfd_create",
+            "number": 319,
+            "signature": [
+                "const char *uname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "kexec_file_load",
+            "number": 320,
+            "signature": [
+                "int kernel_fd",
+                "int initrd_fd",
+                "unsigned long cmdline_len",
+                "const char *cmdline_ptr",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "bpf",
+            "number": 321,
+            "signature": [
+                "int cmd",
+                "union bpf_attr *uattr",
+                "unsigned int size"
+            ]
+        },
+        {
+            "name": "execveat",
+            "number": 322,
+            "signature": [
+                "int fd",
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp",
+                "int flags"
+            ]
+        },
+        {
+            "name": "userfaultfd",
+            "number": 323,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "membarrier",
+            "number": 324,
+            "signature": [
+                "int cmd",
+                "unsigned int flags",
+                "int cpu_id"
+            ]
+        },
+        {
+            "name": "mlock2",
+            "number": 325,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "copy_file_range",
+            "number": 326,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "preadv2",
+            "number": 327,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "pwritev2",
+            "number": 328,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "pkey_mprotect",
+            "number": 329,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long prot",
+                "int pkey"
+            ]
+        },
+        {
+            "name": "pkey_alloc",
+            "number": 330,
+            "signature": [
+                "unsigned long flags",
+                "unsigned long init_val"
+            ]
+        },
+        {
+            "name": "pkey_free",
+            "number": 331,
+            "signature": [
+                "int pkey"
+            ]
+        },
+        {
+            "name": "statx",
+            "number": 332,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags",
+                "unsigned int mask",
+                "struct statx *buffer"
+            ]
+        },
+        {
+            "name": "io_pgetevents",
+            "number": 333,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct __kernel_timespec *timeout",
+                "const struct __aio_sigset *usig"
+            ]
+        },
+        {
+            "name": "rseq",
+            "number": 334,
+            "signature": [
+                "struct rseq *rseq",
+                "u32 rseq_len",
+                "int flags",
+                "u32 sig"
+            ]
+        },
+        {
+            "name": "uretprobe",
+            "number": 335,
+            "signature": []
+        },
+        {
+            "name": "pidfd_send_signal",
+            "number": 424,
+            "signature": [
+                "int pidfd",
+                "int sig",
+                "siginfo_t *info",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "io_uring_setup",
+            "number": 425,
+            "signature": [
+                "u32 entries",
+                "struct io_uring_params *params"
+            ]
+        },
+        {
+            "name": "io_uring_enter",
+            "number": 426,
+            "signature": [
+                "unsigned int fd",
+                "u32 to_submit",
+                "u32 min_complete",
+                "u32 flags",
+                "const void *argp",
+                "size_t argsz"
+            ]
+        },
+        {
+            "name": "io_uring_register",
+            "number": 427,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int opcode",
+                "void *arg",
+                "unsigned int nr_args"
+            ]
+        },
+        {
+            "name": "open_tree",
+            "number": 428,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags"
+            ]
+        },
+        {
+            "name": "move_mount",
+            "number": 429,
+            "signature": [
+                "int from_dfd",
+                "const char *from_pathname",
+                "int to_dfd",
+                "const char *to_pathname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsopen",
+            "number": 430,
+            "signature": [
+                "const char *_fs_name",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsconfig",
+            "number": 431,
+            "signature": [
+                "int fd",
+                "unsigned int cmd",
+                "const char *_key",
+                "const void *_value",
+                "int aux"
+            ]
+        },
+        {
+            "name": "fsmount",
+            "number": 432,
+            "signature": [
+                "int fs_fd",
+                "unsigned int flags",
+                "unsigned int attr_flags"
+            ]
+        },
+        {
+            "name": "fspick",
+            "number": 433,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "pidfd_open",
+            "number": 434,
+            "signature": [
+                "pid_t pid",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "clone3",
+            "number": 435,
+            "signature": [
+                "struct clone_args *uargs",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "close_range",
+            "number": 436,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int max_fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "openat2",
+            "number": 437,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct open_how *how",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "pidfd_getfd",
+            "number": 438,
+            "signature": [
+                "int pidfd",
+                "int fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "faccessat2",
+            "number": 439,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode",
+                "int flags"
+            ]
+        },
+        {
+            "name": "process_madvise",
+            "number": 440,
+            "signature": [
+                "int pidfd",
+                "const struct iovec *vec",
+                "size_t vlen",
+                "int behavior",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "epoll_pwait2",
+            "number": 441,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "const struct __kernel_timespec *timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "mount_setattr",
+            "number": 442,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags",
+                "struct mount_attr *uattr",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "quotactl_fd",
+            "number": 443,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "landlock_create_ruleset",
+            "number": 444,
+            "signature": [
+                "const struct landlock_ruleset_attr *const attr",
+                "const size_t size",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_add_rule",
+            "number": 445,
+            "signature": [
+                "const int ruleset_fd",
+                "const enum landlock_rule_type rule_type",
+                "const void *const rule_attr",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_restrict_self",
+            "number": 446,
+            "signature": [
+                "const int ruleset_fd",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "memfd_secret",
+            "number": 447,
+            "signature": [
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "process_mrelease",
+            "number": 448,
+            "signature": [
+                "int pidfd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_waitv",
+            "number": 449,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int nr_futexes",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "set_mempolicy_home_node",
+            "number": 450,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long home_node",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "cachestat",
+            "number": 451,
+            "signature": [
+                "unsigned int fd",
+                "struct cachestat_range *cstat_range",
+                "struct cachestat *cstat",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fchmodat2",
+            "number": 452,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "map_shadow_stack",
+            "number": 453,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long size",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wake",
+            "number": 454,
+            "signature": [
+                "void *uaddr",
+                "unsigned long mask",
+                "int nr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wait",
+            "number": 455,
+            "signature": [
+                "void *uaddr",
+                "unsigned long val",
+                "unsigned long mask",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "futex_requeue",
+            "number": 456,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int flags",
+                "int nr_wake",
+                "int nr_requeue"
+            ]
+        },
+        {
+            "name": "statmount",
+            "number": 457,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "struct statmount *buf",
+                "size_t bufsize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "listmount",
+            "number": 458,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "u64 *mnt_ids",
+                "size_t nr_mnt_ids",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "lsm_get_self_attr",
+            "number": 459,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_set_self_attr",
+            "number": 460,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_list_modules",
+            "number": 461,
+            "signature": [
+                "u64 *ids",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "mseal",
+            "number": 462,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "setxattrat",
+            "number": 463,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "const struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "getxattrat",
+            "number": 464,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "listxattrat",
+            "number": 465,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattrat",
+            "number": 466,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name"
+            ]
+        }
+    ]
 }

--- a/libdebug/utils/syscall_data/amd64.json
+++ b/libdebug/utils/syscall_data/amd64.json
@@ -1,0 +1,6483 @@
+{
+	"kernel": {
+		"abi": {
+			"bits": 64,
+			"calling_convention": {
+				"parameters": [
+					"rdi",
+					"rsi",
+					"rdx",
+					"r10",
+					"r8",
+					"r9"
+				],
+				"syscall_nr": "rax"
+			},
+			"compat": false,
+			"name": "x64"
+		},
+		"architecture": {
+			"bits": 64,
+			"name": "x86"
+		},
+		"syscall_table_symbol": "sys_call_table",
+		"version": "v6.14",
+		"version_source": "vmlinux"
+	},
+	"syscalls": [
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 0,
+			"kconfig": null,
+			"line": 715,
+			"name": "read",
+			"number": 0,
+			"origname": "read",
+			"signature": [
+				"unsigned int fd",
+				"char *buf",
+				"size_t count"
+			],
+			"symbol": "__x64_sys_read"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 1,
+			"kconfig": null,
+			"line": 739,
+			"name": "write",
+			"number": 1,
+			"origname": "write",
+			"signature": [
+				"unsigned int fd",
+				"const char *buf",
+				"size_t count"
+			],
+			"symbol": "__x64_sys_write"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 2,
+			"kconfig": null,
+			"line": 1447,
+			"name": "open",
+			"number": 2,
+			"origname": "open",
+			"signature": [
+				"const char *filename",
+				"int flags",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_open"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 3,
+			"kconfig": null,
+			"line": 1565,
+			"name": "close",
+			"number": 3,
+			"origname": "close",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__x64_sys_close"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 4,
+			"kconfig": null,
+			"line": 501,
+			"name": "newstat",
+			"number": 4,
+			"origname": "newstat",
+			"signature": [
+				"const char *filename",
+				"struct stat *statbuf"
+			],
+			"symbol": "__x64_sys_newstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 5,
+			"kconfig": null,
+			"line": 539,
+			"name": "newfstat",
+			"number": 5,
+			"origname": "newfstat",
+			"signature": [
+				"unsigned int fd",
+				"struct stat *statbuf"
+			],
+			"symbol": "__x64_sys_newfstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 6,
+			"kconfig": null,
+			"line": 512,
+			"name": "newlstat",
+			"number": 6,
+			"origname": "newlstat",
+			"signature": [
+				"const char *filename",
+				"struct stat *statbuf"
+			],
+			"symbol": "__x64_sys_newlstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 7,
+			"kconfig": null,
+			"line": 1062,
+			"name": "poll",
+			"number": 7,
+			"origname": "poll",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"int timeout_msecs"
+			],
+			"symbol": "__x64_sys_poll"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 8,
+			"kconfig": null,
+			"line": 403,
+			"name": "lseek",
+			"number": 8,
+			"origname": "lseek",
+			"signature": [
+				"unsigned int fd",
+				"off_t offset",
+				"unsigned int whence"
+			],
+			"symbol": "__x64_sys_lseek"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_x86_64.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 9,
+			"kconfig": null,
+			"line": 82,
+			"name": "mmap",
+			"number": 9,
+			"origname": "mmap",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long len",
+				"unsigned long prot",
+				"unsigned long flags",
+				"unsigned long fd",
+				"unsigned long off"
+			],
+			"symbol": "__x64_sys_mmap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 10,
+			"kconfig": "MMU",
+			"line": 858,
+			"name": "mprotect",
+			"number": 10,
+			"origname": "mprotect",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long prot"
+			],
+			"symbol": "__x64_sys_mprotect"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 11,
+			"kconfig": null,
+			"line": 1081,
+			"name": "munmap",
+			"number": 11,
+			"origname": "munmap",
+			"signature": [
+				"unsigned long addr",
+				"size_t len"
+			],
+			"symbol": "__x64_sys_munmap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 12,
+			"kconfig": null,
+			"line": 115,
+			"name": "brk",
+			"number": 12,
+			"origname": "brk",
+			"signature": [
+				"unsigned long brk"
+			],
+			"symbol": "__x64_sys_brk"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 13,
+			"kconfig": null,
+			"line": 4606,
+			"name": "rt_sigaction",
+			"number": 13,
+			"origname": "rt_sigaction",
+			"signature": [
+				"int sig",
+				"const struct sigaction *act",
+				"struct sigaction *oact",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_rt_sigaction"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 14,
+			"kconfig": null,
+			"line": 3320,
+			"name": "rt_sigprocmask",
+			"number": 14,
+			"origname": "rt_sigprocmask",
+			"signature": [
+				"int how",
+				"sigset_t *nset",
+				"sigset_t *oset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_rt_sigprocmask"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/signal_64.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 15,
+			"kconfig": null,
+			"line": 246,
+			"name": "rt_sigreturn",
+			"number": 15,
+			"origname": "rt_sigreturn",
+			"signature": [],
+			"symbol": "__x64_sys_rt_sigreturn"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/ioctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 16,
+			"kconfig": null,
+			"line": 892,
+			"name": "ioctl",
+			"number": 16,
+			"origname": "ioctl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__x64_sys_ioctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 17,
+			"kconfig": null,
+			"line": 761,
+			"name": "pread64",
+			"number": 17,
+			"origname": "pread64",
+			"signature": [
+				"unsigned int fd",
+				"char *buf",
+				"size_t count",
+				"loff_t pos"
+			],
+			"symbol": "__x64_sys_pread64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 18,
+			"kconfig": null,
+			"line": 791,
+			"name": "pwrite64",
+			"number": 18,
+			"origname": "pwrite64",
+			"signature": [
+				"unsigned int fd",
+				"const char *buf",
+				"size_t count",
+				"loff_t pos"
+			],
+			"symbol": "__x64_sys_pwrite64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 19,
+			"kconfig": null,
+			"line": 1155,
+			"name": "readv",
+			"number": 19,
+			"origname": "readv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__x64_sys_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 20,
+			"kconfig": null,
+			"line": 1161,
+			"name": "writev",
+			"number": 20,
+			"origname": "writev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__x64_sys_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 21,
+			"kconfig": null,
+			"line": 546,
+			"name": "access",
+			"number": 21,
+			"origname": "access",
+			"signature": [
+				"const char *filename",
+				"int mode"
+			],
+			"symbol": "__x64_sys_access"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/pipe.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 22,
+			"kconfig": null,
+			"line": 1048,
+			"name": "pipe",
+			"number": 22,
+			"origname": "pipe",
+			"signature": [
+				"int *fildes"
+			],
+			"symbol": "__x64_sys_pipe"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 23,
+			"kconfig": null,
+			"line": 722,
+			"name": "select",
+			"number": 23,
+			"origname": "select",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct __kernel_old_timeval *tvp"
+			],
+			"symbol": "__x64_sys_select"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 24,
+			"kconfig": null,
+			"line": 1377,
+			"name": "sched_yield",
+			"number": 24,
+			"origname": "sched_yield",
+			"signature": [],
+			"symbol": "__x64_sys_sched_yield"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mremap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 25,
+			"kconfig": null,
+			"line": 1045,
+			"name": "mremap",
+			"number": 25,
+			"origname": "mremap",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long old_len",
+				"unsigned long new_len",
+				"unsigned long flags",
+				"unsigned long new_addr"
+			],
+			"symbol": "__x64_sys_mremap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/msync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 26,
+			"kconfig": "MMU",
+			"line": 32,
+			"name": "msync",
+			"number": 26,
+			"origname": "msync",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__x64_sys_msync"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mincore.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 27,
+			"kconfig": "MMU",
+			"line": 232,
+			"name": "mincore",
+			"number": 27,
+			"origname": "mincore",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned char *vec"
+			],
+			"symbol": "__x64_sys_mincore"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 28,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1712,
+			"name": "madvise",
+			"number": 28,
+			"origname": "madvise",
+			"signature": [
+				"unsigned long start",
+				"size_t len_in",
+				"int behavior"
+			],
+			"symbol": "__x64_sys_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 29,
+			"kconfig": "SYSVIPC",
+			"line": 842,
+			"name": "shmget",
+			"number": 29,
+			"origname": "shmget",
+			"signature": [
+				"key_t key",
+				"size_t size",
+				"int shmflg"
+			],
+			"symbol": "__x64_sys_shmget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 30,
+			"kconfig": "SYSVIPC",
+			"line": 1688,
+			"name": "shmat",
+			"number": 30,
+			"origname": "shmat",
+			"signature": [
+				"int shmid",
+				"char *shmaddr",
+				"int shmflg"
+			],
+			"symbol": "__x64_sys_shmat"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 31,
+			"kconfig": "SYSVIPC",
+			"line": 1291,
+			"name": "shmctl",
+			"number": 31,
+			"origname": "shmctl",
+			"signature": [
+				"int shmid",
+				"int cmd",
+				"struct shmid_ds *buf"
+			],
+			"symbol": "__x64_sys_shmctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 32,
+			"kconfig": null,
+			"line": 1394,
+			"name": "dup",
+			"number": 32,
+			"origname": "dup",
+			"signature": [
+				"unsigned int fildes"
+			],
+			"symbol": "__x64_sys_dup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 33,
+			"kconfig": null,
+			"line": 1375,
+			"name": "dup2",
+			"number": 33,
+			"origname": "dup2",
+			"signature": [
+				"unsigned int oldfd",
+				"unsigned int newfd"
+			],
+			"symbol": "__x64_sys_dup2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 34,
+			"kconfig": null,
+			"line": 4799,
+			"name": "pause",
+			"number": 34,
+			"origname": "pause",
+			"signature": [],
+			"symbol": "__x64_sys_pause"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/hrtimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 35,
+			"kconfig": null,
+			"line": 2209,
+			"name": "nanosleep",
+			"number": 35,
+			"origname": "nanosleep",
+			"signature": [
+				"struct __kernel_timespec *rqtp",
+				"struct __kernel_timespec *rmtp"
+			],
+			"symbol": "__x64_sys_nanosleep"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 36,
+			"kconfig": null,
+			"line": 113,
+			"name": "getitimer",
+			"number": 36,
+			"origname": "getitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value"
+			],
+			"symbol": "__x64_sys_getitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 37,
+			"kconfig": null,
+			"line": 326,
+			"name": "alarm",
+			"number": 37,
+			"origname": "alarm",
+			"signature": [
+				"unsigned int seconds"
+			],
+			"symbol": "__x64_sys_alarm"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 38,
+			"kconfig": null,
+			"line": 352,
+			"name": "setitimer",
+			"number": 38,
+			"origname": "setitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value",
+				"struct __kernel_old_itimerval *ovalue"
+			],
+			"symbol": "__x64_sys_setitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 39,
+			"kconfig": null,
+			"line": 969,
+			"name": "getpid",
+			"number": 39,
+			"origname": "getpid",
+			"signature": [],
+			"symbol": "__x64_sys_getpid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 40,
+			"kconfig": null,
+			"line": 1410,
+			"name": "sendfile64",
+			"number": 40,
+			"origname": "sendfile64",
+			"signature": [
+				"int out_fd",
+				"int in_fd",
+				"loff_t *offset",
+				"size_t count"
+			],
+			"symbol": "__x64_sys_sendfile64"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 41,
+			"kconfig": "NET",
+			"line": 1702,
+			"name": "socket",
+			"number": 41,
+			"origname": "socket",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol"
+			],
+			"symbol": "__x64_sys_socket"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 42,
+			"kconfig": "NET",
+			"line": 2067,
+			"name": "connect",
+			"number": 42,
+			"origname": "connect",
+			"signature": [
+				"int fd",
+				"struct sockaddr *uservaddr",
+				"int addrlen"
+			],
+			"symbol": "__x64_sys_connect"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 43,
+			"kconfig": "NET",
+			"line": 2010,
+			"name": "accept",
+			"number": 43,
+			"origname": "accept",
+			"signature": [
+				"int fd",
+				"struct sockaddr *upeer_sockaddr",
+				"int *upeer_addrlen"
+			],
+			"symbol": "__x64_sys_accept"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 44,
+			"kconfig": "NET",
+			"line": 2190,
+			"name": "sendto",
+			"number": 44,
+			"origname": "sendto",
+			"signature": [
+				"int fd",
+				"void *buff",
+				"size_t len",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int addr_len"
+			],
+			"symbol": "__x64_sys_sendto"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 45,
+			"kconfig": "NET",
+			"line": 2248,
+			"name": "recvfrom",
+			"number": 45,
+			"origname": "recvfrom",
+			"signature": [
+				"int fd",
+				"void *ubuf",
+				"size_t size",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int *addr_len"
+			],
+			"symbol": "__x64_sys_recvfrom"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 46,
+			"kconfig": "NET",
+			"line": 2662,
+			"name": "sendmsg",
+			"number": 46,
+			"origname": "sendmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_sendmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 47,
+			"kconfig": "NET",
+			"line": 2871,
+			"name": "recvmsg",
+			"number": 47,
+			"origname": "recvmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_recvmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 48,
+			"kconfig": "NET",
+			"line": 2432,
+			"name": "shutdown",
+			"number": 48,
+			"origname": "shutdown",
+			"signature": [
+				"int fd",
+				"int how"
+			],
+			"symbol": "__x64_sys_shutdown"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 49,
+			"kconfig": "NET",
+			"line": 1851,
+			"name": "bind",
+			"number": 49,
+			"origname": "bind",
+			"signature": [
+				"int fd",
+				"struct sockaddr *umyaddr",
+				"int addrlen"
+			],
+			"symbol": "__x64_sys_bind"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 50,
+			"kconfig": "NET",
+			"line": 1889,
+			"name": "listen",
+			"number": 50,
+			"origname": "listen",
+			"signature": [
+				"int fd",
+				"int backlog"
+			],
+			"symbol": "__x64_sys_listen"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 51,
+			"kconfig": "NET",
+			"line": 2104,
+			"name": "getsockname",
+			"number": 51,
+			"origname": "getsockname",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__x64_sys_getsockname"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 52,
+			"kconfig": "NET",
+			"line": 2141,
+			"name": "getpeername",
+			"number": 52,
+			"origname": "getpeername",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__x64_sys_getpeername"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 53,
+			"kconfig": "NET",
+			"line": 1803,
+			"name": "socketpair",
+			"number": 53,
+			"origname": "socketpair",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol",
+				"int *usockvec"
+			],
+			"symbol": "__x64_sys_socketpair"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 54,
+			"kconfig": "NET",
+			"line": 2331,
+			"name": "setsockopt",
+			"number": 54,
+			"origname": "setsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int optlen"
+			],
+			"symbol": "__x64_sys_setsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 55,
+			"kconfig": "NET",
+			"line": 2397,
+			"name": "getsockopt",
+			"number": 55,
+			"origname": "getsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int *optlen"
+			],
+			"symbol": "__x64_sys_getsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 56,
+			"kconfig": null,
+			"line": 2942,
+			"name": "clone",
+			"number": 56,
+			"origname": "clone",
+			"signature": [
+				"unsigned long clone_flags",
+				"unsigned long newsp",
+				"int *parent_tidptr",
+				"int *child_tidptr",
+				"unsigned long tls"
+			],
+			"symbol": "__x64_sys_clone"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 57,
+			"kconfig": "MMU",
+			"line": 2897,
+			"name": "fork",
+			"number": 57,
+			"origname": "fork",
+			"signature": [],
+			"symbol": "__x64_sys_fork"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 58,
+			"kconfig": null,
+			"line": 2913,
+			"name": "vfork",
+			"number": 58,
+			"origname": "vfork",
+			"signature": [],
+			"symbol": "__x64_sys_vfork"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 59,
+			"kconfig": null,
+			"line": 2111,
+			"name": "execve",
+			"number": 59,
+			"origname": "execve",
+			"signature": [
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp"
+			],
+			"symbol": "__x64_sys_execve"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 60,
+			"kconfig": null,
+			"line": 1052,
+			"name": "exit",
+			"number": 60,
+			"origname": "exit",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__x64_sys_exit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 61,
+			"kconfig": null,
+			"line": 1874,
+			"name": "wait4",
+			"number": 61,
+			"origname": "wait4",
+			"signature": [
+				"pid_t upid",
+				"int *stat_addr",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__x64_sys_wait4"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 62,
+			"kconfig": null,
+			"line": 3951,
+			"name": "kill",
+			"number": 62,
+			"origname": "kill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__x64_sys_kill"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 63,
+			"kconfig": null,
+			"line": 1317,
+			"name": "newuname",
+			"number": 63,
+			"origname": "newuname",
+			"signature": [
+				"struct new_utsname *name"
+			],
+			"symbol": "__x64_sys_newuname"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 64,
+			"kconfig": "SYSVIPC",
+			"line": 624,
+			"name": "semget",
+			"number": 64,
+			"origname": "semget",
+			"signature": [
+				"key_t key",
+				"int nsems",
+				"int semflg"
+			],
+			"symbol": "__x64_sys_semget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 65,
+			"kconfig": "SYSVIPC",
+			"line": 2296,
+			"name": "semop",
+			"number": 65,
+			"origname": "semop",
+			"signature": [
+				"int semid",
+				"struct sembuf *tsops",
+				"unsigned nsops"
+			],
+			"symbol": "__x64_sys_semop"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 66,
+			"kconfig": "SYSVIPC",
+			"line": 1705,
+			"name": "semctl",
+			"number": 66,
+			"origname": "semctl",
+			"signature": [
+				"int semid",
+				"int semnum",
+				"int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__x64_sys_semctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 67,
+			"kconfig": "SYSVIPC",
+			"line": 1829,
+			"name": "shmdt",
+			"number": 67,
+			"origname": "shmdt",
+			"signature": [
+				"char *shmaddr"
+			],
+			"symbol": "__x64_sys_shmdt"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 68,
+			"kconfig": "SYSVIPC",
+			"line": 315,
+			"name": "msgget",
+			"number": 68,
+			"origname": "msgget",
+			"signature": [
+				"key_t key",
+				"int msgflg"
+			],
+			"symbol": "__x64_sys_msgget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 69,
+			"kconfig": "SYSVIPC",
+			"line": 971,
+			"name": "msgsnd",
+			"number": 69,
+			"origname": "msgsnd",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"int msgflg"
+			],
+			"symbol": "__x64_sys_msgsnd"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 70,
+			"kconfig": "SYSVIPC",
+			"line": 1270,
+			"name": "msgrcv",
+			"number": 70,
+			"origname": "msgrcv",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"long msgtyp",
+				"int msgflg"
+			],
+			"symbol": "__x64_sys_msgrcv"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 71,
+			"kconfig": "SYSVIPC",
+			"line": 640,
+			"name": "msgctl",
+			"number": 71,
+			"origname": "msgctl",
+			"signature": [
+				"int msqid",
+				"int cmd",
+				"struct msqid_ds *buf"
+			],
+			"symbol": "__x64_sys_msgctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fcntl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 72,
+			"kconfig": null,
+			"line": 576,
+			"name": "fcntl",
+			"number": 72,
+			"origname": "fcntl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__x64_sys_fcntl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/locks.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 73,
+			"kconfig": null,
+			"line": 2135,
+			"name": "flock",
+			"number": 73,
+			"origname": "flock",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd"
+			],
+			"symbol": "__x64_sys_flock"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 74,
+			"kconfig": null,
+			"line": 215,
+			"name": "fsync",
+			"number": 74,
+			"origname": "fsync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__x64_sys_fsync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 75,
+			"kconfig": null,
+			"line": 220,
+			"name": "fdatasync",
+			"number": 75,
+			"origname": "fdatasync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__x64_sys_fdatasync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 76,
+			"kconfig": null,
+			"line": 148,
+			"name": "truncate",
+			"number": 76,
+			"origname": "truncate",
+			"signature": [
+				"const char *path",
+				"long length"
+			],
+			"symbol": "__x64_sys_truncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 77,
+			"kconfig": null,
+			"line": 210,
+			"name": "ftruncate",
+			"number": 77,
+			"origname": "ftruncate",
+			"signature": [
+				"unsigned int fd",
+				"off_t length"
+			],
+			"symbol": "__x64_sys_ftruncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 78,
+			"kconfig": null,
+			"line": 308,
+			"name": "getdents",
+			"number": 78,
+			"origname": "getdents",
+			"signature": [
+				"unsigned int fd",
+				"struct linux_dirent *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__x64_sys_getdents"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/d_path.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 79,
+			"kconfig": null,
+			"line": 412,
+			"name": "getcwd",
+			"number": 79,
+			"origname": "getcwd",
+			"signature": [
+				"char *buf",
+				"unsigned long size"
+			],
+			"symbol": "__x64_sys_getcwd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 80,
+			"kconfig": null,
+			"line": 551,
+			"name": "chdir",
+			"number": 80,
+			"origname": "chdir",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__x64_sys_chdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 81,
+			"kconfig": null,
+			"line": 577,
+			"name": "fchdir",
+			"number": 81,
+			"origname": "fchdir",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__x64_sys_fchdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 82,
+			"kconfig": null,
+			"line": 5271,
+			"name": "rename",
+			"number": 82,
+			"origname": "rename",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__x64_sys_rename"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 83,
+			"kconfig": null,
+			"line": 4354,
+			"name": "mkdir",
+			"number": 83,
+			"origname": "mkdir",
+			"signature": [
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_mkdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 84,
+			"kconfig": null,
+			"line": 4472,
+			"name": "rmdir",
+			"number": 84,
+			"origname": "rmdir",
+			"signature": [
+				"const char *pathname"
+			],
+			"symbol": "__x64_sys_rmdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 85,
+			"kconfig": null,
+			"line": 1515,
+			"name": "creat",
+			"number": 85,
+			"origname": "creat",
+			"signature": [
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_creat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 86,
+			"kconfig": null,
+			"line": 4897,
+			"name": "link",
+			"number": 86,
+			"origname": "link",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__x64_sys_link"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 87,
+			"kconfig": null,
+			"line": 4635,
+			"name": "unlink",
+			"number": 87,
+			"origname": "unlink",
+			"signature": [
+				"const char *pathname"
+			],
+			"symbol": "__x64_sys_unlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 88,
+			"kconfig": null,
+			"line": 4716,
+			"name": "symlink",
+			"number": 88,
+			"origname": "symlink",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__x64_sys_symlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 89,
+			"kconfig": null,
+			"line": 598,
+			"name": "readlink",
+			"number": 89,
+			"origname": "readlink",
+			"signature": [
+				"const char *path",
+				"char *buf",
+				"int bufsiz"
+			],
+			"symbol": "__x64_sys_readlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 90,
+			"kconfig": null,
+			"line": 712,
+			"name": "chmod",
+			"number": 90,
+			"origname": "chmod",
+			"signature": [
+				"const char *filename",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_chmod"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 91,
+			"kconfig": null,
+			"line": 663,
+			"name": "fchmod",
+			"number": 91,
+			"origname": "fchmod",
+			"signature": [
+				"unsigned int fd",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_fchmod"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 92,
+			"kconfig": null,
+			"line": 831,
+			"name": "chown",
+			"number": 92,
+			"origname": "chown",
+			"signature": [
+				"const char *filename",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__x64_sys_chown"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 93,
+			"kconfig": null,
+			"line": 865,
+			"name": "fchown",
+			"number": 93,
+			"origname": "fchown",
+			"signature": [
+				"unsigned int fd",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__x64_sys_fchown"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 94,
+			"kconfig": null,
+			"line": 836,
+			"name": "lchown",
+			"number": 94,
+			"origname": "lchown",
+			"signature": [
+				"const char *filename",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__x64_sys_lchown"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 95,
+			"kconfig": null,
+			"line": 1908,
+			"name": "umask",
+			"number": 95,
+			"origname": "umask",
+			"signature": [
+				"int mask"
+			],
+			"symbol": "__x64_sys_umask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 96,
+			"kconfig": null,
+			"line": 140,
+			"name": "gettimeofday",
+			"number": 96,
+			"origname": "gettimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__x64_sys_gettimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 97,
+			"kconfig": null,
+			"line": 1529,
+			"name": "getrlimit",
+			"number": 97,
+			"origname": "getrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__x64_sys_getrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 98,
+			"kconfig": null,
+			"line": 1882,
+			"name": "getrusage",
+			"number": 98,
+			"origname": "getrusage",
+			"signature": [
+				"int who",
+				"struct rusage *ru"
+			],
+			"symbol": "__x64_sys_getrusage"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 99,
+			"kconfig": null,
+			"line": 2902,
+			"name": "sysinfo",
+			"number": 99,
+			"origname": "sysinfo",
+			"signature": [
+				"struct sysinfo *info"
+			],
+			"symbol": "__x64_sys_sysinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 100,
+			"kconfig": null,
+			"line": 1034,
+			"name": "times",
+			"number": 100,
+			"origname": "times",
+			"signature": [
+				"struct tms *tbuf"
+			],
+			"symbol": "__x64_sys_times"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/ptrace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 101,
+			"kconfig": null,
+			"line": 1258,
+			"name": "ptrace",
+			"number": 101,
+			"origname": "ptrace",
+			"signature": [
+				"long request",
+				"long pid",
+				"unsigned long addr",
+				"unsigned long data"
+			],
+			"symbol": "__x64_sys_ptrace"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 102,
+			"kconfig": null,
+			"line": 997,
+			"name": "getuid",
+			"number": 102,
+			"origname": "getuid",
+			"signature": [],
+			"symbol": "__x64_sys_getuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/printk/printk.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 103,
+			"kconfig": null,
+			"line": 1875,
+			"name": "syslog",
+			"number": 103,
+			"origname": "syslog",
+			"signature": [
+				"int type",
+				"char *buf",
+				"int len"
+			],
+			"symbol": "__x64_sys_syslog"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 104,
+			"kconfig": null,
+			"line": 1009,
+			"name": "getgid",
+			"number": 104,
+			"origname": "getgid",
+			"signature": [],
+			"symbol": "__x64_sys_getgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 105,
+			"kconfig": "MULTIUSER",
+			"line": 668,
+			"name": "setuid",
+			"number": 105,
+			"origname": "setuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__x64_sys_setuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 106,
+			"kconfig": "MULTIUSER",
+			"line": 485,
+			"name": "setgid",
+			"number": 106,
+			"origname": "setgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__x64_sys_setgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 107,
+			"kconfig": null,
+			"line": 1003,
+			"name": "geteuid",
+			"number": 107,
+			"origname": "geteuid",
+			"signature": [],
+			"symbol": "__x64_sys_geteuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 108,
+			"kconfig": null,
+			"line": 1015,
+			"name": "getegid",
+			"number": 108,
+			"origname": "getegid",
+			"signature": [],
+			"symbol": "__x64_sys_getegid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 109,
+			"kconfig": null,
+			"line": 1084,
+			"name": "setpgid",
+			"number": 109,
+			"origname": "setpgid",
+			"signature": [
+				"pid_t pid",
+				"pid_t pgid"
+			],
+			"symbol": "__x64_sys_setpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 110,
+			"kconfig": null,
+			"line": 986,
+			"name": "getppid",
+			"number": 110,
+			"origname": "getppid",
+			"signature": [],
+			"symbol": "__x64_sys_getppid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 111,
+			"kconfig": null,
+			"line": 1190,
+			"name": "getpgrp",
+			"number": 111,
+			"origname": "getpgrp",
+			"signature": [],
+			"symbol": "__x64_sys_getpgrp"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 112,
+			"kconfig": null,
+			"line": 1269,
+			"name": "setsid",
+			"number": 112,
+			"origname": "setsid",
+			"signature": [],
+			"symbol": "__x64_sys_setsid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 113,
+			"kconfig": "MULTIUSER",
+			"line": 605,
+			"name": "setreuid",
+			"number": 113,
+			"origname": "setreuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid"
+			],
+			"symbol": "__x64_sys_setreuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 114,
+			"kconfig": "MULTIUSER",
+			"line": 439,
+			"name": "setregid",
+			"number": 114,
+			"origname": "setregid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid"
+			],
+			"symbol": "__x64_sys_setregid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 115,
+			"kconfig": "MULTIUSER",
+			"line": 161,
+			"name": "getgroups",
+			"number": 115,
+			"origname": "getgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__x64_sys_getgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 116,
+			"kconfig": "MULTIUSER",
+			"line": 198,
+			"name": "setgroups",
+			"number": 116,
+			"origname": "setgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__x64_sys_setgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 117,
+			"kconfig": "MULTIUSER",
+			"line": 753,
+			"name": "setresuid",
+			"number": 117,
+			"origname": "setresuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid",
+				"uid_t suid"
+			],
+			"symbol": "__x64_sys_setresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 118,
+			"kconfig": "MULTIUSER",
+			"line": 758,
+			"name": "getresuid",
+			"number": 118,
+			"origname": "getresuid",
+			"signature": [
+				"uid_t *ruidp",
+				"uid_t *euidp",
+				"uid_t *suidp"
+			],
+			"symbol": "__x64_sys_getresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 119,
+			"kconfig": "MULTIUSER",
+			"line": 842,
+			"name": "setresgid",
+			"number": 119,
+			"origname": "setresgid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid",
+				"gid_t sgid"
+			],
+			"symbol": "__x64_sys_setresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 120,
+			"kconfig": "MULTIUSER",
+			"line": 847,
+			"name": "getresgid",
+			"number": 120,
+			"origname": "getresgid",
+			"signature": [
+				"gid_t *rgidp",
+				"gid_t *egidp",
+				"gid_t *sgidp"
+			],
+			"symbol": "__x64_sys_getresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 121,
+			"kconfig": null,
+			"line": 1183,
+			"name": "getpgid",
+			"number": 121,
+			"origname": "getpgid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__x64_sys_getpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 122,
+			"kconfig": "MULTIUSER",
+			"line": 910,
+			"name": "setfsuid",
+			"number": 122,
+			"origname": "setfsuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__x64_sys_setfsuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 123,
+			"kconfig": "MULTIUSER",
+			"line": 954,
+			"name": "setfsgid",
+			"number": 123,
+			"origname": "setfsgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__x64_sys_setfsgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 124,
+			"kconfig": null,
+			"line": 1197,
+			"name": "getsid",
+			"number": 124,
+			"origname": "getsid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__x64_sys_getsid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 125,
+			"kconfig": "MULTIUSER",
+			"line": 137,
+			"name": "capget",
+			"number": 125,
+			"origname": "capget",
+			"signature": [
+				"cap_user_header_t header",
+				"cap_user_data_t dataptr"
+			],
+			"symbol": "__x64_sys_capget"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 126,
+			"kconfig": "MULTIUSER",
+			"line": 216,
+			"name": "capset",
+			"number": 126,
+			"origname": "capset",
+			"signature": [
+				"cap_user_header_t header",
+				"const cap_user_data_t data"
+			],
+			"symbol": "__x64_sys_capset"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 127,
+			"kconfig": null,
+			"line": 3392,
+			"name": "rt_sigpending",
+			"number": 127,
+			"origname": "rt_sigpending",
+			"signature": [
+				"sigset_t *uset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_rt_sigpending"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 128,
+			"kconfig": null,
+			"line": 3806,
+			"name": "rt_sigtimedwait",
+			"number": 128,
+			"origname": "rt_sigtimedwait",
+			"signature": [
+				"const sigset_t *uthese",
+				"siginfo_t *uinfo",
+				"const struct __kernel_timespec *uts",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_rt_sigtimedwait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 129,
+			"kconfig": null,
+			"line": 4188,
+			"name": "rt_sigqueueinfo",
+			"number": 129,
+			"origname": "rt_sigqueueinfo",
+			"signature": [
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__x64_sys_rt_sigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 130,
+			"kconfig": null,
+			"line": 4829,
+			"name": "rt_sigsuspend",
+			"number": 130,
+			"origname": "rt_sigsuspend",
+			"signature": [
+				"sigset_t *unewset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_rt_sigsuspend"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 131,
+			"kconfig": null,
+			"line": 4423,
+			"name": "sigaltstack",
+			"number": 131,
+			"origname": "sigaltstack",
+			"signature": [
+				"const stack_t *uss",
+				"stack_t *uoss"
+			],
+			"symbol": "__x64_sys_sigaltstack"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 132,
+			"kconfig": null,
+			"line": 210,
+			"name": "utime",
+			"number": 132,
+			"origname": "utime",
+			"signature": [
+				"char *filename",
+				"struct utimbuf *times"
+			],
+			"symbol": "__x64_sys_utime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 133,
+			"kconfig": null,
+			"line": 4272,
+			"name": "mknod",
+			"number": 133,
+			"origname": "mknod",
+			"signature": [
+				"const char *filename",
+				"umode_t mode",
+				"unsigned dev"
+			],
+			"symbol": "__x64_sys_mknod"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exec_domain.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 135,
+			"kconfig": null,
+			"line": 38,
+			"name": "personality",
+			"number": 135,
+			"origname": "personality",
+			"signature": [
+				"unsigned int personality"
+			],
+			"symbol": "__x64_sys_personality"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 136,
+			"kconfig": null,
+			"line": 246,
+			"name": "ustat",
+			"number": 136,
+			"origname": "ustat",
+			"signature": [
+				"unsigned dev",
+				"struct ustat *ubuf"
+			],
+			"symbol": "__x64_sys_ustat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 137,
+			"kconfig": null,
+			"line": 190,
+			"name": "statfs",
+			"number": 137,
+			"origname": "statfs",
+			"signature": [
+				"const char *pathname",
+				"struct statfs *buf"
+			],
+			"symbol": "__x64_sys_statfs"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 138,
+			"kconfig": null,
+			"line": 211,
+			"name": "fstatfs",
+			"number": 138,
+			"origname": "fstatfs",
+			"signature": [
+				"unsigned int fd",
+				"struct statfs *buf"
+			],
+			"symbol": "__x64_sys_fstatfs"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/filesystems.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 139,
+			"kconfig": "SYSFS_SYSCALL",
+			"line": 191,
+			"name": "sysfs",
+			"number": 139,
+			"origname": "sysfs",
+			"signature": [
+				"int option",
+				"unsigned long arg1",
+				"unsigned long arg2"
+			],
+			"symbol": "__x64_sys_sysfs"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 140,
+			"kconfig": null,
+			"line": 299,
+			"name": "getpriority",
+			"number": 140,
+			"origname": "getpriority",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__x64_sys_getpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 141,
+			"kconfig": null,
+			"line": 229,
+			"name": "setpriority",
+			"number": 141,
+			"origname": "setpriority",
+			"signature": [
+				"int which",
+				"int who",
+				"int niceval"
+			],
+			"symbol": "__x64_sys_setpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 142,
+			"kconfig": null,
+			"line": 970,
+			"name": "sched_setparam",
+			"number": 142,
+			"origname": "sched_setparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__x64_sys_sched_setparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 143,
+			"kconfig": null,
+			"line": 1046,
+			"name": "sched_getparam",
+			"number": 143,
+			"origname": "sched_getparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__x64_sys_sched_getparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 144,
+			"kconfig": null,
+			"line": 955,
+			"name": "sched_setscheduler",
+			"number": 144,
+			"origname": "sched_setscheduler",
+			"signature": [
+				"pid_t pid",
+				"int policy",
+				"struct sched_param *param"
+			],
+			"symbol": "__x64_sys_sched_setscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 145,
+			"kconfig": null,
+			"line": 1016,
+			"name": "sched_getscheduler",
+			"number": 145,
+			"origname": "sched_getscheduler",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__x64_sys_sched_getscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 146,
+			"kconfig": null,
+			"line": 1485,
+			"name": "sched_get_priority_max",
+			"number": 146,
+			"origname": "sched_get_priority_max",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__x64_sys_sched_get_priority_max"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 147,
+			"kconfig": null,
+			"line": 1513,
+			"name": "sched_get_priority_min",
+			"number": 147,
+			"origname": "sched_get_priority_min",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__x64_sys_sched_get_priority_min"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 148,
+			"kconfig": null,
+			"line": 1571,
+			"name": "sched_rr_get_interval",
+			"number": 148,
+			"origname": "sched_rr_get_interval",
+			"signature": [
+				"pid_t pid",
+				"struct __kernel_timespec *interval"
+			],
+			"symbol": "__x64_sys_sched_rr_get_interval"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 149,
+			"kconfig": "MMU",
+			"line": 659,
+			"name": "mlock",
+			"number": 149,
+			"origname": "mlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__x64_sys_mlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 150,
+			"kconfig": "MMU",
+			"line": 677,
+			"name": "munlock",
+			"number": 150,
+			"origname": "munlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__x64_sys_munlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 151,
+			"kconfig": "MMU",
+			"line": 745,
+			"name": "mlockall",
+			"number": 151,
+			"origname": "mlockall",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__x64_sys_mlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 152,
+			"kconfig": "MMU",
+			"line": 774,
+			"name": "munlockall",
+			"number": 152,
+			"origname": "munlockall",
+			"signature": [],
+			"symbol": "__x64_sys_munlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 153,
+			"kconfig": null,
+			"line": 1596,
+			"name": "vhangup",
+			"number": 153,
+			"origname": "vhangup",
+			"signature": [],
+			"symbol": "__x64_sys_vhangup"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ldt.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 154,
+			"kconfig": "MODIFY_LDT_SYSCALL",
+			"line": 667,
+			"name": "modify_ldt",
+			"number": 154,
+			"origname": "modify_ldt",
+			"signature": [
+				"int func",
+				"void *ptr",
+				"unsigned long bytecount"
+			],
+			"symbol": "__x64_sys_modify_ldt"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 155,
+			"kconfig": null,
+			"line": 4388,
+			"name": "pivot_root",
+			"number": 155,
+			"origname": "pivot_root",
+			"signature": [
+				"const char *new_root",
+				"const char *put_old"
+			],
+			"symbol": "__x64_sys_pivot_root"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 157,
+			"kconfig": null,
+			"line": 2469,
+			"name": "prctl",
+			"number": 157,
+			"origname": "prctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__x64_sys_prctl"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/process_64.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 158,
+			"kconfig": null,
+			"line": 983,
+			"name": "arch_prctl",
+			"number": 158,
+			"origname": "arch_prctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2"
+			],
+			"symbol": "__x64_sys_arch_prctl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 159,
+			"kconfig": null,
+			"line": 269,
+			"name": "adjtimex",
+			"number": 159,
+			"origname": "adjtimex",
+			"signature": [
+				"struct __kernel_timex *txc_p"
+			],
+			"symbol": "__x64_sys_adjtimex"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 160,
+			"kconfig": null,
+			"line": 1742,
+			"name": "setrlimit",
+			"number": 160,
+			"origname": "setrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__x64_sys_setrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 161,
+			"kconfig": null,
+			"line": 594,
+			"name": "chroot",
+			"number": 161,
+			"origname": "chroot",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__x64_sys_chroot"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 162,
+			"kconfig": null,
+			"line": 111,
+			"name": "sync",
+			"number": 162,
+			"origname": "sync",
+			"signature": [],
+			"symbol": "__x64_sys_sync"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/acct.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 163,
+			"kconfig": "BSD_PROCESS_ACCT",
+			"line": 314,
+			"name": "acct",
+			"number": 163,
+			"origname": "acct",
+			"signature": [
+				"const char *name"
+			],
+			"symbol": "__x64_sys_acct"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 164,
+			"kconfig": null,
+			"line": 199,
+			"name": "settimeofday",
+			"number": 164,
+			"origname": "settimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__x64_sys_settimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 165,
+			"kconfig": null,
+			"line": 4088,
+			"name": "mount",
+			"number": 165,
+			"origname": "mount",
+			"signature": [
+				"char *dev_name",
+				"char *dir_name",
+				"char *type",
+				"unsigned long flags",
+				"void *data"
+			],
+			"symbol": "__x64_sys_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 166,
+			"kconfig": null,
+			"line": 2077,
+			"name": "umount",
+			"number": 166,
+			"origname": "umount",
+			"signature": [
+				"char *name",
+				"int flags"
+			],
+			"symbol": "__x64_sys_umount"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 167,
+			"kconfig": "SWAP",
+			"line": 3266,
+			"name": "swapon",
+			"number": 167,
+			"origname": "swapon",
+			"signature": [
+				"const char *specialfile",
+				"int swap_flags"
+			],
+			"symbol": "__x64_sys_swapon"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 168,
+			"kconfig": "SWAP",
+			"line": 2652,
+			"name": "swapoff",
+			"number": 168,
+			"origname": "swapoff",
+			"signature": [
+				"const char *specialfile"
+			],
+			"symbol": "__x64_sys_swapoff"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/reboot.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 169,
+			"kconfig": null,
+			"line": 722,
+			"name": "reboot",
+			"number": 169,
+			"origname": "reboot",
+			"signature": [
+				"int magic1",
+				"int magic2",
+				"unsigned int cmd",
+				"void *arg"
+			],
+			"symbol": "__x64_sys_reboot"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 170,
+			"kconfig": null,
+			"line": 1385,
+			"name": "sethostname",
+			"number": 170,
+			"origname": "sethostname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__x64_sys_sethostname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 171,
+			"kconfig": null,
+			"line": 1439,
+			"name": "setdomainname",
+			"number": 171,
+			"origname": "setdomainname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__x64_sys_setdomainname"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ioport.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 172,
+			"kconfig": "X86_IOPL_IOPERM",
+			"line": 173,
+			"name": "iopl",
+			"number": 172,
+			"origname": "iopl",
+			"signature": [
+				"unsigned int level"
+			],
+			"symbol": "__x64_sys_iopl"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ioport.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 173,
+			"kconfig": "X86_IOPL_IOPERM",
+			"line": 152,
+			"name": "ioperm",
+			"number": 173,
+			"origname": "ioperm",
+			"signature": [
+				"unsigned long from",
+				"unsigned long num",
+				"int turn_on"
+			],
+			"symbol": "__x64_sys_ioperm"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 175,
+			"kconfig": "MODULES",
+			"line": 3515,
+			"name": "init_module",
+			"number": 175,
+			"origname": "init_module",
+			"signature": [
+				"void *umod",
+				"unsigned long len",
+				"const char *uargs"
+			],
+			"symbol": "__x64_sys_init_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 176,
+			"kconfig": "MODULE_UNLOAD",
+			"line": 732,
+			"name": "delete_module",
+			"number": 176,
+			"origname": "delete_module",
+			"signature": [
+				"const char *name_user",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_delete_module"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 179,
+			"kconfig": "QUOTACTL",
+			"line": 917,
+			"name": "quotactl",
+			"number": 179,
+			"origname": "quotactl",
+			"signature": [
+				"unsigned int cmd",
+				"const char *special",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__x64_sys_quotactl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 186,
+			"kconfig": null,
+			"line": 975,
+			"name": "gettid",
+			"number": 186,
+			"origname": "gettid",
+			"signature": [],
+			"symbol": "__x64_sys_gettid"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/readahead.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 187,
+			"kconfig": null,
+			"line": 711,
+			"name": "readahead",
+			"number": 187,
+			"origname": "readahead",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"size_t count"
+			],
+			"symbol": "__x64_sys_readahead"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 188,
+			"kconfig": null,
+			"line": 743,
+			"name": "setxattr",
+			"number": 188,
+			"origname": "setxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__x64_sys_setxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 189,
+			"kconfig": null,
+			"line": 750,
+			"name": "lsetxattr",
+			"number": 189,
+			"origname": "lsetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__x64_sys_lsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 190,
+			"kconfig": null,
+			"line": 758,
+			"name": "fsetxattr",
+			"number": 190,
+			"origname": "fsetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__x64_sys_fsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 191,
+			"kconfig": null,
+			"line": 888,
+			"name": "getxattr",
+			"number": 191,
+			"origname": "getxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_getxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 192,
+			"kconfig": null,
+			"line": 894,
+			"name": "lgetxattr",
+			"number": 192,
+			"origname": "lgetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_lgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 193,
+			"kconfig": null,
+			"line": 901,
+			"name": "fgetxattr",
+			"number": 193,
+			"origname": "fgetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_fgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 194,
+			"kconfig": null,
+			"line": 998,
+			"name": "listxattr",
+			"number": 194,
+			"origname": "listxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_listxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 195,
+			"kconfig": null,
+			"line": 1004,
+			"name": "llistxattr",
+			"number": 195,
+			"origname": "llistxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_llistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 196,
+			"kconfig": null,
+			"line": 1010,
+			"name": "flistxattr",
+			"number": 196,
+			"origname": "flistxattr",
+			"signature": [
+				"int fd",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_flistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 197,
+			"kconfig": null,
+			"line": 1097,
+			"name": "removexattr",
+			"number": 197,
+			"origname": "removexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__x64_sys_removexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 198,
+			"kconfig": null,
+			"line": 1103,
+			"name": "lremovexattr",
+			"number": 198,
+			"origname": "lremovexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__x64_sys_lremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 199,
+			"kconfig": null,
+			"line": 1109,
+			"name": "fremovexattr",
+			"number": 199,
+			"origname": "fremovexattr",
+			"signature": [
+				"int fd",
+				"const char *name"
+			],
+			"symbol": "__x64_sys_fremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 200,
+			"kconfig": null,
+			"line": 4160,
+			"name": "tkill",
+			"number": 200,
+			"origname": "tkill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__x64_sys_tkill"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 201,
+			"kconfig": null,
+			"line": 62,
+			"name": "time",
+			"number": 201,
+			"origname": "time",
+			"signature": [
+				"__kernel_old_time_t *tloc"
+			],
+			"symbol": "__x64_sys_time"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 202,
+			"kconfig": "FUTEX",
+			"line": 160,
+			"name": "futex",
+			"number": 202,
+			"origname": "futex",
+			"signature": [
+				"u32 *uaddr",
+				"int op",
+				"u32 val",
+				"const struct __kernel_timespec *utime",
+				"u32 *uaddr2",
+				"u32 val3"
+			],
+			"symbol": "__x64_sys_futex"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 203,
+			"kconfig": null,
+			"line": 1279,
+			"name": "sched_setaffinity",
+			"number": 203,
+			"origname": "sched_setaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__x64_sys_sched_setaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 204,
+			"kconfig": null,
+			"line": 1324,
+			"name": "sched_getaffinity",
+			"number": 204,
+			"origname": "sched_getaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__x64_sys_sched_getaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 206,
+			"kconfig": "AIO",
+			"line": 1382,
+			"name": "io_setup",
+			"number": 206,
+			"origname": "io_setup",
+			"signature": [
+				"unsigned nr_events",
+				"aio_context_t *ctxp"
+			],
+			"symbol": "__x64_sys_io_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 207,
+			"kconfig": "AIO",
+			"line": 1451,
+			"name": "io_destroy",
+			"number": 207,
+			"origname": "io_destroy",
+			"signature": [
+				"aio_context_t ctx"
+			],
+			"symbol": "__x64_sys_io_destroy"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 208,
+			"kconfig": "AIO",
+			"line": 2250,
+			"name": "io_getevents",
+			"number": 208,
+			"origname": "io_getevents",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct __kernel_timespec *timeout"
+			],
+			"symbol": "__x64_sys_io_getevents"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 209,
+			"kconfig": "AIO",
+			"line": 2081,
+			"name": "io_submit",
+			"number": 209,
+			"origname": "io_submit",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long nr",
+				"struct iocb **iocbpp"
+			],
+			"symbol": "__x64_sys_io_submit"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 210,
+			"kconfig": "AIO",
+			"line": 2175,
+			"name": "io_cancel",
+			"number": 210,
+			"origname": "io_cancel",
+			"signature": [
+				"aio_context_t ctx_id",
+				"struct iocb *iocb",
+				"struct io_event *result"
+			],
+			"symbol": "__x64_sys_io_cancel"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 213,
+			"kconfig": "EPOLL",
+			"line": 2256,
+			"name": "epoll_create",
+			"number": 213,
+			"origname": "epoll_create",
+			"signature": [
+				"int size"
+			],
+			"symbol": "__x64_sys_epoll_create"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 216,
+			"kconfig": "MMU",
+			"line": 1091,
+			"name": "remap_file_pages",
+			"number": 216,
+			"origname": "remap_file_pages",
+			"signature": [
+				"unsigned long start",
+				"unsigned long size",
+				"unsigned long prot",
+				"unsigned long pgoff",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_remap_file_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 217,
+			"kconfig": null,
+			"line": 389,
+			"name": "getdents64",
+			"number": 217,
+			"origname": "getdents64",
+			"signature": [
+				"unsigned int fd",
+				"struct linux_dirent64 *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__x64_sys_getdents64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 218,
+			"kconfig": null,
+			"line": 1949,
+			"name": "set_tid_address",
+			"number": 218,
+			"origname": "set_tid_address",
+			"signature": [
+				"int *tidptr"
+			],
+			"symbol": "__x64_sys_set_tid_address"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 219,
+			"kconfig": null,
+			"line": 3177,
+			"name": "restart_syscall",
+			"number": 219,
+			"origname": "restart_syscall",
+			"signature": [],
+			"symbol": "__x64_sys_restart_syscall"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 220,
+			"kconfig": "SYSVIPC",
+			"line": 2268,
+			"name": "semtimedop",
+			"number": 220,
+			"origname": "semtimedop",
+			"signature": [
+				"int semid",
+				"struct sembuf *tsops",
+				"unsigned int nsops",
+				"const struct __kernel_timespec *timeout"
+			],
+			"symbol": "__x64_sys_semtimedop"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/fadvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 221,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 208,
+			"name": "fadvise64",
+			"number": 221,
+			"origname": "fadvise64",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"size_t len",
+				"int advice"
+			],
+			"symbol": "__x64_sys_fadvise64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 222,
+			"kconfig": "POSIX_TIMERS",
+			"line": 480,
+			"name": "timer_create",
+			"number": 222,
+			"origname": "timer_create",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct sigevent *timer_event_spec",
+				"timer_t *created_timer_id"
+			],
+			"symbol": "__x64_sys_timer_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 223,
+			"kconfig": "POSIX_TIMERS",
+			"line": 914,
+			"name": "timer_settime",
+			"number": 223,
+			"origname": "timer_settime",
+			"signature": [
+				"timer_t timer_id",
+				"int flags",
+				"const struct __kernel_itimerspec *new_setting",
+				"struct __kernel_itimerspec *old_setting"
+			],
+			"symbol": "__x64_sys_timer_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 224,
+			"kconfig": "POSIX_TIMERS",
+			"line": 676,
+			"name": "timer_gettime",
+			"number": 224,
+			"origname": "timer_gettime",
+			"signature": [
+				"timer_t timer_id",
+				"struct __kernel_itimerspec *setting"
+			],
+			"symbol": "__x64_sys_timer_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 225,
+			"kconfig": "POSIX_TIMERS",
+			"line": 724,
+			"name": "timer_getoverrun",
+			"number": 225,
+			"origname": "timer_getoverrun",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__x64_sys_timer_getoverrun"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 226,
+			"kconfig": "POSIX_TIMERS",
+			"line": 994,
+			"name": "timer_delete",
+			"number": 226,
+			"origname": "timer_delete",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__x64_sys_timer_delete"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 227,
+			"kconfig": null,
+			"line": 1119,
+			"name": "clock_settime",
+			"number": 227,
+			"origname": "clock_settime",
+			"signature": [
+				"const clockid_t which_clock",
+				"const struct __kernel_timespec *tp"
+			],
+			"symbol": "__x64_sys_clock_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 228,
+			"kconfig": null,
+			"line": 1138,
+			"name": "clock_gettime",
+			"number": 228,
+			"origname": "clock_gettime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__x64_sys_clock_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 229,
+			"kconfig": null,
+			"line": 1258,
+			"name": "clock_getres",
+			"number": 229,
+			"origname": "clock_getres",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__x64_sys_clock_getres"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 230,
+			"kconfig": null,
+			"line": 1379,
+			"name": "clock_nanosleep",
+			"number": 230,
+			"origname": "clock_nanosleep",
+			"signature": [
+				"const clockid_t which_clock",
+				"int flags",
+				"const struct __kernel_timespec *rqtp",
+				"struct __kernel_timespec *rmtp"
+			],
+			"symbol": "__x64_sys_clock_nanosleep"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 231,
+			"kconfig": null,
+			"line": 1096,
+			"name": "exit_group",
+			"number": 231,
+			"origname": "exit_group",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__x64_sys_exit_group"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 232,
+			"kconfig": "EPOLL",
+			"line": 2487,
+			"name": "epoll_wait",
+			"number": 232,
+			"origname": "epoll_wait",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"int timeout"
+			],
+			"symbol": "__x64_sys_epoll_wait"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 233,
+			"kconfig": "EPOLL",
+			"line": 2436,
+			"name": "epoll_ctl",
+			"number": 233,
+			"origname": "epoll_ctl",
+			"signature": [
+				"int epfd",
+				"int op",
+				"int fd",
+				"struct epoll_event *event"
+			],
+			"symbol": "__x64_sys_epoll_ctl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 234,
+			"kconfig": null,
+			"line": 4144,
+			"name": "tgkill",
+			"number": 234,
+			"origname": "tgkill",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__x64_sys_tgkill"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 235,
+			"kconfig": null,
+			"line": 204,
+			"name": "utimes",
+			"number": 235,
+			"origname": "utimes",
+			"signature": [
+				"char *filename",
+				"struct __kernel_old_timeval *utimes"
+			],
+			"symbol": "__x64_sys_utimes"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 237,
+			"kconfig": "NUMA",
+			"line": 1607,
+			"name": "mbind",
+			"number": 237,
+			"origname": "mbind",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_mbind"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 238,
+			"kconfig": "NUMA",
+			"line": 1634,
+			"name": "set_mempolicy",
+			"number": 238,
+			"origname": "set_mempolicy",
+			"signature": [
+				"int mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode"
+			],
+			"symbol": "__x64_sys_set_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 239,
+			"kconfig": "NUMA",
+			"line": 1764,
+			"name": "get_mempolicy",
+			"number": 239,
+			"origname": "get_mempolicy",
+			"signature": [
+				"int *policy",
+				"unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned long addr",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_get_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 240,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 944,
+			"name": "mq_open",
+			"number": 240,
+			"origname": "mq_open",
+			"signature": [
+				"const char *u_name",
+				"int oflag",
+				"umode_t mode",
+				"struct mq_attr *u_attr"
+			],
+			"symbol": "__x64_sys_mq_open"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 241,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 954,
+			"name": "mq_unlink",
+			"number": 241,
+			"origname": "mq_unlink",
+			"signature": [
+				"const char *u_name"
+			],
+			"symbol": "__x64_sys_mq_unlink"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 242,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1258,
+			"name": "mq_timedsend",
+			"number": 242,
+			"origname": "mq_timedsend",
+			"signature": [
+				"mqd_t mqdes",
+				"const char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__x64_sys_mq_timedsend"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 243,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1272,
+			"name": "mq_timedreceive",
+			"number": 243,
+			"origname": "mq_timedreceive",
+			"signature": [
+				"mqd_t mqdes",
+				"char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int *u_msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__x64_sys_mq_timedreceive"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 244,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1400,
+			"name": "mq_notify",
+			"number": 244,
+			"origname": "mq_notify",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct sigevent *u_notification"
+			],
+			"symbol": "__x64_sys_mq_notify"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 245,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1452,
+			"name": "mq_getsetattr",
+			"number": 245,
+			"origname": "mq_getsetattr",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct mq_attr *u_mqstat",
+				"struct mq_attr *u_omqstat"
+			],
+			"symbol": "__x64_sys_mq_getsetattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kexec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 246,
+			"kconfig": "KEXEC",
+			"line": 242,
+			"name": "kexec_load",
+			"number": 246,
+			"origname": "kexec_load",
+			"signature": [
+				"unsigned long entry",
+				"unsigned long nr_segments",
+				"struct kexec_segment *segments",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_kexec_load"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 247,
+			"kconfig": null,
+			"line": 1782,
+			"name": "waitid",
+			"number": 247,
+			"origname": "waitid",
+			"signature": [
+				"int which",
+				"pid_t upid",
+				"struct siginfo *infop",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__x64_sys_waitid"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 248,
+			"kconfig": "KEYS",
+			"line": 74,
+			"name": "add_key",
+			"number": 248,
+			"origname": "add_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const void *_payload",
+				"size_t plen",
+				"key_serial_t ringid"
+			],
+			"symbol": "__x64_sys_add_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 249,
+			"kconfig": "KEYS",
+			"line": 167,
+			"name": "request_key",
+			"number": 249,
+			"origname": "request_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const char *_callout_info",
+				"key_serial_t destringid"
+			],
+			"symbol": "__x64_sys_request_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 250,
+			"kconfig": "KEYS",
+			"line": 1874,
+			"name": "keyctl",
+			"number": 250,
+			"origname": "keyctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__x64_sys_keyctl"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 251,
+			"kconfig": "BLOCK",
+			"line": 69,
+			"name": "ioprio_set",
+			"number": 251,
+			"origname": "ioprio_set",
+			"signature": [
+				"int which",
+				"int who",
+				"int ioprio"
+			],
+			"symbol": "__x64_sys_ioprio_set"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 252,
+			"kconfig": "BLOCK",
+			"line": 184,
+			"name": "ioprio_get",
+			"number": 252,
+			"origname": "ioprio_get",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__x64_sys_ioprio_get"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 253,
+			"kconfig": "INOTIFY_USER",
+			"line": 724,
+			"name": "inotify_init",
+			"number": 253,
+			"origname": "inotify_init",
+			"signature": [],
+			"symbol": "__x64_sys_inotify_init"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 254,
+			"kconfig": "INOTIFY_USER",
+			"line": 729,
+			"name": "inotify_add_watch",
+			"number": 254,
+			"origname": "inotify_add_watch",
+			"signature": [
+				"int fd",
+				"const char *pathname",
+				"u32 mask"
+			],
+			"symbol": "__x64_sys_inotify_add_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 255,
+			"kconfig": "INOTIFY_USER",
+			"line": 786,
+			"name": "inotify_rm_watch",
+			"number": 255,
+			"origname": "inotify_rm_watch",
+			"signature": [
+				"int fd",
+				"__s32 wd"
+			],
+			"symbol": "__x64_sys_inotify_rm_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 256,
+			"kconfig": "MIGRATION",
+			"line": 1727,
+			"name": "migrate_pages",
+			"number": 256,
+			"origname": "migrate_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long maxnode",
+				"const unsigned long *old_nodes",
+				"const unsigned long *new_nodes"
+			],
+			"symbol": "__x64_sys_migrate_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 257,
+			"kconfig": null,
+			"line": 1454,
+			"name": "openat",
+			"number": 257,
+			"origname": "openat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int flags",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_openat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 258,
+			"kconfig": null,
+			"line": 4349,
+			"name": "mkdirat",
+			"number": 258,
+			"origname": "mkdirat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_mkdirat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 259,
+			"kconfig": null,
+			"line": 4266,
+			"name": "mknodat",
+			"number": 259,
+			"origname": "mknodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int dev"
+			],
+			"symbol": "__x64_sys_mknodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 260,
+			"kconfig": null,
+			"line": 825,
+			"name": "fchownat",
+			"number": 260,
+			"origname": "fchownat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"uid_t user",
+				"gid_t group",
+				"int flag"
+			],
+			"symbol": "__x64_sys_fchownat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 261,
+			"kconfig": null,
+			"line": 198,
+			"name": "futimesat",
+			"number": 261,
+			"origname": "futimesat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct __kernel_old_timeval *utimes"
+			],
+			"symbol": "__x64_sys_futimesat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 262,
+			"kconfig": null,
+			"line": 526,
+			"name": "newfstatat",
+			"number": 262,
+			"origname": "newfstatat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct stat *statbuf",
+				"int flag"
+			],
+			"symbol": "__x64_sys_newfstatat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 263,
+			"kconfig": null,
+			"line": 4625,
+			"name": "unlinkat",
+			"number": 263,
+			"origname": "unlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"int flag"
+			],
+			"symbol": "__x64_sys_unlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 264,
+			"kconfig": null,
+			"line": 5264,
+			"name": "renameat",
+			"number": 264,
+			"origname": "renameat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__x64_sys_renameat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 265,
+			"kconfig": null,
+			"line": 4890,
+			"name": "linkat",
+			"number": 265,
+			"origname": "linkat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"int flags"
+			],
+			"symbol": "__x64_sys_linkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 266,
+			"kconfig": null,
+			"line": 4710,
+			"name": "symlinkat",
+			"number": 266,
+			"origname": "symlinkat",
+			"signature": [
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__x64_sys_symlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 267,
+			"kconfig": null,
+			"line": 592,
+			"name": "readlinkat",
+			"number": 267,
+			"origname": "readlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"char *buf",
+				"int bufsiz"
+			],
+			"symbol": "__x64_sys_readlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 268,
+			"kconfig": null,
+			"line": 706,
+			"name": "fchmodat",
+			"number": 268,
+			"origname": "fchmodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode"
+			],
+			"symbol": "__x64_sys_fchmodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 269,
+			"kconfig": null,
+			"line": 535,
+			"name": "faccessat",
+			"number": 269,
+			"origname": "faccessat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode"
+			],
+			"symbol": "__x64_sys_faccessat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 270,
+			"kconfig": null,
+			"line": 793,
+			"name": "pselect6",
+			"number": 270,
+			"origname": "pselect6",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct __kernel_timespec *tsp",
+				"void *sig"
+			],
+			"symbol": "__x64_sys_pselect6"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 271,
+			"kconfig": null,
+			"line": 1095,
+			"name": "ppoll",
+			"number": 271,
+			"origname": "ppoll",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"struct __kernel_timespec *tsp",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_ppoll"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 272,
+			"kconfig": null,
+			"line": 3411,
+			"name": "unshare",
+			"number": 272,
+			"origname": "unshare",
+			"signature": [
+				"unsigned long unshare_flags"
+			],
+			"symbol": "__x64_sys_unshare"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 273,
+			"kconfig": "FUTEX",
+			"line": 28,
+			"name": "set_robust_list",
+			"number": 273,
+			"origname": "set_robust_list",
+			"signature": [
+				"struct robust_list_head *head",
+				"size_t len"
+			],
+			"symbol": "__x64_sys_set_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 274,
+			"kconfig": "FUTEX",
+			"line": 48,
+			"name": "get_robust_list",
+			"number": 274,
+			"origname": "get_robust_list",
+			"signature": [
+				"int pid",
+				"struct robust_list_head **head_ptr",
+				"size_t *len_ptr"
+			],
+			"symbol": "__x64_sys_get_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 275,
+			"kconfig": null,
+			"line": 1621,
+			"name": "splice",
+			"number": 275,
+			"origname": "splice",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_splice"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 276,
+			"kconfig": null,
+			"line": 1988,
+			"name": "tee",
+			"number": 276,
+			"origname": "tee",
+			"signature": [
+				"int fdin",
+				"int fdout",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_tee"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 277,
+			"kconfig": null,
+			"line": 363,
+			"name": "sync_file_range",
+			"number": 277,
+			"origname": "sync_file_range",
+			"signature": [
+				"int fd",
+				"loff_t offset",
+				"loff_t nbytes",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_sync_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 278,
+			"kconfig": null,
+			"line": 1583,
+			"name": "vmsplice",
+			"number": 278,
+			"origname": "vmsplice",
+			"signature": [
+				"int fd",
+				"const struct iovec *uiov",
+				"unsigned long nr_segs",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_vmsplice"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/migrate.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 279,
+			"kconfig": "MIGRATION",
+			"line": 2586,
+			"name": "move_pages",
+			"number": 279,
+			"origname": "move_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long nr_pages",
+				"const void **pages",
+				"const int *nodes",
+				"int *status",
+				"int flags"
+			],
+			"symbol": "__x64_sys_move_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 280,
+			"kconfig": null,
+			"line": 143,
+			"name": "utimensat",
+			"number": 280,
+			"origname": "utimensat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct __kernel_timespec *utimes",
+				"int flags"
+			],
+			"symbol": "__x64_sys_utimensat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 281,
+			"kconfig": "EPOLL",
+			"line": 2521,
+			"name": "epoll_pwait",
+			"number": 281,
+			"origname": "epoll_pwait",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"int timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_epoll_pwait"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/signalfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 282,
+			"kconfig": "SIGNALFD",
+			"line": 319,
+			"name": "signalfd",
+			"number": 282,
+			"origname": "signalfd",
+			"signature": [
+				"int ufd",
+				"sigset_t *user_mask",
+				"size_t sizemask"
+			],
+			"symbol": "__x64_sys_signalfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 283,
+			"kconfig": null,
+			"line": 395,
+			"name": "timerfd_create",
+			"number": 283,
+			"origname": "timerfd_create",
+			"signature": [
+				"int clockid",
+				"int flags"
+			],
+			"symbol": "__x64_sys_timerfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 284,
+			"kconfig": null,
+			"line": 429,
+			"name": "eventfd",
+			"number": 284,
+			"origname": "eventfd",
+			"signature": [
+				"unsigned int count"
+			],
+			"symbol": "__x64_sys_eventfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 285,
+			"kconfig": null,
+			"line": 365,
+			"name": "fallocate",
+			"number": 285,
+			"origname": "fallocate",
+			"signature": [
+				"int fd",
+				"int mode",
+				"loff_t offset",
+				"loff_t len"
+			],
+			"symbol": "__x64_sys_fallocate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 286,
+			"kconfig": null,
+			"line": 560,
+			"name": "timerfd_settime",
+			"number": 286,
+			"origname": "timerfd_settime",
+			"signature": [
+				"int ufd",
+				"int flags",
+				"const struct __kernel_itimerspec *utmr",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__x64_sys_timerfd_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 287,
+			"kconfig": null,
+			"line": 578,
+			"name": "timerfd_gettime",
+			"number": 287,
+			"origname": "timerfd_gettime",
+			"signature": [
+				"int ufd",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__x64_sys_timerfd_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 288,
+			"kconfig": "NET",
+			"line": 2004,
+			"name": "accept4",
+			"number": 288,
+			"origname": "accept4",
+			"signature": [
+				"int fd",
+				"struct sockaddr *upeer_sockaddr",
+				"int *upeer_addrlen",
+				"int flags"
+			],
+			"symbol": "__x64_sys_accept4"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/signalfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 289,
+			"kconfig": "SIGNALFD",
+			"line": 307,
+			"name": "signalfd4",
+			"number": 289,
+			"origname": "signalfd4",
+			"signature": [
+				"int ufd",
+				"sigset_t *user_mask",
+				"size_t sizemask",
+				"int flags"
+			],
+			"symbol": "__x64_sys_signalfd4"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 290,
+			"kconfig": null,
+			"line": 424,
+			"name": "eventfd2",
+			"number": 290,
+			"origname": "eventfd2",
+			"signature": [
+				"unsigned int count",
+				"int flags"
+			],
+			"symbol": "__x64_sys_eventfd2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 291,
+			"kconfig": "EPOLL",
+			"line": 2251,
+			"name": "epoll_create1",
+			"number": 291,
+			"origname": "epoll_create1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__x64_sys_epoll_create1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 292,
+			"kconfig": null,
+			"line": 1370,
+			"name": "dup3",
+			"number": 292,
+			"origname": "dup3",
+			"signature": [
+				"unsigned int oldfd",
+				"unsigned int newfd",
+				"int flags"
+			],
+			"symbol": "__x64_sys_dup3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/pipe.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 293,
+			"kconfig": null,
+			"line": 1043,
+			"name": "pipe2",
+			"number": 293,
+			"origname": "pipe2",
+			"signature": [
+				"int *fildes",
+				"int flags"
+			],
+			"symbol": "__x64_sys_pipe2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 294,
+			"kconfig": "INOTIFY_USER",
+			"line": 719,
+			"name": "inotify_init1",
+			"number": 294,
+			"origname": "inotify_init1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__x64_sys_inotify_init1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 295,
+			"kconfig": null,
+			"line": 1167,
+			"name": "preadv",
+			"number": 295,
+			"origname": "preadv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__x64_sys_preadv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 296,
+			"kconfig": null,
+			"line": 1187,
+			"name": "pwritev",
+			"number": 296,
+			"origname": "pwritev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__x64_sys_pwritev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 297,
+			"kconfig": null,
+			"line": 4228,
+			"name": "rt_tgsigqueueinfo",
+			"number": 297,
+			"origname": "rt_tgsigqueueinfo",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__x64_sys_rt_tgsigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/events/core.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 298,
+			"kconfig": "PERF_EVENTS",
+			"line": 12798,
+			"name": "perf_event_open",
+			"number": 298,
+			"origname": "perf_event_open",
+			"signature": [
+				"struct perf_event_attr *attr_uptr",
+				"pid_t pid",
+				"int cpu",
+				"int group_fd",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_perf_event_open"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 299,
+			"kconfig": "NET",
+			"line": 3020,
+			"name": "recvmmsg",
+			"number": 299,
+			"origname": "recvmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout"
+			],
+			"symbol": "__x64_sys_recvmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 300,
+			"kconfig": "FANOTIFY",
+			"line": 1466,
+			"name": "fanotify_init",
+			"number": 300,
+			"origname": "fanotify_init",
+			"signature": [
+				"unsigned int flags",
+				"unsigned int event_f_flags"
+			],
+			"symbol": "__x64_sys_fanotify_init"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 301,
+			"kconfig": "FANOTIFY",
+			"line": 2003,
+			"name": "fanotify_mark",
+			"number": 301,
+			"origname": "fanotify_mark",
+			"signature": [
+				"int fanotify_fd",
+				"unsigned int flags",
+				"__u64 mask",
+				"int dfd",
+				"const char *pathname"
+			],
+			"symbol": "__x64_sys_fanotify_mark"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 302,
+			"kconfig": null,
+			"line": 1695,
+			"name": "prlimit64",
+			"number": 302,
+			"origname": "prlimit64",
+			"signature": [
+				"pid_t pid",
+				"unsigned int resource",
+				"const struct rlimit64 *new_rlim",
+				"struct rlimit64 *old_rlim"
+			],
+			"symbol": "__x64_sys_prlimit64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 303,
+			"kconfig": "FHANDLE",
+			"line": 129,
+			"name": "name_to_handle_at",
+			"number": 303,
+			"origname": "name_to_handle_at",
+			"signature": [
+				"int dfd",
+				"const char *name",
+				"struct file_handle *handle",
+				"void *mnt_id",
+				"int flag"
+			],
+			"symbol": "__x64_sys_name_to_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 304,
+			"kconfig": "FHANDLE",
+			"line": 434,
+			"name": "open_by_handle_at",
+			"number": 304,
+			"origname": "open_by_handle_at",
+			"signature": [
+				"int mountdirfd",
+				"struct file_handle *handle",
+				"int flags"
+			],
+			"symbol": "__x64_sys_open_by_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 305,
+			"kconfig": null,
+			"line": 1168,
+			"name": "clock_adjtime",
+			"number": 305,
+			"origname": "clock_adjtime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timex *utx"
+			],
+			"symbol": "__x64_sys_clock_adjtime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 306,
+			"kconfig": null,
+			"line": 149,
+			"name": "syncfs",
+			"number": 306,
+			"origname": "syncfs",
+			"signature": [
+				"int fd"
+			],
+			"symbol": "__x64_sys_syncfs"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 307,
+			"kconfig": "NET",
+			"line": 2740,
+			"name": "sendmmsg",
+			"number": 307,
+			"origname": "sendmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_sendmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/nsproxy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 308,
+			"kconfig": null,
+			"line": 546,
+			"name": "setns",
+			"number": 308,
+			"origname": "setns",
+			"signature": [
+				"int fd",
+				"int flags"
+			],
+			"symbol": "__x64_sys_setns"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 309,
+			"kconfig": null,
+			"line": 2822,
+			"name": "getcpu",
+			"number": 309,
+			"origname": "getcpu",
+			"signature": [
+				"unsigned *cpup",
+				"unsigned *nodep",
+				"struct getcpu_cache *unused"
+			],
+			"symbol": "__x64_sys_getcpu"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 310,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 292,
+			"name": "process_vm_readv",
+			"number": 310,
+			"origname": "process_vm_readv",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_process_vm_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 311,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 299,
+			"name": "process_vm_writev",
+			"number": 311,
+			"origname": "process_vm_writev",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_process_vm_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kcmp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 312,
+			"kconfig": "KCMP",
+			"line": 135,
+			"name": "kcmp",
+			"number": 312,
+			"origname": "kcmp",
+			"signature": [
+				"pid_t pid1",
+				"pid_t pid2",
+				"int type",
+				"unsigned long idx1",
+				"unsigned long idx2"
+			],
+			"symbol": "__x64_sys_kcmp"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 313,
+			"kconfig": "MODULES",
+			"line": 3669,
+			"name": "finit_module",
+			"number": 313,
+			"origname": "finit_module",
+			"signature": [
+				"int fd",
+				"const char *uargs",
+				"int flags"
+			],
+			"symbol": "__x64_sys_finit_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 314,
+			"kconfig": null,
+			"line": 981,
+			"name": "sched_setattr",
+			"number": 314,
+			"origname": "sched_setattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_sched_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 315,
+			"kconfig": null,
+			"line": 1081,
+			"name": "sched_getattr",
+			"number": 315,
+			"origname": "sched_getattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int usize",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_sched_getattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 316,
+			"kconfig": null,
+			"line": 5257,
+			"name": "renameat2",
+			"number": 316,
+			"origname": "renameat2",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_renameat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/seccomp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 317,
+			"kconfig": "SECCOMP",
+			"line": 2101,
+			"name": "seccomp",
+			"number": 317,
+			"origname": "seccomp",
+			"signature": [
+				"unsigned int op",
+				"unsigned int flags",
+				"void *uargs"
+			],
+			"symbol": "__x64_sys_seccomp"
+		},
+		{
+			"esoteric": false,
+			"file": "drivers/char/random.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 318,
+			"kconfig": null,
+			"line": 1388,
+			"name": "getrandom",
+			"number": 318,
+			"origname": "getrandom",
+			"signature": [
+				"char *ubuf",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_getrandom"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/memfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 319,
+			"kconfig": "MEMFD_CREATE",
+			"line": 458,
+			"name": "memfd_create",
+			"number": 319,
+			"origname": "memfd_create",
+			"signature": [
+				"const char *uname",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_memfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kexec_file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 320,
+			"kconfig": "KEXEC_FILE",
+			"line": 332,
+			"name": "kexec_file_load",
+			"number": 320,
+			"origname": "kexec_file_load",
+			"signature": [
+				"int kernel_fd",
+				"int initrd_fd",
+				"unsigned long cmdline_len",
+				"const char *cmdline_ptr",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_kexec_file_load"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/bpf/syscall.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 321,
+			"kconfig": "BPF_SYSCALL",
+			"line": 5900,
+			"name": "bpf",
+			"number": 321,
+			"origname": "bpf",
+			"signature": [
+				"int cmd",
+				"union bpf_attr *uattr",
+				"unsigned int size"
+			],
+			"symbol": "__x64_sys_bpf"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 322,
+			"kconfig": null,
+			"line": 2119,
+			"name": "execveat",
+			"number": 322,
+			"origname": "execveat",
+			"signature": [
+				"int fd",
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp",
+				"int flags"
+			],
+			"symbol": "__x64_sys_execveat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/userfaultfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 323,
+			"kconfig": "USERFAULTFD",
+			"line": 2155,
+			"name": "userfaultfd",
+			"number": 323,
+			"origname": "userfaultfd",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__x64_sys_userfaultfd"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/membarrier.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 324,
+			"kconfig": "MEMBARRIER",
+			"line": 625,
+			"name": "membarrier",
+			"number": 324,
+			"origname": "membarrier",
+			"signature": [
+				"int cmd",
+				"unsigned int flags",
+				"int cpu_id"
+			],
+			"symbol": "__x64_sys_membarrier"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 325,
+			"kconfig": "MMU",
+			"line": 664,
+			"name": "mlock2",
+			"number": 325,
+			"origname": "mlock2",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__x64_sys_mlock2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 326,
+			"kconfig": null,
+			"line": 1637,
+			"name": "copy_file_range",
+			"number": 326,
+			"origname": "copy_file_range",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_copy_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 327,
+			"kconfig": null,
+			"line": 1175,
+			"name": "preadv2",
+			"number": 327,
+			"origname": "preadv2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__x64_sys_preadv2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 328,
+			"kconfig": null,
+			"line": 1195,
+			"name": "pwritev2",
+			"number": 328,
+			"origname": "pwritev2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__x64_sys_pwritev2"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 329,
+			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
+			"line": 866,
+			"name": "pkey_mprotect",
+			"number": 329,
+			"origname": "pkey_mprotect",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long prot",
+				"int pkey"
+			],
+			"symbol": "__x64_sys_pkey_mprotect"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 330,
+			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
+			"line": 872,
+			"name": "pkey_alloc",
+			"number": 330,
+			"origname": "pkey_alloc",
+			"signature": [
+				"unsigned long flags",
+				"unsigned long init_val"
+			],
+			"symbol": "__x64_sys_pkey_alloc"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 331,
+			"kconfig": "X86_INTEL_MEMORY_PROTECTION_KEYS",
+			"line": 902,
+			"name": "pkey_free",
+			"number": 331,
+			"origname": "pkey_free",
+			"signature": [
+				"int pkey"
+			],
+			"symbol": "__x64_sys_pkey_free"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 332,
+			"kconfig": null,
+			"line": 799,
+			"name": "statx",
+			"number": 332,
+			"origname": "statx",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags",
+				"unsigned int mask",
+				"struct statx *buffer"
+			],
+			"symbol": "__x64_sys_statx"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 333,
+			"kconfig": "AIO",
+			"line": 2275,
+			"name": "io_pgetevents",
+			"number": 333,
+			"origname": "io_pgetevents",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct __kernel_timespec *timeout",
+				"const struct __aio_sigset *usig"
+			],
+			"symbol": "__x64_sys_io_pgetevents"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/rseq.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 334,
+			"kconfig": "RSEQ",
+			"line": 452,
+			"name": "rseq",
+			"number": 334,
+			"origname": "rseq",
+			"signature": [
+				"struct rseq *rseq",
+				"u32 rseq_len",
+				"int flags",
+				"u32 sig"
+			],
+			"symbol": "__x64_sys_rseq"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/uprobes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 335,
+			"kconfig": null,
+			"line": 367,
+			"name": "uretprobe",
+			"number": 335,
+			"origname": "uretprobe",
+			"signature": [],
+			"symbol": "__x64_sys_uretprobe"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 424,
+			"kconfig": null,
+			"line": 4026,
+			"name": "pidfd_send_signal",
+			"number": 424,
+			"origname": "pidfd_send_signal",
+			"signature": [
+				"int pidfd",
+				"int sig",
+				"siginfo_t *info",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_pidfd_send_signal"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 425,
+			"kconfig": "IO_URING",
+			"line": 3814,
+			"name": "io_uring_setup",
+			"number": 425,
+			"origname": "io_uring_setup",
+			"signature": [
+				"u32 entries",
+				"struct io_uring_params *params"
+			],
+			"symbol": "__x64_sys_io_uring_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 426,
+			"kconfig": "IO_URING",
+			"line": 3307,
+			"name": "io_uring_enter",
+			"number": 426,
+			"origname": "io_uring_enter",
+			"signature": [
+				"unsigned int fd",
+				"u32 to_submit",
+				"u32 min_complete",
+				"u32 flags",
+				"const void *argp",
+				"size_t argsz"
+			],
+			"symbol": "__x64_sys_io_uring_enter"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/register.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 427,
+			"kconfig": "IO_URING",
+			"line": 896,
+			"name": "io_uring_register",
+			"number": 427,
+			"origname": "io_uring_register",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int opcode",
+				"void *arg",
+				"unsigned int nr_args"
+			],
+			"symbol": "__x64_sys_io_uring_register"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 428,
+			"kconfig": null,
+			"line": 2892,
+			"name": "open_tree",
+			"number": 428,
+			"origname": "open_tree",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags"
+			],
+			"symbol": "__x64_sys_open_tree"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 429,
+			"kconfig": null,
+			"line": 4280,
+			"name": "move_mount",
+			"number": 429,
+			"origname": "move_mount",
+			"signature": [
+				"int from_dfd",
+				"const char *from_pathname",
+				"int to_dfd",
+				"const char *to_pathname",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_move_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 430,
+			"kconfig": null,
+			"line": 114,
+			"name": "fsopen",
+			"number": 430,
+			"origname": "fsopen",
+			"signature": [
+				"const char *_fs_name",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_fsopen"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 431,
+			"kconfig": null,
+			"line": 344,
+			"name": "fsconfig",
+			"number": 431,
+			"origname": "fsconfig",
+			"signature": [
+				"int fd",
+				"unsigned int cmd",
+				"const char *_key",
+				"const void *_value",
+				"int aux"
+			],
+			"symbol": "__x64_sys_fsconfig"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 432,
+			"kconfig": null,
+			"line": 4156,
+			"name": "fsmount",
+			"number": 432,
+			"origname": "fsmount",
+			"signature": [
+				"int fs_fd",
+				"unsigned int flags",
+				"unsigned int attr_flags"
+			],
+			"symbol": "__x64_sys_fsmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 433,
+			"kconfig": null,
+			"line": 157,
+			"name": "fspick",
+			"number": 433,
+			"origname": "fspick",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_fspick"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 434,
+			"kconfig": null,
+			"line": 626,
+			"name": "pidfd_open",
+			"number": 434,
+			"origname": "pidfd_open",
+			"signature": [
+				"pid_t pid",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_pidfd_open"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 435,
+			"kconfig": null,
+			"line": 3098,
+			"name": "clone3",
+			"number": 435,
+			"origname": "clone3",
+			"signature": [
+				"struct clone_args *uargs",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_clone3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 436,
+			"kconfig": null,
+			"line": 769,
+			"name": "close_range",
+			"number": 436,
+			"origname": "close_range",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int max_fd",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_close_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 437,
+			"kconfig": null,
+			"line": 1462,
+			"name": "openat2",
+			"number": 437,
+			"origname": "openat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct open_how *how",
+				"size_t usize"
+			],
+			"symbol": "__x64_sys_openat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 438,
+			"kconfig": null,
+			"line": 854,
+			"name": "pidfd_getfd",
+			"number": 438,
+			"origname": "pidfd_getfd",
+			"signature": [
+				"int pidfd",
+				"int fd",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_pidfd_getfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 439,
+			"kconfig": null,
+			"line": 540,
+			"name": "faccessat2",
+			"number": 439,
+			"origname": "faccessat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode",
+				"int flags"
+			],
+			"symbol": "__x64_sys_faccessat2"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 440,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1756,
+			"name": "process_madvise",
+			"number": 440,
+			"origname": "process_madvise",
+			"signature": [
+				"int pidfd",
+				"const struct iovec *vec",
+				"size_t vlen",
+				"int behavior",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_process_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 441,
+			"kconfig": "EPOLL",
+			"line": 2532,
+			"name": "epoll_pwait2",
+			"number": 441,
+			"origname": "epoll_pwait2",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"const struct __kernel_timespec *timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__x64_sys_epoll_pwait2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 442,
+			"kconfig": null,
+			"line": 4847,
+			"name": "mount_setattr",
+			"number": 442,
+			"origname": "mount_setattr",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags",
+				"struct mount_attr *uattr",
+				"size_t usize"
+			],
+			"symbol": "__x64_sys_mount_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 443,
+			"kconfig": "QUOTACTL",
+			"line": 973,
+			"name": "quotactl_fd",
+			"number": 443,
+			"origname": "quotactl_fd",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__x64_sys_quotactl_fd"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 444,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 180,
+			"name": "landlock_create_ruleset",
+			"number": 444,
+			"origname": "landlock_create_ruleset",
+			"signature": [
+				"const struct landlock_ruleset_attr *const attr",
+				"const size_t size",
+				"const __u32 flags"
+			],
+			"symbol": "__x64_sys_landlock_create_ruleset"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 445,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 398,
+			"name": "landlock_add_rule",
+			"number": 445,
+			"origname": "landlock_add_rule",
+			"signature": [
+				"const int ruleset_fd",
+				"const enum landlock_rule_type rule_type",
+				"const void *const rule_attr",
+				"const __u32 flags"
+			],
+			"symbol": "__x64_sys_landlock_add_rule"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 446,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 451,
+			"name": "landlock_restrict_self",
+			"number": 446,
+			"origname": "landlock_restrict_self",
+			"signature": [
+				"const int ruleset_fd",
+				"const __u32 flags"
+			],
+			"symbol": "__x64_sys_landlock_restrict_self"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/secretmem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 447,
+			"kconfig": "SECRETMEM",
+			"line": 232,
+			"name": "memfd_secret",
+			"number": 447,
+			"origname": "memfd_secret",
+			"signature": [
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_memfd_secret"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/oom_kill.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 448,
+			"kconfig": "MMU",
+			"line": 1204,
+			"name": "process_mrelease",
+			"number": 448,
+			"origname": "process_mrelease",
+			"signature": [
+				"int pidfd",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_process_mrelease"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 449,
+			"kconfig": "FUTEX",
+			"line": 290,
+			"name": "futex_waitv",
+			"number": 449,
+			"origname": "futex_waitv",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int nr_futexes",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__x64_sys_futex_waitv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 450,
+			"kconfig": "NUMA",
+			"line": 1540,
+			"name": "set_mempolicy_home_node",
+			"number": 450,
+			"origname": "set_mempolicy_home_node",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long home_node",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_set_mempolicy_home_node"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/filemap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 451,
+			"kconfig": "CACHESTAT_SYSCALL",
+			"line": 4498,
+			"name": "cachestat",
+			"number": 451,
+			"origname": "cachestat",
+			"signature": [
+				"unsigned int fd",
+				"struct cachestat_range *cstat_range",
+				"struct cachestat *cstat",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_cachestat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 452,
+			"kconfig": null,
+			"line": 700,
+			"name": "fchmodat2",
+			"number": 452,
+			"origname": "fchmodat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_fchmodat2"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/shstk.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 453,
+			"kconfig": "X86_USER_SHADOW_STACK",
+			"line": 505,
+			"name": "map_shadow_stack",
+			"number": 453,
+			"origname": "map_shadow_stack",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long size",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_map_shadow_stack"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 454,
+			"kconfig": "FUTEX",
+			"line": 338,
+			"name": "futex_wake",
+			"number": 454,
+			"origname": "futex_wake",
+			"signature": [
+				"void *uaddr",
+				"unsigned long mask",
+				"int nr",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_futex_wake"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 455,
+			"kconfig": "FUTEX",
+			"line": 370,
+			"name": "futex_wait",
+			"number": 455,
+			"origname": "futex_wait",
+			"signature": [
+				"void *uaddr",
+				"unsigned long val",
+				"unsigned long mask",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__x64_sys_futex_wait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 456,
+			"kconfig": "FUTEX",
+			"line": 414,
+			"name": "futex_requeue",
+			"number": 456,
+			"origname": "futex_requeue",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int flags",
+				"int nr_wake",
+				"int nr_requeue"
+			],
+			"symbol": "__x64_sys_futex_requeue"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 457,
+			"kconfig": null,
+			"line": 5508,
+			"name": "statmount",
+			"number": 457,
+			"origname": "statmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"struct statmount *buf",
+				"size_t bufsize",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_statmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 458,
+			"kconfig": null,
+			"line": 5615,
+			"name": "listmount",
+			"number": 458,
+			"origname": "listmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"u64 *mnt_ids",
+				"size_t nr_mnt_ids",
+				"unsigned int flags"
+			],
+			"symbol": "__x64_sys_listmount"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 459,
+			"kconfig": "SECURITY",
+			"line": 77,
+			"name": "lsm_get_self_attr",
+			"number": 459,
+			"origname": "lsm_get_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__x64_sys_lsm_get_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 460,
+			"kconfig": "SECURITY",
+			"line": 55,
+			"name": "lsm_set_self_attr",
+			"number": 460,
+			"origname": "lsm_set_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 size",
+				"u32 flags"
+			],
+			"symbol": "__x64_sys_lsm_set_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 461,
+			"kconfig": "SECURITY",
+			"line": 96,
+			"name": "lsm_list_modules",
+			"number": 461,
+			"origname": "lsm_list_modules",
+			"signature": [
+				"u64 *ids",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__x64_sys_lsm_list_modules"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mseal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 462,
+			"kconfig": null,
+			"line": 265,
+			"name": "mseal",
+			"number": 462,
+			"origname": "mseal",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long flags"
+			],
+			"symbol": "__x64_sys_mseal"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 463,
+			"kconfig": null,
+			"line": 719,
+			"name": "setxattrat",
+			"number": 463,
+			"origname": "setxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"const struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__x64_sys_setxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 464,
+			"kconfig": null,
+			"line": 863,
+			"name": "getxattrat",
+			"number": 464,
+			"origname": "getxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__x64_sys_getxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 465,
+			"kconfig": null,
+			"line": 991,
+			"name": "listxattrat",
+			"number": 465,
+			"origname": "listxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__x64_sys_listxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 466,
+			"kconfig": null,
+			"line": 1091,
+			"name": "removexattrat",
+			"number": 466,
+			"origname": "removexattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name"
+			],
+			"symbol": "__x64_sys_removexattrat"
+		}
+	],
+	"systrack_version": "0.7"
+}

--- a/libdebug/utils/syscall_data/filter.py
+++ b/libdebug/utils/syscall_data/filter.py
@@ -1,0 +1,50 @@
+#
+# This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
+# Copyright (c) 2024 Roberto Alessandro Bertolini. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for details.
+#
+
+# This script is used to compress the syscall data files,
+# removing unnecessary fields and keeping only the ones we need.
+
+import json
+from argparse import ArgumentParser
+from pathlib import Path
+
+p = ArgumentParser(description="Compress syscall data files by removing unnecessary fields.")
+p.add_argument(
+    "input_file",
+    type=Path,
+    help="Path to the input syscall data file.",
+)
+p.add_argument(
+    "output_file",
+    type=Path,
+    help="Path to the output compressed syscall data file.",
+)
+
+
+def compress_syscall_data(input_file: Path, output_file: Path) -> None:
+    """Compress syscall data by removing unnecessary fields."""
+    with input_file.open("r") as f:
+        data = json.load(f)
+
+    compressed_data = {
+        "syscalls": [
+            {
+                "name": syscall["name"],
+                "number": syscall["number"],
+                "signature": syscall["signature"],
+            }
+            for syscall in data.get("syscalls", [])
+        ],
+    }
+
+    with output_file.open("w") as f:
+        json.dump(compressed_data, f, indent=4)
+
+
+if __name__ == "__main__":
+    args = p.parse_args()
+    compress_syscall_data(args.input_file, args.output_file)
+    print(f"Compressed syscall data saved to {args.output_file}")

--- a/libdebug/utils/syscall_data/i386.json
+++ b/libdebug/utils/syscall_data/i386.json
@@ -1,0 +1,7672 @@
+{
+	"kernel": {
+		"abi": {
+			"bits": 32,
+			"calling_convention": {
+				"parameters": [
+					"ebx",
+					"ecx",
+					"edx",
+					"esi",
+					"edi",
+					"ebp"
+				],
+				"syscall_nr": "eax"
+			},
+			"compat": false,
+			"name": "ia32"
+		},
+		"architecture": {
+			"bits": 32,
+			"name": "x86"
+		},
+		"syscall_table_symbol": "sys_call_table",
+		"version": "v6.14",
+		"version_source": "vmlinux"
+	},
+	"syscalls": [
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 0,
+			"kconfig": null,
+			"line": 3177,
+			"name": "restart_syscall",
+			"number": 0,
+			"origname": "restart_syscall",
+			"signature": [],
+			"symbol": "__ia32_sys_restart_syscall"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 1,
+			"kconfig": null,
+			"line": 1052,
+			"name": "exit",
+			"number": 1,
+			"origname": "exit",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__ia32_sys_exit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 2,
+			"kconfig": "MMU",
+			"line": 2897,
+			"name": "fork",
+			"number": 2,
+			"origname": "fork",
+			"signature": [],
+			"symbol": "__ia32_sys_fork"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 3,
+			"kconfig": null,
+			"line": 715,
+			"name": "read",
+			"number": 3,
+			"origname": "read",
+			"signature": [
+				"unsigned int fd",
+				"char *buf",
+				"size_t count"
+			],
+			"symbol": "__ia32_sys_read"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 4,
+			"kconfig": null,
+			"line": 739,
+			"name": "write",
+			"number": 4,
+			"origname": "write",
+			"signature": [
+				"unsigned int fd",
+				"const char *buf",
+				"size_t count"
+			],
+			"symbol": "__ia32_sys_write"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 5,
+			"kconfig": null,
+			"line": 1447,
+			"name": "open",
+			"number": 5,
+			"origname": "open",
+			"signature": [
+				"const char *filename",
+				"int flags",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_open"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 6,
+			"kconfig": null,
+			"line": 1565,
+			"name": "close",
+			"number": 6,
+			"origname": "close",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__ia32_sys_close"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 7,
+			"kconfig": null,
+			"line": 1893,
+			"name": "waitpid",
+			"number": 7,
+			"origname": "waitpid",
+			"signature": [
+				"pid_t pid",
+				"int *stat_addr",
+				"int options"
+			],
+			"symbol": "__ia32_sys_waitpid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 8,
+			"kconfig": null,
+			"line": 1515,
+			"name": "creat",
+			"number": 8,
+			"origname": "creat",
+			"signature": [
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_creat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 9,
+			"kconfig": null,
+			"line": 4897,
+			"name": "link",
+			"number": 9,
+			"origname": "link",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__ia32_sys_link"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 10,
+			"kconfig": null,
+			"line": 4635,
+			"name": "unlink",
+			"number": 10,
+			"origname": "unlink",
+			"signature": [
+				"const char *pathname"
+			],
+			"symbol": "__ia32_sys_unlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 11,
+			"kconfig": null,
+			"line": 2111,
+			"name": "execve",
+			"number": 11,
+			"origname": "execve",
+			"signature": [
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp"
+			],
+			"symbol": "__ia32_sys_execve"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 12,
+			"kconfig": null,
+			"line": 551,
+			"name": "chdir",
+			"number": 12,
+			"origname": "chdir",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__ia32_sys_chdir"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 13,
+			"kconfig": null,
+			"line": 105,
+			"name": "time",
+			"number": 13,
+			"origname": "time32",
+			"signature": [
+				"old_time32_t *tloc"
+			],
+			"symbol": "__ia32_sys_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 14,
+			"kconfig": null,
+			"line": 4272,
+			"name": "mknod",
+			"number": 14,
+			"origname": "mknod",
+			"signature": [
+				"const char *filename",
+				"umode_t mode",
+				"unsigned dev"
+			],
+			"symbol": "__ia32_sys_mknod"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 15,
+			"kconfig": null,
+			"line": 712,
+			"name": "chmod",
+			"number": 15,
+			"origname": "chmod",
+			"signature": [
+				"const char *filename",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_chmod"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 16,
+			"kconfig": "UID16",
+			"line": 28,
+			"name": "lchown16",
+			"number": 16,
+			"origname": "lchown16",
+			"signature": [
+				"const char *filename",
+				"old_uid_t user",
+				"old_gid_t group"
+			],
+			"symbol": "__ia32_sys_lchown16"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 18,
+			"kconfig": null,
+			"line": 417,
+			"name": "stat",
+			"number": 18,
+			"origname": "stat",
+			"signature": [
+				"const char *filename",
+				"struct __old_kernel_stat *statbuf"
+			],
+			"symbol": "__ia32_sys_stat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 19,
+			"kconfig": null,
+			"line": 403,
+			"name": "lseek",
+			"number": 19,
+			"origname": "lseek",
+			"signature": [
+				"unsigned int fd",
+				"off_t offset",
+				"unsigned int whence"
+			],
+			"symbol": "__ia32_sys_lseek"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 20,
+			"kconfig": null,
+			"line": 969,
+			"name": "getpid",
+			"number": 20,
+			"origname": "getpid",
+			"signature": [],
+			"symbol": "__ia32_sys_getpid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 21,
+			"kconfig": null,
+			"line": 4088,
+			"name": "mount",
+			"number": 21,
+			"origname": "mount",
+			"signature": [
+				"char *dev_name",
+				"char *dir_name",
+				"char *type",
+				"unsigned long flags",
+				"void *data"
+			],
+			"symbol": "__ia32_sys_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 22,
+			"kconfig": null,
+			"line": 2087,
+			"name": "oldumount",
+			"number": 22,
+			"origname": "oldumount",
+			"signature": [
+				"char *name"
+			],
+			"symbol": "__ia32_sys_oldumount"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 23,
+			"kconfig": "UID16",
+			"line": 53,
+			"name": "setuid16",
+			"number": 23,
+			"origname": "setuid16",
+			"signature": [
+				"old_uid_t uid"
+			],
+			"symbol": "__ia32_sys_setuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 24,
+			"kconfig": "UID16",
+			"line": 203,
+			"name": "getuid16",
+			"number": 24,
+			"origname": "getuid16",
+			"signature": [],
+			"symbol": "__ia32_sys_getuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 25,
+			"kconfig": null,
+			"line": 119,
+			"name": "stime",
+			"number": 25,
+			"origname": "stime32",
+			"signature": [
+				"old_time32_t *tptr"
+			],
+			"symbol": "__ia32_sys_stime32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/ptrace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 26,
+			"kconfig": null,
+			"line": 1258,
+			"name": "ptrace",
+			"number": 26,
+			"origname": "ptrace",
+			"signature": [
+				"long request",
+				"long pid",
+				"unsigned long addr",
+				"unsigned long data"
+			],
+			"symbol": "__ia32_sys_ptrace"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 27,
+			"kconfig": null,
+			"line": 326,
+			"name": "alarm",
+			"number": 27,
+			"origname": "alarm",
+			"signature": [
+				"unsigned int seconds"
+			],
+			"symbol": "__ia32_sys_alarm"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 28,
+			"kconfig": null,
+			"line": 443,
+			"name": "fstat",
+			"number": 28,
+			"origname": "fstat",
+			"signature": [
+				"unsigned int fd",
+				"struct __old_kernel_stat *statbuf"
+			],
+			"symbol": "__ia32_sys_fstat"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 29,
+			"kconfig": null,
+			"line": 4799,
+			"name": "pause",
+			"number": 29,
+			"origname": "pause",
+			"signature": [],
+			"symbol": "__ia32_sys_pause"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 30,
+			"kconfig": null,
+			"line": 231,
+			"name": "utime",
+			"number": 30,
+			"origname": "utime32",
+			"signature": [
+				"const char *filename",
+				"struct old_utimbuf32 *t"
+			],
+			"symbol": "__ia32_sys_utime32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 33,
+			"kconfig": null,
+			"line": 546,
+			"name": "access",
+			"number": 33,
+			"origname": "access",
+			"signature": [
+				"const char *filename",
+				"int mode"
+			],
+			"symbol": "__ia32_sys_access"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 34,
+			"kconfig": null,
+			"line": 153,
+			"name": "nice",
+			"number": 34,
+			"origname": "nice",
+			"signature": [
+				"int increment"
+			],
+			"symbol": "__ia32_sys_nice"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 36,
+			"kconfig": null,
+			"line": 111,
+			"name": "sync",
+			"number": 36,
+			"origname": "sync",
+			"signature": [],
+			"symbol": "__ia32_sys_sync"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 37,
+			"kconfig": null,
+			"line": 3951,
+			"name": "kill",
+			"number": 37,
+			"origname": "kill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__ia32_sys_kill"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 38,
+			"kconfig": null,
+			"line": 5271,
+			"name": "rename",
+			"number": 38,
+			"origname": "rename",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__ia32_sys_rename"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 39,
+			"kconfig": null,
+			"line": 4354,
+			"name": "mkdir",
+			"number": 39,
+			"origname": "mkdir",
+			"signature": [
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_mkdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 40,
+			"kconfig": null,
+			"line": 4472,
+			"name": "rmdir",
+			"number": 40,
+			"origname": "rmdir",
+			"signature": [
+				"const char *pathname"
+			],
+			"symbol": "__ia32_sys_rmdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 41,
+			"kconfig": null,
+			"line": 1394,
+			"name": "dup",
+			"number": 41,
+			"origname": "dup",
+			"signature": [
+				"unsigned int fildes"
+			],
+			"symbol": "__ia32_sys_dup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/pipe.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 42,
+			"kconfig": null,
+			"line": 1048,
+			"name": "pipe",
+			"number": 42,
+			"origname": "pipe",
+			"signature": [
+				"int *fildes"
+			],
+			"symbol": "__ia32_sys_pipe"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 43,
+			"kconfig": null,
+			"line": 1034,
+			"name": "times",
+			"number": 43,
+			"origname": "times",
+			"signature": [
+				"struct tms *tbuf"
+			],
+			"symbol": "__ia32_sys_times"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 45,
+			"kconfig": null,
+			"line": 115,
+			"name": "brk",
+			"number": 45,
+			"origname": "brk",
+			"signature": [
+				"unsigned long brk"
+			],
+			"symbol": "__ia32_sys_brk"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 46,
+			"kconfig": "UID16",
+			"line": 43,
+			"name": "setgid16",
+			"number": 46,
+			"origname": "setgid16",
+			"signature": [
+				"old_gid_t gid"
+			],
+			"symbol": "__ia32_sys_setgid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 47,
+			"kconfig": "UID16",
+			"line": 213,
+			"name": "getgid16",
+			"number": 47,
+			"origname": "getgid16",
+			"signature": [],
+			"symbol": "__ia32_sys_getgid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 48,
+			"kconfig": null,
+			"line": 4782,
+			"name": "signal",
+			"number": 48,
+			"origname": "signal",
+			"signature": [
+				"int sig",
+				"__sighandler_t handler"
+			],
+			"symbol": "__ia32_sys_signal"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 49,
+			"kconfig": "UID16",
+			"line": 208,
+			"name": "geteuid16",
+			"number": 49,
+			"origname": "geteuid16",
+			"signature": [],
+			"symbol": "__ia32_sys_geteuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 50,
+			"kconfig": "UID16",
+			"line": 218,
+			"name": "getegid16",
+			"number": 50,
+			"origname": "getegid16",
+			"signature": [],
+			"symbol": "__ia32_sys_getegid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/acct.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 51,
+			"kconfig": "BSD_PROCESS_ACCT",
+			"line": 314,
+			"name": "acct",
+			"number": 51,
+			"origname": "acct",
+			"signature": [
+				"const char *name"
+			],
+			"symbol": "__ia32_sys_acct"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 52,
+			"kconfig": null,
+			"line": 2077,
+			"name": "umount",
+			"number": 52,
+			"origname": "umount",
+			"signature": [
+				"char *name",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_umount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/ioctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 54,
+			"kconfig": null,
+			"line": 892,
+			"name": "ioctl",
+			"number": 54,
+			"origname": "ioctl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__ia32_sys_ioctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fcntl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 55,
+			"kconfig": null,
+			"line": 576,
+			"name": "fcntl",
+			"number": 55,
+			"origname": "fcntl",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__ia32_sys_fcntl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 57,
+			"kconfig": null,
+			"line": 1084,
+			"name": "setpgid",
+			"number": 57,
+			"origname": "setpgid",
+			"signature": [
+				"pid_t pid",
+				"pid_t pgid"
+			],
+			"symbol": "__ia32_sys_setpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 59,
+			"kconfig": null,
+			"line": 1358,
+			"name": "olduname",
+			"number": 59,
+			"origname": "olduname",
+			"signature": [
+				"struct oldold_utsname *name"
+			],
+			"symbol": "__ia32_sys_olduname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 60,
+			"kconfig": null,
+			"line": 1908,
+			"name": "umask",
+			"number": 60,
+			"origname": "umask",
+			"signature": [
+				"int mask"
+			],
+			"symbol": "__ia32_sys_umask"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 61,
+			"kconfig": null,
+			"line": 594,
+			"name": "chroot",
+			"number": 61,
+			"origname": "chroot",
+			"signature": [
+				"const char *filename"
+			],
+			"symbol": "__ia32_sys_chroot"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 62,
+			"kconfig": null,
+			"line": 246,
+			"name": "ustat",
+			"number": 62,
+			"origname": "ustat",
+			"signature": [
+				"unsigned dev",
+				"struct ustat *ubuf"
+			],
+			"symbol": "__ia32_sys_ustat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 63,
+			"kconfig": null,
+			"line": 1375,
+			"name": "dup2",
+			"number": 63,
+			"origname": "dup2",
+			"signature": [
+				"unsigned int oldfd",
+				"unsigned int newfd"
+			],
+			"symbol": "__ia32_sys_dup2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 64,
+			"kconfig": null,
+			"line": 986,
+			"name": "getppid",
+			"number": 64,
+			"origname": "getppid",
+			"signature": [],
+			"symbol": "__ia32_sys_getppid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 65,
+			"kconfig": null,
+			"line": 1190,
+			"name": "getpgrp",
+			"number": 65,
+			"origname": "getpgrp",
+			"signature": [],
+			"symbol": "__ia32_sys_getpgrp"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 66,
+			"kconfig": null,
+			"line": 1269,
+			"name": "setsid",
+			"number": 66,
+			"origname": "setsid",
+			"signature": [],
+			"symbol": "__ia32_sys_setsid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 67,
+			"kconfig": null,
+			"line": 4678,
+			"name": "sigaction",
+			"number": 67,
+			"origname": "sigaction",
+			"signature": [
+				"int sig",
+				"const struct old_sigaction *act",
+				"struct old_sigaction *oact"
+			],
+			"symbol": "__ia32_sys_sigaction"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 68,
+			"kconfig": "SGETMASK_SYSCALL",
+			"line": 4760,
+			"name": "sgetmask",
+			"number": 68,
+			"origname": "sgetmask",
+			"signature": [],
+			"symbol": "__ia32_sys_sgetmask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 69,
+			"kconfig": "SGETMASK_SYSCALL",
+			"line": 4766,
+			"name": "ssetmask",
+			"number": 69,
+			"origname": "ssetmask",
+			"signature": [
+				"int newmask"
+			],
+			"symbol": "__ia32_sys_ssetmask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 70,
+			"kconfig": "UID16",
+			"line": 48,
+			"name": "setreuid16",
+			"number": 70,
+			"origname": "setreuid16",
+			"signature": [
+				"old_uid_t ruid",
+				"old_uid_t euid"
+			],
+			"symbol": "__ia32_sys_setreuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 71,
+			"kconfig": "UID16",
+			"line": 38,
+			"name": "setregid16",
+			"number": 71,
+			"origname": "setregid16",
+			"signature": [
+				"old_gid_t rgid",
+				"old_gid_t egid"
+			],
+			"symbol": "__ia32_sys_setregid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 72,
+			"kconfig": null,
+			"line": 4866,
+			"name": "sigsuspend",
+			"number": 72,
+			"origname": "sigsuspend",
+			"signature": [
+				"int unused1",
+				"int unused2",
+				"old_sigset_t mask"
+			],
+			"symbol": "__ia32_sys_sigsuspend"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 73,
+			"kconfig": null,
+			"line": 4519,
+			"name": "sigpending",
+			"number": 73,
+			"origname": "sigpending",
+			"signature": [
+				"old_sigset_t *uset"
+			],
+			"symbol": "__ia32_sys_sigpending"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 74,
+			"kconfig": null,
+			"line": 1385,
+			"name": "sethostname",
+			"number": 74,
+			"origname": "sethostname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__ia32_sys_sethostname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 75,
+			"kconfig": null,
+			"line": 1742,
+			"name": "setrlimit",
+			"number": 75,
+			"origname": "setrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__ia32_sys_setrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 76,
+			"kconfig": null,
+			"line": 1594,
+			"name": "getrlimit",
+			"number": 76,
+			"origname": "old_getrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__ia32_sys_old_getrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 77,
+			"kconfig": null,
+			"line": 1882,
+			"name": "getrusage",
+			"number": 77,
+			"origname": "getrusage",
+			"signature": [
+				"int who",
+				"struct rusage *ru"
+			],
+			"symbol": "__ia32_sys_getrusage"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 78,
+			"kconfig": null,
+			"line": 140,
+			"name": "gettimeofday",
+			"number": 78,
+			"origname": "gettimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__ia32_sys_gettimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 79,
+			"kconfig": null,
+			"line": 199,
+			"name": "settimeofday",
+			"number": 79,
+			"origname": "settimeofday",
+			"signature": [
+				"struct __kernel_old_timeval *tv",
+				"struct timezone *tz"
+			],
+			"symbol": "__ia32_sys_settimeofday"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 80,
+			"kconfig": "UID16",
+			"line": 154,
+			"name": "getgroups16",
+			"number": 80,
+			"origname": "getgroups16",
+			"signature": [
+				"int gidsetsize",
+				"old_gid_t *grouplist"
+			],
+			"symbol": "__ia32_sys_getgroups16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 81,
+			"kconfig": "UID16",
+			"line": 177,
+			"name": "setgroups16",
+			"number": 81,
+			"origname": "setgroups16",
+			"signature": [
+				"int gidsetsize",
+				"old_gid_t *grouplist"
+			],
+			"symbol": "__ia32_sys_setgroups16"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 82,
+			"kconfig": null,
+			"line": 828,
+			"name": "select",
+			"number": 82,
+			"origname": "old_select",
+			"signature": [
+				"struct sel_arg_struct *arg"
+			],
+			"symbol": "__ia32_sys_old_select"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 83,
+			"kconfig": null,
+			"line": 4716,
+			"name": "symlink",
+			"number": 83,
+			"origname": "symlink",
+			"signature": [
+				"const char *oldname",
+				"const char *newname"
+			],
+			"symbol": "__ia32_sys_symlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 84,
+			"kconfig": null,
+			"line": 430,
+			"name": "lstat",
+			"number": 84,
+			"origname": "lstat",
+			"signature": [
+				"const char *filename",
+				"struct __old_kernel_stat *statbuf"
+			],
+			"symbol": "__ia32_sys_lstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 85,
+			"kconfig": null,
+			"line": 598,
+			"name": "readlink",
+			"number": 85,
+			"origname": "readlink",
+			"signature": [
+				"const char *path",
+				"char *buf",
+				"int bufsiz"
+			],
+			"symbol": "__ia32_sys_readlink"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 86,
+			"kconfig": "USELIB",
+			"line": 125,
+			"name": "uselib",
+			"number": 86,
+			"origname": "uselib",
+			"signature": [
+				"const char *library"
+			],
+			"symbol": "__ia32_sys_uselib"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 87,
+			"kconfig": "SWAP",
+			"line": 3266,
+			"name": "swapon",
+			"number": 87,
+			"origname": "swapon",
+			"signature": [
+				"const char *specialfile",
+				"int swap_flags"
+			],
+			"symbol": "__ia32_sys_swapon"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/reboot.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 88,
+			"kconfig": null,
+			"line": 722,
+			"name": "reboot",
+			"number": 88,
+			"origname": "reboot",
+			"signature": [
+				"int magic1",
+				"int magic2",
+				"unsigned int cmd",
+				"void *arg"
+			],
+			"symbol": "__ia32_sys_reboot"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 89,
+			"kconfig": null,
+			"line": 218,
+			"name": "readdir",
+			"number": 89,
+			"origname": "old_readdir",
+			"signature": [
+				"unsigned int fd",
+				"struct old_linux_dirent *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__ia32_sys_old_readdir"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 90,
+			"kconfig": null,
+			"line": 631,
+			"name": "mmap",
+			"number": 90,
+			"origname": "old_mmap",
+			"signature": [
+				"struct mmap_arg_struct *arg"
+			],
+			"symbol": "__ia32_sys_old_mmap"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 91,
+			"kconfig": null,
+			"line": 1081,
+			"name": "munmap",
+			"number": 91,
+			"origname": "munmap",
+			"signature": [
+				"unsigned long addr",
+				"size_t len"
+			],
+			"symbol": "__ia32_sys_munmap"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 92,
+			"kconfig": null,
+			"line": 148,
+			"name": "truncate",
+			"number": 92,
+			"origname": "truncate",
+			"signature": [
+				"const char *path",
+				"long length"
+			],
+			"symbol": "__ia32_sys_truncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 93,
+			"kconfig": null,
+			"line": 210,
+			"name": "ftruncate",
+			"number": 93,
+			"origname": "ftruncate",
+			"signature": [
+				"unsigned int fd",
+				"off_t length"
+			],
+			"symbol": "__ia32_sys_ftruncate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 94,
+			"kconfig": null,
+			"line": 663,
+			"name": "fchmod",
+			"number": 94,
+			"origname": "fchmod",
+			"signature": [
+				"unsigned int fd",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_fchmod"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 95,
+			"kconfig": "UID16",
+			"line": 33,
+			"name": "fchown16",
+			"number": 95,
+			"origname": "fchown16",
+			"signature": [
+				"unsigned int fd",
+				"old_uid_t user",
+				"old_gid_t group"
+			],
+			"symbol": "__ia32_sys_fchown16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 96,
+			"kconfig": null,
+			"line": 299,
+			"name": "getpriority",
+			"number": 96,
+			"origname": "getpriority",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__ia32_sys_getpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 97,
+			"kconfig": null,
+			"line": 229,
+			"name": "setpriority",
+			"number": 97,
+			"origname": "setpriority",
+			"signature": [
+				"int which",
+				"int who",
+				"int niceval"
+			],
+			"symbol": "__ia32_sys_setpriority"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 99,
+			"kconfig": null,
+			"line": 190,
+			"name": "statfs",
+			"number": 99,
+			"origname": "statfs",
+			"signature": [
+				"const char *pathname",
+				"struct statfs *buf"
+			],
+			"symbol": "__ia32_sys_statfs"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 100,
+			"kconfig": null,
+			"line": 211,
+			"name": "fstatfs",
+			"number": 100,
+			"origname": "fstatfs",
+			"signature": [
+				"unsigned int fd",
+				"struct statfs *buf"
+			],
+			"symbol": "__ia32_sys_fstatfs"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ioport.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 101,
+			"kconfig": "X86_IOPL_IOPERM",
+			"line": 152,
+			"name": "ioperm",
+			"number": 101,
+			"origname": "ioperm",
+			"signature": [
+				"unsigned long from",
+				"unsigned long num",
+				"int turn_on"
+			],
+			"symbol": "__ia32_sys_ioperm"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 102,
+			"kconfig": "NET",
+			"line": 3062,
+			"name": "socketcall",
+			"number": 102,
+			"origname": "socketcall",
+			"signature": [
+				"int call",
+				"unsigned long *args"
+			],
+			"symbol": "__ia32_sys_socketcall"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/printk/printk.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 103,
+			"kconfig": null,
+			"line": 1875,
+			"name": "syslog",
+			"number": 103,
+			"origname": "syslog",
+			"signature": [
+				"int type",
+				"char *buf",
+				"int len"
+			],
+			"symbol": "__ia32_sys_syslog"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 104,
+			"kconfig": null,
+			"line": 352,
+			"name": "setitimer",
+			"number": 104,
+			"origname": "setitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value",
+				"struct __kernel_old_itimerval *ovalue"
+			],
+			"symbol": "__ia32_sys_setitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/itimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 105,
+			"kconfig": null,
+			"line": 113,
+			"name": "getitimer",
+			"number": 105,
+			"origname": "getitimer",
+			"signature": [
+				"int which",
+				"struct __kernel_old_itimerval *value"
+			],
+			"symbol": "__ia32_sys_getitimer"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 106,
+			"kconfig": null,
+			"line": 501,
+			"name": "newstat",
+			"number": 106,
+			"origname": "newstat",
+			"signature": [
+				"const char *filename",
+				"struct stat *statbuf"
+			],
+			"symbol": "__ia32_sys_newstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 107,
+			"kconfig": null,
+			"line": 512,
+			"name": "newlstat",
+			"number": 107,
+			"origname": "newlstat",
+			"signature": [
+				"const char *filename",
+				"struct stat *statbuf"
+			],
+			"symbol": "__ia32_sys_newlstat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 108,
+			"kconfig": null,
+			"line": 539,
+			"name": "newfstat",
+			"number": 108,
+			"origname": "newfstat",
+			"signature": [
+				"unsigned int fd",
+				"struct stat *statbuf"
+			],
+			"symbol": "__ia32_sys_newfstat"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 109,
+			"kconfig": null,
+			"line": 1338,
+			"name": "uname",
+			"number": 109,
+			"origname": "uname",
+			"signature": [
+				"struct old_utsname *name"
+			],
+			"symbol": "__ia32_sys_uname"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ioport.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 110,
+			"kconfig": "X86_IOPL_IOPERM",
+			"line": 173,
+			"name": "iopl",
+			"number": 110,
+			"origname": "iopl",
+			"signature": [
+				"unsigned int level"
+			],
+			"symbol": "__ia32_sys_iopl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 111,
+			"kconfig": null,
+			"line": 1596,
+			"name": "vhangup",
+			"number": 111,
+			"origname": "vhangup",
+			"signature": [],
+			"symbol": "__ia32_sys_vhangup"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/vm86_32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 113,
+			"kconfig": "X86_LEGACY_VM86",
+			"line": 170,
+			"name": "vm86old",
+			"number": 113,
+			"origname": "vm86old",
+			"signature": [
+				"struct vm86_struct *user_vm86"
+			],
+			"symbol": "__ia32_sys_vm86old"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 114,
+			"kconfig": null,
+			"line": 1874,
+			"name": "wait4",
+			"number": 114,
+			"origname": "wait4",
+			"signature": [
+				"pid_t upid",
+				"int *stat_addr",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__ia32_sys_wait4"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/swapfile.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 115,
+			"kconfig": "SWAP",
+			"line": 2652,
+			"name": "swapoff",
+			"number": 115,
+			"origname": "swapoff",
+			"signature": [
+				"const char *specialfile"
+			],
+			"symbol": "__ia32_sys_swapoff"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 116,
+			"kconfig": null,
+			"line": 2902,
+			"name": "sysinfo",
+			"number": 116,
+			"origname": "sysinfo",
+			"signature": [
+				"struct sysinfo *info"
+			],
+			"symbol": "__ia32_sys_sysinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/syscall.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 117,
+			"kconfig": "SYSVIPC",
+			"line": 110,
+			"name": "ipc",
+			"number": 117,
+			"origname": "ipc",
+			"signature": [
+				"unsigned int call",
+				"int first",
+				"unsigned long second",
+				"unsigned long third",
+				"void *ptr",
+				"long fifth"
+			],
+			"symbol": "__ia32_sys_ipc"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 118,
+			"kconfig": null,
+			"line": 215,
+			"name": "fsync",
+			"number": 118,
+			"origname": "fsync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__ia32_sys_fsync"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/signal_32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 119,
+			"kconfig": null,
+			"line": 125,
+			"name": "sigreturn",
+			"number": 119,
+			"origname": "sigreturn",
+			"signature": [],
+			"symbol": "__ia32_sys_sigreturn"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 120,
+			"kconfig": null,
+			"line": 2926,
+			"name": "clone",
+			"number": 120,
+			"origname": "clone",
+			"signature": [
+				"unsigned long clone_flags",
+				"unsigned long newsp",
+				"int *parent_tidptr",
+				"unsigned long tls",
+				"int *child_tidptr"
+			],
+			"symbol": "__ia32_sys_clone"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 121,
+			"kconfig": null,
+			"line": 1439,
+			"name": "setdomainname",
+			"number": 121,
+			"origname": "setdomainname",
+			"signature": [
+				"char *name",
+				"int len"
+			],
+			"symbol": "__ia32_sys_setdomainname"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 122,
+			"kconfig": null,
+			"line": 1317,
+			"name": "newuname",
+			"number": 122,
+			"origname": "newuname",
+			"signature": [
+				"struct new_utsname *name"
+			],
+			"symbol": "__ia32_sys_newuname"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/ldt.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 123,
+			"kconfig": "MODIFY_LDT_SYSCALL",
+			"line": 667,
+			"name": "modify_ldt",
+			"number": 123,
+			"origname": "modify_ldt",
+			"signature": [
+				"int func",
+				"void *ptr",
+				"unsigned long bytecount"
+			],
+			"symbol": "__ia32_sys_modify_ldt"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/time.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 124,
+			"kconfig": null,
+			"line": 349,
+			"name": "adjtimex",
+			"number": 124,
+			"origname": "adjtimex_time32",
+			"signature": [
+				"struct old_timex32 *utp"
+			],
+			"symbol": "__ia32_sys_adjtimex_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mprotect.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 125,
+			"kconfig": "MMU",
+			"line": 858,
+			"name": "mprotect",
+			"number": 125,
+			"origname": "mprotect",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned long prot"
+			],
+			"symbol": "__ia32_sys_mprotect"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 126,
+			"kconfig": null,
+			"line": 4558,
+			"name": "sigprocmask",
+			"number": 126,
+			"origname": "sigprocmask",
+			"signature": [
+				"int how",
+				"old_sigset_t *nset",
+				"old_sigset_t *oset"
+			],
+			"symbol": "__ia32_sys_sigprocmask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 128,
+			"kconfig": "MODULES",
+			"line": 3515,
+			"name": "init_module",
+			"number": 128,
+			"origname": "init_module",
+			"signature": [
+				"void *umod",
+				"unsigned long len",
+				"const char *uargs"
+			],
+			"symbol": "__ia32_sys_init_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 129,
+			"kconfig": "MODULE_UNLOAD",
+			"line": 732,
+			"name": "delete_module",
+			"number": 129,
+			"origname": "delete_module",
+			"signature": [
+				"const char *name_user",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_delete_module"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 131,
+			"kconfig": "QUOTACTL",
+			"line": 917,
+			"name": "quotactl",
+			"number": 131,
+			"origname": "quotactl",
+			"signature": [
+				"unsigned int cmd",
+				"const char *special",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__ia32_sys_quotactl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 132,
+			"kconfig": null,
+			"line": 1183,
+			"name": "getpgid",
+			"number": 132,
+			"origname": "getpgid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__ia32_sys_getpgid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 133,
+			"kconfig": null,
+			"line": 577,
+			"name": "fchdir",
+			"number": 133,
+			"origname": "fchdir",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__ia32_sys_fchdir"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/filesystems.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 135,
+			"kconfig": "SYSFS_SYSCALL",
+			"line": 191,
+			"name": "sysfs",
+			"number": 135,
+			"origname": "sysfs",
+			"signature": [
+				"int option",
+				"unsigned long arg1",
+				"unsigned long arg2"
+			],
+			"symbol": "__ia32_sys_sysfs"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exec_domain.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 136,
+			"kconfig": null,
+			"line": 38,
+			"name": "personality",
+			"number": 136,
+			"origname": "personality",
+			"signature": [
+				"unsigned int personality"
+			],
+			"symbol": "__ia32_sys_personality"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 138,
+			"kconfig": "UID16",
+			"line": 104,
+			"name": "setfsuid16",
+			"number": 138,
+			"origname": "setfsuid16",
+			"signature": [
+				"old_uid_t uid"
+			],
+			"symbol": "__ia32_sys_setfsuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 139,
+			"kconfig": "UID16",
+			"line": 109,
+			"name": "setfsgid16",
+			"number": 139,
+			"origname": "setfsgid16",
+			"signature": [
+				"old_gid_t gid"
+			],
+			"symbol": "__ia32_sys_setfsgid16"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 140,
+			"kconfig": null,
+			"line": 417,
+			"name": "llseek",
+			"number": 140,
+			"origname": "llseek",
+			"signature": [
+				"unsigned int fd",
+				"unsigned long offset_high",
+				"unsigned long offset_low",
+				"loff_t *result",
+				"unsigned int whence"
+			],
+			"symbol": "__ia32_sys_llseek"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 141,
+			"kconfig": null,
+			"line": 308,
+			"name": "getdents",
+			"number": 141,
+			"origname": "getdents",
+			"signature": [
+				"unsigned int fd",
+				"struct linux_dirent *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__ia32_sys_getdents"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 142,
+			"kconfig": null,
+			"line": 722,
+			"name": "select",
+			"number": 142,
+			"origname": "select",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct __kernel_old_timeval *tvp"
+			],
+			"symbol": "__ia32_sys_select"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/locks.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 143,
+			"kconfig": null,
+			"line": 2135,
+			"name": "flock",
+			"number": 143,
+			"origname": "flock",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd"
+			],
+			"symbol": "__ia32_sys_flock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/msync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 144,
+			"kconfig": "MMU",
+			"line": 32,
+			"name": "msync",
+			"number": 144,
+			"origname": "msync",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_msync"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 145,
+			"kconfig": null,
+			"line": 1155,
+			"name": "readv",
+			"number": 145,
+			"origname": "readv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__ia32_sys_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 146,
+			"kconfig": null,
+			"line": 1161,
+			"name": "writev",
+			"number": 146,
+			"origname": "writev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen"
+			],
+			"symbol": "__ia32_sys_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 147,
+			"kconfig": null,
+			"line": 1197,
+			"name": "getsid",
+			"number": 147,
+			"origname": "getsid",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__ia32_sys_getsid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 148,
+			"kconfig": null,
+			"line": 220,
+			"name": "fdatasync",
+			"number": 148,
+			"origname": "fdatasync",
+			"signature": [
+				"unsigned int fd"
+			],
+			"symbol": "__ia32_sys_fdatasync"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 150,
+			"kconfig": "MMU",
+			"line": 659,
+			"name": "mlock",
+			"number": 150,
+			"origname": "mlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__ia32_sys_mlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 151,
+			"kconfig": "MMU",
+			"line": 677,
+			"name": "munlock",
+			"number": 151,
+			"origname": "munlock",
+			"signature": [
+				"unsigned long start",
+				"size_t len"
+			],
+			"symbol": "__ia32_sys_munlock"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 152,
+			"kconfig": "MMU",
+			"line": 745,
+			"name": "mlockall",
+			"number": 152,
+			"origname": "mlockall",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__ia32_sys_mlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 153,
+			"kconfig": "MMU",
+			"line": 774,
+			"name": "munlockall",
+			"number": 153,
+			"origname": "munlockall",
+			"signature": [],
+			"symbol": "__ia32_sys_munlockall"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 154,
+			"kconfig": null,
+			"line": 970,
+			"name": "sched_setparam",
+			"number": 154,
+			"origname": "sched_setparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__ia32_sys_sched_setparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 155,
+			"kconfig": null,
+			"line": 1046,
+			"name": "sched_getparam",
+			"number": 155,
+			"origname": "sched_getparam",
+			"signature": [
+				"pid_t pid",
+				"struct sched_param *param"
+			],
+			"symbol": "__ia32_sys_sched_getparam"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 156,
+			"kconfig": null,
+			"line": 955,
+			"name": "sched_setscheduler",
+			"number": 156,
+			"origname": "sched_setscheduler",
+			"signature": [
+				"pid_t pid",
+				"int policy",
+				"struct sched_param *param"
+			],
+			"symbol": "__ia32_sys_sched_setscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 157,
+			"kconfig": null,
+			"line": 1016,
+			"name": "sched_getscheduler",
+			"number": 157,
+			"origname": "sched_getscheduler",
+			"signature": [
+				"pid_t pid"
+			],
+			"symbol": "__ia32_sys_sched_getscheduler"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 158,
+			"kconfig": null,
+			"line": 1377,
+			"name": "sched_yield",
+			"number": 158,
+			"origname": "sched_yield",
+			"signature": [],
+			"symbol": "__ia32_sys_sched_yield"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 159,
+			"kconfig": null,
+			"line": 1485,
+			"name": "sched_get_priority_max",
+			"number": 159,
+			"origname": "sched_get_priority_max",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__ia32_sys_sched_get_priority_max"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 160,
+			"kconfig": null,
+			"line": 1513,
+			"name": "sched_get_priority_min",
+			"number": 160,
+			"origname": "sched_get_priority_min",
+			"signature": [
+				"int policy"
+			],
+			"symbol": "__ia32_sys_sched_get_priority_min"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 161,
+			"kconfig": null,
+			"line": 1584,
+			"name": "sched_rr_get_interval",
+			"number": 161,
+			"origname": "sched_rr_get_interval_time32",
+			"signature": [
+				"pid_t pid",
+				"struct old_timespec32 *interval"
+			],
+			"symbol": "__ia32_sys_sched_rr_get_interval_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/hrtimer.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 162,
+			"kconfig": null,
+			"line": 2231,
+			"name": "nanosleep",
+			"number": 162,
+			"origname": "nanosleep_time32",
+			"signature": [
+				"struct old_timespec32 *rqtp",
+				"struct old_timespec32 *rmtp"
+			],
+			"symbol": "__ia32_sys_nanosleep_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mremap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 163,
+			"kconfig": null,
+			"line": 1045,
+			"name": "mremap",
+			"number": 163,
+			"origname": "mremap",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long old_len",
+				"unsigned long new_len",
+				"unsigned long flags",
+				"unsigned long new_addr"
+			],
+			"symbol": "__ia32_sys_mremap"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 164,
+			"kconfig": "UID16",
+			"line": 58,
+			"name": "setresuid16",
+			"number": 164,
+			"origname": "setresuid16",
+			"signature": [
+				"old_uid_t ruid",
+				"old_uid_t euid",
+				"old_uid_t suid"
+			],
+			"symbol": "__ia32_sys_setresuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 165,
+			"kconfig": "UID16",
+			"line": 64,
+			"name": "getresuid16",
+			"number": 165,
+			"origname": "getresuid16",
+			"signature": [
+				"old_uid_t *ruidp",
+				"old_uid_t *euidp",
+				"old_uid_t *suidp"
+			],
+			"symbol": "__ia32_sys_getresuid16"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/vm86_32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 166,
+			"kconfig": "X86_LEGACY_VM86",
+			"line": 176,
+			"name": "vm86",
+			"number": 166,
+			"origname": "vm86",
+			"signature": [
+				"unsigned long cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__ia32_sys_vm86"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 168,
+			"kconfig": null,
+			"line": 1062,
+			"name": "poll",
+			"number": 168,
+			"origname": "poll",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"int timeout_msecs"
+			],
+			"symbol": "__ia32_sys_poll"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 170,
+			"kconfig": "UID16",
+			"line": 81,
+			"name": "setresgid16",
+			"number": 170,
+			"origname": "setresgid16",
+			"signature": [
+				"old_gid_t rgid",
+				"old_gid_t egid",
+				"old_gid_t sgid"
+			],
+			"symbol": "__ia32_sys_setresgid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 171,
+			"kconfig": "UID16",
+			"line": 87,
+			"name": "getresgid16",
+			"number": 171,
+			"origname": "getresgid16",
+			"signature": [
+				"old_gid_t *rgidp",
+				"old_gid_t *egidp",
+				"old_gid_t *sgidp"
+			],
+			"symbol": "__ia32_sys_getresgid16"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 172,
+			"kconfig": null,
+			"line": 2469,
+			"name": "prctl",
+			"number": 172,
+			"origname": "prctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__ia32_sys_prctl"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/signal_32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 173,
+			"kconfig": null,
+			"line": 148,
+			"name": "rt_sigreturn",
+			"number": 173,
+			"origname": "rt_sigreturn",
+			"signature": [],
+			"symbol": "__ia32_sys_rt_sigreturn"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 174,
+			"kconfig": null,
+			"line": 4606,
+			"name": "rt_sigaction",
+			"number": 174,
+			"origname": "rt_sigaction",
+			"signature": [
+				"int sig",
+				"const struct sigaction *act",
+				"struct sigaction *oact",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigaction"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 175,
+			"kconfig": null,
+			"line": 3320,
+			"name": "rt_sigprocmask",
+			"number": 175,
+			"origname": "rt_sigprocmask",
+			"signature": [
+				"int how",
+				"sigset_t *nset",
+				"sigset_t *oset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigprocmask"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 176,
+			"kconfig": null,
+			"line": 3392,
+			"name": "rt_sigpending",
+			"number": 176,
+			"origname": "rt_sigpending",
+			"signature": [
+				"sigset_t *uset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigpending"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 177,
+			"kconfig": null,
+			"line": 3839,
+			"name": "rt_sigtimedwait",
+			"number": 177,
+			"origname": "rt_sigtimedwait_time32",
+			"signature": [
+				"const sigset_t *uthese",
+				"siginfo_t *uinfo",
+				"const struct old_timespec32 *uts",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigtimedwait_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 178,
+			"kconfig": null,
+			"line": 4188,
+			"name": "rt_sigqueueinfo",
+			"number": 178,
+			"origname": "rt_sigqueueinfo",
+			"signature": [
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__ia32_sys_rt_sigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 179,
+			"kconfig": null,
+			"line": 4829,
+			"name": "rt_sigsuspend",
+			"number": 179,
+			"origname": "rt_sigsuspend",
+			"signature": [
+				"sigset_t *unewset",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigsuspend"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 180,
+			"kconfig": null,
+			"line": 68,
+			"name": "pread64",
+			"number": 180,
+			"origname": "ia32_pread64",
+			"signature": [
+				"unsigned int fd",
+				"char *ubuf",
+				"u32 count",
+				"u32 poslo",
+				"u32 poshi"
+			],
+			"symbol": "__ia32_sys_ia32_pread64"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 181,
+			"kconfig": null,
+			"line": 75,
+			"name": "pwrite64",
+			"number": 181,
+			"origname": "ia32_pwrite64",
+			"signature": [
+				"unsigned int fd",
+				"const char *ubuf",
+				"u32 count",
+				"u32 poslo",
+				"u32 poshi"
+			],
+			"symbol": "__ia32_sys_ia32_pwrite64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/uid16.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 182,
+			"kconfig": "UID16",
+			"line": 23,
+			"name": "chown16",
+			"number": 182,
+			"origname": "chown16",
+			"signature": [
+				"const char *filename",
+				"old_uid_t user",
+				"old_gid_t group"
+			],
+			"symbol": "__ia32_sys_chown16"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/d_path.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 183,
+			"kconfig": null,
+			"line": 412,
+			"name": "getcwd",
+			"number": 183,
+			"origname": "getcwd",
+			"signature": [
+				"char *buf",
+				"unsigned long size"
+			],
+			"symbol": "__ia32_sys_getcwd"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 184,
+			"kconfig": "MULTIUSER",
+			"line": 137,
+			"name": "capget",
+			"number": 184,
+			"origname": "capget",
+			"signature": [
+				"cap_user_header_t header",
+				"cap_user_data_t dataptr"
+			],
+			"symbol": "__ia32_sys_capget"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/capability.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 185,
+			"kconfig": "MULTIUSER",
+			"line": 216,
+			"name": "capset",
+			"number": 185,
+			"origname": "capset",
+			"signature": [
+				"cap_user_header_t header",
+				"const cap_user_data_t data"
+			],
+			"symbol": "__ia32_sys_capset"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 186,
+			"kconfig": null,
+			"line": 4423,
+			"name": "sigaltstack",
+			"number": 186,
+			"origname": "sigaltstack",
+			"signature": [
+				"const stack_t *uss",
+				"stack_t *uoss"
+			],
+			"symbol": "__ia32_sys_sigaltstack"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 187,
+			"kconfig": null,
+			"line": 1391,
+			"name": "sendfile",
+			"number": 187,
+			"origname": "sendfile",
+			"signature": [
+				"int out_fd",
+				"int in_fd",
+				"off_t *offset",
+				"size_t count"
+			],
+			"symbol": "__ia32_sys_sendfile"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 190,
+			"kconfig": null,
+			"line": 2913,
+			"name": "vfork",
+			"number": 190,
+			"origname": "vfork",
+			"signature": [],
+			"symbol": "__ia32_sys_vfork"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 191,
+			"kconfig": null,
+			"line": 1529,
+			"name": "getrlimit",
+			"number": 191,
+			"origname": "getrlimit",
+			"signature": [
+				"unsigned int resource",
+				"struct rlimit *rlim"
+			],
+			"symbol": "__ia32_sys_getrlimit"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 192,
+			"kconfig": null,
+			"line": 614,
+			"name": "mmap_pgoff",
+			"number": 192,
+			"origname": "mmap_pgoff",
+			"signature": [
+				"unsigned long addr",
+				"unsigned long len",
+				"unsigned long prot",
+				"unsigned long flags",
+				"unsigned long fd",
+				"unsigned long pgoff"
+			],
+			"symbol": "__ia32_sys_mmap_pgoff"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 193,
+			"kconfig": null,
+			"line": 54,
+			"name": "truncate64",
+			"number": 193,
+			"origname": "ia32_truncate64",
+			"signature": [
+				"const char *filename",
+				"unsigned long offset_low",
+				"unsigned long offset_high"
+			],
+			"symbol": "__ia32_sys_ia32_truncate64"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 194,
+			"kconfig": null,
+			"line": 61,
+			"name": "ftruncate64",
+			"number": 194,
+			"origname": "ia32_ftruncate64",
+			"signature": [
+				"unsigned int fd",
+				"unsigned long offset_low",
+				"unsigned long offset_high"
+			],
+			"symbol": "__ia32_sys_ia32_ftruncate64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 195,
+			"kconfig": null,
+			"line": 647,
+			"name": "stat64",
+			"number": 195,
+			"origname": "stat64",
+			"signature": [
+				"const char *filename",
+				"struct stat64 *statbuf"
+			],
+			"symbol": "__ia32_sys_stat64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 196,
+			"kconfig": null,
+			"line": 659,
+			"name": "lstat64",
+			"number": 196,
+			"origname": "lstat64",
+			"signature": [
+				"const char *filename",
+				"struct stat64 *statbuf"
+			],
+			"symbol": "__ia32_sys_lstat64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 197,
+			"kconfig": null,
+			"line": 671,
+			"name": "fstat64",
+			"number": 197,
+			"origname": "fstat64",
+			"signature": [
+				"unsigned long fd",
+				"struct stat64 *statbuf"
+			],
+			"symbol": "__ia32_sys_fstat64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 198,
+			"kconfig": null,
+			"line": 836,
+			"name": "lchown",
+			"number": 198,
+			"origname": "lchown",
+			"signature": [
+				"const char *filename",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__ia32_sys_lchown"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 199,
+			"kconfig": null,
+			"line": 997,
+			"name": "getuid",
+			"number": 199,
+			"origname": "getuid",
+			"signature": [],
+			"symbol": "__ia32_sys_getuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 200,
+			"kconfig": null,
+			"line": 1009,
+			"name": "getgid",
+			"number": 200,
+			"origname": "getgid",
+			"signature": [],
+			"symbol": "__ia32_sys_getgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 201,
+			"kconfig": null,
+			"line": 1003,
+			"name": "geteuid",
+			"number": 201,
+			"origname": "geteuid",
+			"signature": [],
+			"symbol": "__ia32_sys_geteuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 202,
+			"kconfig": null,
+			"line": 1015,
+			"name": "getegid",
+			"number": 202,
+			"origname": "getegid",
+			"signature": [],
+			"symbol": "__ia32_sys_getegid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 203,
+			"kconfig": "MULTIUSER",
+			"line": 605,
+			"name": "setreuid",
+			"number": 203,
+			"origname": "setreuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid"
+			],
+			"symbol": "__ia32_sys_setreuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 204,
+			"kconfig": "MULTIUSER",
+			"line": 439,
+			"name": "setregid",
+			"number": 204,
+			"origname": "setregid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid"
+			],
+			"symbol": "__ia32_sys_setregid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 205,
+			"kconfig": "MULTIUSER",
+			"line": 161,
+			"name": "getgroups",
+			"number": 205,
+			"origname": "getgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__ia32_sys_getgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/groups.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 206,
+			"kconfig": "MULTIUSER",
+			"line": 198,
+			"name": "setgroups",
+			"number": 206,
+			"origname": "setgroups",
+			"signature": [
+				"int gidsetsize",
+				"gid_t *grouplist"
+			],
+			"symbol": "__ia32_sys_setgroups"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 207,
+			"kconfig": null,
+			"line": 865,
+			"name": "fchown",
+			"number": 207,
+			"origname": "fchown",
+			"signature": [
+				"unsigned int fd",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__ia32_sys_fchown"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 208,
+			"kconfig": "MULTIUSER",
+			"line": 753,
+			"name": "setresuid",
+			"number": 208,
+			"origname": "setresuid",
+			"signature": [
+				"uid_t ruid",
+				"uid_t euid",
+				"uid_t suid"
+			],
+			"symbol": "__ia32_sys_setresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 209,
+			"kconfig": "MULTIUSER",
+			"line": 758,
+			"name": "getresuid",
+			"number": 209,
+			"origname": "getresuid",
+			"signature": [
+				"uid_t *ruidp",
+				"uid_t *euidp",
+				"uid_t *suidp"
+			],
+			"symbol": "__ia32_sys_getresuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 210,
+			"kconfig": "MULTIUSER",
+			"line": 842,
+			"name": "setresgid",
+			"number": 210,
+			"origname": "setresgid",
+			"signature": [
+				"gid_t rgid",
+				"gid_t egid",
+				"gid_t sgid"
+			],
+			"symbol": "__ia32_sys_setresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 211,
+			"kconfig": "MULTIUSER",
+			"line": 847,
+			"name": "getresgid",
+			"number": 211,
+			"origname": "getresgid",
+			"signature": [
+				"gid_t *rgidp",
+				"gid_t *egidp",
+				"gid_t *sgidp"
+			],
+			"symbol": "__ia32_sys_getresgid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 212,
+			"kconfig": null,
+			"line": 831,
+			"name": "chown",
+			"number": 212,
+			"origname": "chown",
+			"signature": [
+				"const char *filename",
+				"uid_t user",
+				"gid_t group"
+			],
+			"symbol": "__ia32_sys_chown"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 213,
+			"kconfig": "MULTIUSER",
+			"line": 668,
+			"name": "setuid",
+			"number": 213,
+			"origname": "setuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__ia32_sys_setuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 214,
+			"kconfig": "MULTIUSER",
+			"line": 485,
+			"name": "setgid",
+			"number": 214,
+			"origname": "setgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__ia32_sys_setgid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 215,
+			"kconfig": "MULTIUSER",
+			"line": 910,
+			"name": "setfsuid",
+			"number": 215,
+			"origname": "setfsuid",
+			"signature": [
+				"uid_t uid"
+			],
+			"symbol": "__ia32_sys_setfsuid"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 216,
+			"kconfig": "MULTIUSER",
+			"line": 954,
+			"name": "setfsgid",
+			"number": 216,
+			"origname": "setfsgid",
+			"signature": [
+				"gid_t gid"
+			],
+			"symbol": "__ia32_sys_setfsgid"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 217,
+			"kconfig": null,
+			"line": 4388,
+			"name": "pivot_root",
+			"number": 217,
+			"origname": "pivot_root",
+			"signature": [
+				"const char *new_root",
+				"const char *put_old"
+			],
+			"symbol": "__ia32_sys_pivot_root"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mincore.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 218,
+			"kconfig": "MMU",
+			"line": 232,
+			"name": "mincore",
+			"number": 218,
+			"origname": "mincore",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"unsigned char *vec"
+			],
+			"symbol": "__ia32_sys_mincore"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 219,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1712,
+			"name": "madvise",
+			"number": 219,
+			"origname": "madvise",
+			"signature": [
+				"unsigned long start",
+				"size_t len_in",
+				"int behavior"
+			],
+			"symbol": "__ia32_sys_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/readdir.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 220,
+			"kconfig": null,
+			"line": 389,
+			"name": "getdents64",
+			"number": 220,
+			"origname": "getdents64",
+			"signature": [
+				"unsigned int fd",
+				"struct linux_dirent64 *dirent",
+				"unsigned int count"
+			],
+			"symbol": "__ia32_sys_getdents64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fcntl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 221,
+			"kconfig": null,
+			"line": 597,
+			"name": "fcntl64",
+			"number": 221,
+			"origname": "fcntl64",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__ia32_sys_fcntl64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 224,
+			"kconfig": null,
+			"line": 975,
+			"name": "gettid",
+			"number": 224,
+			"origname": "gettid",
+			"signature": [],
+			"symbol": "__ia32_sys_gettid"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 225,
+			"kconfig": null,
+			"line": 97,
+			"name": "readahead",
+			"number": 225,
+			"origname": "ia32_readahead",
+			"signature": [
+				"int fd",
+				"unsigned int off_lo",
+				"unsigned int off_hi",
+				"size_t count"
+			],
+			"symbol": "__ia32_sys_ia32_readahead"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 226,
+			"kconfig": null,
+			"line": 743,
+			"name": "setxattr",
+			"number": 226,
+			"origname": "setxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_setxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 227,
+			"kconfig": null,
+			"line": 750,
+			"name": "lsetxattr",
+			"number": 227,
+			"origname": "lsetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_lsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 228,
+			"kconfig": null,
+			"line": 758,
+			"name": "fsetxattr",
+			"number": 228,
+			"origname": "fsetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"const void *value",
+				"size_t size",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_fsetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 229,
+			"kconfig": null,
+			"line": 888,
+			"name": "getxattr",
+			"number": 229,
+			"origname": "getxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_getxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 230,
+			"kconfig": null,
+			"line": 894,
+			"name": "lgetxattr",
+			"number": 230,
+			"origname": "lgetxattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_lgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 231,
+			"kconfig": null,
+			"line": 901,
+			"name": "fgetxattr",
+			"number": 231,
+			"origname": "fgetxattr",
+			"signature": [
+				"int fd",
+				"const char *name",
+				"void *value",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_fgetxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 232,
+			"kconfig": null,
+			"line": 998,
+			"name": "listxattr",
+			"number": 232,
+			"origname": "listxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_listxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 233,
+			"kconfig": null,
+			"line": 1004,
+			"name": "llistxattr",
+			"number": 233,
+			"origname": "llistxattr",
+			"signature": [
+				"const char *pathname",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_llistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 234,
+			"kconfig": null,
+			"line": 1010,
+			"name": "flistxattr",
+			"number": 234,
+			"origname": "flistxattr",
+			"signature": [
+				"int fd",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_flistxattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 235,
+			"kconfig": null,
+			"line": 1097,
+			"name": "removexattr",
+			"number": 235,
+			"origname": "removexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__ia32_sys_removexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 236,
+			"kconfig": null,
+			"line": 1103,
+			"name": "lremovexattr",
+			"number": 236,
+			"origname": "lremovexattr",
+			"signature": [
+				"const char *pathname",
+				"const char *name"
+			],
+			"symbol": "__ia32_sys_lremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 237,
+			"kconfig": null,
+			"line": 1109,
+			"name": "fremovexattr",
+			"number": 237,
+			"origname": "fremovexattr",
+			"signature": [
+				"int fd",
+				"const char *name"
+			],
+			"symbol": "__ia32_sys_fremovexattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 238,
+			"kconfig": null,
+			"line": 4160,
+			"name": "tkill",
+			"number": 238,
+			"origname": "tkill",
+			"signature": [
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__ia32_sys_tkill"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 239,
+			"kconfig": null,
+			"line": 1410,
+			"name": "sendfile64",
+			"number": 239,
+			"origname": "sendfile64",
+			"signature": [
+				"int out_fd",
+				"int in_fd",
+				"loff_t *offset",
+				"size_t count"
+			],
+			"symbol": "__ia32_sys_sendfile64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 240,
+			"kconfig": "FUTEX",
+			"line": 492,
+			"name": "futex",
+			"number": 240,
+			"origname": "futex_time32",
+			"signature": [
+				"u32 *uaddr",
+				"int op",
+				"u32 val",
+				"const struct old_timespec32 *utime",
+				"u32 *uaddr2",
+				"u32 val3"
+			],
+			"symbol": "__ia32_sys_futex_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 241,
+			"kconfig": null,
+			"line": 1279,
+			"name": "sched_setaffinity",
+			"number": 241,
+			"origname": "sched_setaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__ia32_sys_sched_setaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 242,
+			"kconfig": null,
+			"line": 1324,
+			"name": "sched_getaffinity",
+			"number": 242,
+			"origname": "sched_getaffinity",
+			"signature": [
+				"pid_t pid",
+				"unsigned int len",
+				"unsigned long *user_mask_ptr"
+			],
+			"symbol": "__ia32_sys_sched_getaffinity"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/tls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 243,
+			"kconfig": null,
+			"line": 186,
+			"name": "set_thread_area",
+			"number": 243,
+			"origname": "set_thread_area",
+			"signature": [
+				"struct user_desc *u_info"
+			],
+			"symbol": "__ia32_sys_set_thread_area"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/tls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 244,
+			"kconfig": null,
+			"line": 238,
+			"name": "get_thread_area",
+			"number": 244,
+			"origname": "get_thread_area",
+			"signature": [
+				"struct user_desc *u_info"
+			],
+			"symbol": "__ia32_sys_get_thread_area"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 245,
+			"kconfig": "AIO",
+			"line": 1382,
+			"name": "io_setup",
+			"number": 245,
+			"origname": "io_setup",
+			"signature": [
+				"unsigned nr_events",
+				"aio_context_t *ctxp"
+			],
+			"symbol": "__ia32_sys_io_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 246,
+			"kconfig": "AIO",
+			"line": 1451,
+			"name": "io_destroy",
+			"number": 246,
+			"origname": "io_destroy",
+			"signature": [
+				"aio_context_t ctx"
+			],
+			"symbol": "__ia32_sys_io_destroy"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 247,
+			"kconfig": "AIO",
+			"line": 2348,
+			"name": "io_getevents",
+			"number": 247,
+			"origname": "io_getevents_time32",
+			"signature": [
+				"__u32 ctx_id",
+				"__s32 min_nr",
+				"__s32 nr",
+				"struct io_event *events",
+				"struct old_timespec32 *timeout"
+			],
+			"symbol": "__ia32_sys_io_getevents_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 248,
+			"kconfig": "AIO",
+			"line": 2081,
+			"name": "io_submit",
+			"number": 248,
+			"origname": "io_submit",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long nr",
+				"struct iocb **iocbpp"
+			],
+			"symbol": "__ia32_sys_io_submit"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 249,
+			"kconfig": "AIO",
+			"line": 2175,
+			"name": "io_cancel",
+			"number": 249,
+			"origname": "io_cancel",
+			"signature": [
+				"aio_context_t ctx_id",
+				"struct iocb *iocb",
+				"struct io_event *result"
+			],
+			"symbol": "__ia32_sys_io_cancel"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 250,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 112,
+			"name": "fadvise64",
+			"number": 250,
+			"origname": "ia32_fadvise64",
+			"signature": [
+				"int fd",
+				"unsigned int offset_lo",
+				"unsigned int offset_hi",
+				"size_t len",
+				"int advice"
+			],
+			"symbol": "__ia32_sys_ia32_fadvise64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 252,
+			"kconfig": null,
+			"line": 1096,
+			"name": "exit_group",
+			"number": 252,
+			"origname": "exit_group",
+			"signature": [
+				"int error_code"
+			],
+			"symbol": "__ia32_sys_exit_group"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 254,
+			"kconfig": "EPOLL",
+			"line": 2256,
+			"name": "epoll_create",
+			"number": 254,
+			"origname": "epoll_create",
+			"signature": [
+				"int size"
+			],
+			"symbol": "__ia32_sys_epoll_create"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 255,
+			"kconfig": "EPOLL",
+			"line": 2436,
+			"name": "epoll_ctl",
+			"number": 255,
+			"origname": "epoll_ctl",
+			"signature": [
+				"int epfd",
+				"int op",
+				"int fd",
+				"struct epoll_event *event"
+			],
+			"symbol": "__ia32_sys_epoll_ctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 256,
+			"kconfig": "EPOLL",
+			"line": 2487,
+			"name": "epoll_wait",
+			"number": 256,
+			"origname": "epoll_wait",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"int timeout"
+			],
+			"symbol": "__ia32_sys_epoll_wait"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mmap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 257,
+			"kconfig": "MMU",
+			"line": 1091,
+			"name": "remap_file_pages",
+			"number": 257,
+			"origname": "remap_file_pages",
+			"signature": [
+				"unsigned long start",
+				"unsigned long size",
+				"unsigned long prot",
+				"unsigned long pgoff",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_remap_file_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 258,
+			"kconfig": null,
+			"line": 1949,
+			"name": "set_tid_address",
+			"number": 258,
+			"origname": "set_tid_address",
+			"signature": [
+				"int *tidptr"
+			],
+			"symbol": "__ia32_sys_set_tid_address"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 259,
+			"kconfig": "POSIX_TIMERS",
+			"line": 480,
+			"name": "timer_create",
+			"number": 259,
+			"origname": "timer_create",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct sigevent *timer_event_spec",
+				"timer_t *created_timer_id"
+			],
+			"symbol": "__ia32_sys_timer_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 260,
+			"kconfig": "POSIX_TIMERS",
+			"line": 937,
+			"name": "timer_settime",
+			"number": 260,
+			"origname": "timer_settime32",
+			"signature": [
+				"timer_t timer_id",
+				"int flags",
+				"struct old_itimerspec32 *new",
+				"struct old_itimerspec32 *old"
+			],
+			"symbol": "__ia32_sys_timer_settime32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 261,
+			"kconfig": "POSIX_TIMERS",
+			"line": 691,
+			"name": "timer_gettime",
+			"number": 261,
+			"origname": "timer_gettime32",
+			"signature": [
+				"timer_t timer_id",
+				"struct old_itimerspec32 *setting"
+			],
+			"symbol": "__ia32_sys_timer_gettime32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 262,
+			"kconfig": "POSIX_TIMERS",
+			"line": 724,
+			"name": "timer_getoverrun",
+			"number": 262,
+			"origname": "timer_getoverrun",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__ia32_sys_timer_getoverrun"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 263,
+			"kconfig": "POSIX_TIMERS",
+			"line": 994,
+			"name": "timer_delete",
+			"number": 263,
+			"origname": "timer_delete",
+			"signature": [
+				"timer_t timer_id"
+			],
+			"symbol": "__ia32_sys_timer_delete"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 264,
+			"kconfig": null,
+			"line": 1278,
+			"name": "clock_settime",
+			"number": 264,
+			"origname": "clock_settime32",
+			"signature": [
+				"clockid_t which_clock",
+				"struct old_timespec32 *tp"
+			],
+			"symbol": "__ia32_sys_clock_settime32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 265,
+			"kconfig": null,
+			"line": 1293,
+			"name": "clock_gettime",
+			"number": 265,
+			"origname": "clock_gettime32",
+			"signature": [
+				"clockid_t which_clock",
+				"struct old_timespec32 *tp"
+			],
+			"symbol": "__ia32_sys_clock_gettime32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 266,
+			"kconfig": null,
+			"line": 1329,
+			"name": "clock_getres",
+			"number": 266,
+			"origname": "clock_getres_time32",
+			"signature": [
+				"clockid_t which_clock",
+				"struct old_timespec32 *tp"
+			],
+			"symbol": "__ia32_sys_clock_getres_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 267,
+			"kconfig": null,
+			"line": 1407,
+			"name": "clock_nanosleep",
+			"number": 267,
+			"origname": "clock_nanosleep_time32",
+			"signature": [
+				"clockid_t which_clock",
+				"int flags",
+				"struct old_timespec32 *rqtp",
+				"struct old_timespec32 *rmtp"
+			],
+			"symbol": "__ia32_sys_clock_nanosleep_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 268,
+			"kconfig": null,
+			"line": 199,
+			"name": "statfs64",
+			"number": 268,
+			"origname": "statfs64",
+			"signature": [
+				"const char *pathname",
+				"size_t sz",
+				"struct statfs64 *buf"
+			],
+			"symbol": "__ia32_sys_statfs64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/statfs.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 269,
+			"kconfig": null,
+			"line": 220,
+			"name": "fstatfs64",
+			"number": 269,
+			"origname": "fstatfs64",
+			"signature": [
+				"unsigned int fd",
+				"size_t sz",
+				"struct statfs64 *buf"
+			],
+			"symbol": "__ia32_sys_fstatfs64"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 270,
+			"kconfig": null,
+			"line": 4144,
+			"name": "tgkill",
+			"number": 270,
+			"origname": "tgkill",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig"
+			],
+			"symbol": "__ia32_sys_tgkill"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 271,
+			"kconfig": null,
+			"line": 290,
+			"name": "utimes",
+			"number": 271,
+			"origname": "utimes_time32",
+			"signature": [
+				"const char *filename",
+				"struct old_timeval32 *t"
+			],
+			"symbol": "__ia32_sys_utimes_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 272,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 87,
+			"name": "fadvise64_64",
+			"number": 272,
+			"origname": "ia32_fadvise64_64",
+			"signature": [
+				"int fd",
+				"__u32 offset_low",
+				"__u32 offset_high",
+				"__u32 len_low",
+				"__u32 len_high",
+				"int advice"
+			],
+			"symbol": "__ia32_sys_ia32_fadvise64_64"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 274,
+			"kconfig": "NUMA",
+			"line": 1607,
+			"name": "mbind",
+			"number": 274,
+			"origname": "mbind",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_mbind"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 275,
+			"kconfig": "NUMA",
+			"line": 1764,
+			"name": "get_mempolicy",
+			"number": 275,
+			"origname": "get_mempolicy",
+			"signature": [
+				"int *policy",
+				"unsigned long *nmask",
+				"unsigned long maxnode",
+				"unsigned long addr",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_get_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 276,
+			"kconfig": "NUMA",
+			"line": 1634,
+			"name": "set_mempolicy",
+			"number": 276,
+			"origname": "set_mempolicy",
+			"signature": [
+				"int mode",
+				"const unsigned long *nmask",
+				"unsigned long maxnode"
+			],
+			"symbol": "__ia32_sys_set_mempolicy"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 277,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 944,
+			"name": "mq_open",
+			"number": 277,
+			"origname": "mq_open",
+			"signature": [
+				"const char *u_name",
+				"int oflag",
+				"umode_t mode",
+				"struct mq_attr *u_attr"
+			],
+			"symbol": "__ia32_sys_mq_open"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 278,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 954,
+			"name": "mq_unlink",
+			"number": 278,
+			"origname": "mq_unlink",
+			"signature": [
+				"const char *u_name"
+			],
+			"symbol": "__ia32_sys_mq_unlink"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 279,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1582,
+			"name": "mq_timedsend",
+			"number": 279,
+			"origname": "mq_timedsend_time32",
+			"signature": [
+				"mqd_t mqdes",
+				"const char *u_msg_ptr",
+				"unsigned int msg_len",
+				"unsigned int msg_prio",
+				"const struct old_timespec32 *u_abs_timeout"
+			],
+			"symbol": "__ia32_sys_mq_timedsend_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 280,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1597,
+			"name": "mq_timedreceive",
+			"number": 280,
+			"origname": "mq_timedreceive_time32",
+			"signature": [
+				"mqd_t mqdes",
+				"char *u_msg_ptr",
+				"unsigned int msg_len",
+				"unsigned int *u_msg_prio",
+				"const struct old_timespec32 *u_abs_timeout"
+			],
+			"symbol": "__ia32_sys_mq_timedreceive_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 281,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1400,
+			"name": "mq_notify",
+			"number": 281,
+			"origname": "mq_notify",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct sigevent *u_notification"
+			],
+			"symbol": "__ia32_sys_mq_notify"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 282,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1452,
+			"name": "mq_getsetattr",
+			"number": 282,
+			"origname": "mq_getsetattr",
+			"signature": [
+				"mqd_t mqdes",
+				"const struct mq_attr *u_mqstat",
+				"struct mq_attr *u_omqstat"
+			],
+			"symbol": "__ia32_sys_mq_getsetattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kexec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 283,
+			"kconfig": "KEXEC",
+			"line": 242,
+			"name": "kexec_load",
+			"number": 283,
+			"origname": "kexec_load",
+			"signature": [
+				"unsigned long entry",
+				"unsigned long nr_segments",
+				"struct kexec_segment *segments",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_kexec_load"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/exit.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 284,
+			"kconfig": null,
+			"line": 1782,
+			"name": "waitid",
+			"number": 284,
+			"origname": "waitid",
+			"signature": [
+				"int which",
+				"pid_t upid",
+				"struct siginfo *infop",
+				"int options",
+				"struct rusage *ru"
+			],
+			"symbol": "__ia32_sys_waitid"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 286,
+			"kconfig": "KEYS",
+			"line": 74,
+			"name": "add_key",
+			"number": 286,
+			"origname": "add_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const void *_payload",
+				"size_t plen",
+				"key_serial_t ringid"
+			],
+			"symbol": "__ia32_sys_add_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 287,
+			"kconfig": "KEYS",
+			"line": 167,
+			"name": "request_key",
+			"number": 287,
+			"origname": "request_key",
+			"signature": [
+				"const char *_type",
+				"const char *_description",
+				"const char *_callout_info",
+				"key_serial_t destringid"
+			],
+			"symbol": "__ia32_sys_request_key"
+		},
+		{
+			"esoteric": false,
+			"file": "security/keys/keyctl.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 288,
+			"kconfig": "KEYS",
+			"line": 1874,
+			"name": "keyctl",
+			"number": 288,
+			"origname": "keyctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2",
+				"unsigned long arg3",
+				"unsigned long arg4",
+				"unsigned long arg5"
+			],
+			"symbol": "__ia32_sys_keyctl"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 289,
+			"kconfig": "BLOCK",
+			"line": 69,
+			"name": "ioprio_set",
+			"number": 289,
+			"origname": "ioprio_set",
+			"signature": [
+				"int which",
+				"int who",
+				"int ioprio"
+			],
+			"symbol": "__ia32_sys_ioprio_set"
+		},
+		{
+			"esoteric": false,
+			"file": "block/ioprio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 290,
+			"kconfig": "BLOCK",
+			"line": 184,
+			"name": "ioprio_get",
+			"number": 290,
+			"origname": "ioprio_get",
+			"signature": [
+				"int which",
+				"int who"
+			],
+			"symbol": "__ia32_sys_ioprio_get"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 291,
+			"kconfig": "INOTIFY_USER",
+			"line": 724,
+			"name": "inotify_init",
+			"number": 291,
+			"origname": "inotify_init",
+			"signature": [],
+			"symbol": "__ia32_sys_inotify_init"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 292,
+			"kconfig": "INOTIFY_USER",
+			"line": 729,
+			"name": "inotify_add_watch",
+			"number": 292,
+			"origname": "inotify_add_watch",
+			"signature": [
+				"int fd",
+				"const char *pathname",
+				"u32 mask"
+			],
+			"symbol": "__ia32_sys_inotify_add_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 293,
+			"kconfig": "INOTIFY_USER",
+			"line": 786,
+			"name": "inotify_rm_watch",
+			"number": 293,
+			"origname": "inotify_rm_watch",
+			"signature": [
+				"int fd",
+				"__s32 wd"
+			],
+			"symbol": "__ia32_sys_inotify_rm_watch"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 294,
+			"kconfig": "MIGRATION",
+			"line": 1727,
+			"name": "migrate_pages",
+			"number": 294,
+			"origname": "migrate_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long maxnode",
+				"const unsigned long *old_nodes",
+				"const unsigned long *new_nodes"
+			],
+			"symbol": "__ia32_sys_migrate_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 295,
+			"kconfig": null,
+			"line": 1454,
+			"name": "openat",
+			"number": 295,
+			"origname": "openat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int flags",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_openat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 296,
+			"kconfig": null,
+			"line": 4349,
+			"name": "mkdirat",
+			"number": 296,
+			"origname": "mkdirat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_mkdirat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 297,
+			"kconfig": null,
+			"line": 4266,
+			"name": "mknodat",
+			"number": 297,
+			"origname": "mknodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int dev"
+			],
+			"symbol": "__ia32_sys_mknodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 298,
+			"kconfig": null,
+			"line": 825,
+			"name": "fchownat",
+			"number": 298,
+			"origname": "fchownat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"uid_t user",
+				"gid_t group",
+				"int flag"
+			],
+			"symbol": "__ia32_sys_fchownat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 299,
+			"kconfig": null,
+			"line": 283,
+			"name": "futimesat",
+			"number": 299,
+			"origname": "futimesat_time32",
+			"signature": [
+				"unsigned int dfd",
+				"const char *filename",
+				"struct old_timeval32 *t"
+			],
+			"symbol": "__ia32_sys_futimesat_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 300,
+			"kconfig": null,
+			"line": 682,
+			"name": "fstatat64",
+			"number": 300,
+			"origname": "fstatat64",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct stat64 *statbuf",
+				"int flag"
+			],
+			"symbol": "__ia32_sys_fstatat64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 301,
+			"kconfig": null,
+			"line": 4625,
+			"name": "unlinkat",
+			"number": 301,
+			"origname": "unlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"int flag"
+			],
+			"symbol": "__ia32_sys_unlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 302,
+			"kconfig": null,
+			"line": 5264,
+			"name": "renameat",
+			"number": 302,
+			"origname": "renameat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__ia32_sys_renameat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 303,
+			"kconfig": null,
+			"line": 4890,
+			"name": "linkat",
+			"number": 303,
+			"origname": "linkat",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_linkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 304,
+			"kconfig": null,
+			"line": 4710,
+			"name": "symlinkat",
+			"number": 304,
+			"origname": "symlinkat",
+			"signature": [
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname"
+			],
+			"symbol": "__ia32_sys_symlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 305,
+			"kconfig": null,
+			"line": 592,
+			"name": "readlinkat",
+			"number": 305,
+			"origname": "readlinkat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"char *buf",
+				"int bufsiz"
+			],
+			"symbol": "__ia32_sys_readlinkat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 306,
+			"kconfig": null,
+			"line": 706,
+			"name": "fchmodat",
+			"number": 306,
+			"origname": "fchmodat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode"
+			],
+			"symbol": "__ia32_sys_fchmodat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 307,
+			"kconfig": null,
+			"line": 535,
+			"name": "faccessat",
+			"number": 307,
+			"origname": "faccessat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode"
+			],
+			"symbol": "__ia32_sys_faccessat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 308,
+			"kconfig": null,
+			"line": 807,
+			"name": "pselect6",
+			"number": 308,
+			"origname": "pselect6_time32",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct old_timespec32 *tsp",
+				"void *sig"
+			],
+			"symbol": "__ia32_sys_pselect6_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 309,
+			"kconfig": null,
+			"line": 1121,
+			"name": "ppoll",
+			"number": 309,
+			"origname": "ppoll_time32",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"struct old_timespec32 *tsp",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_ppoll_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 310,
+			"kconfig": null,
+			"line": 3411,
+			"name": "unshare",
+			"number": 310,
+			"origname": "unshare",
+			"signature": [
+				"unsigned long unshare_flags"
+			],
+			"symbol": "__ia32_sys_unshare"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 311,
+			"kconfig": "FUTEX",
+			"line": 28,
+			"name": "set_robust_list",
+			"number": 311,
+			"origname": "set_robust_list",
+			"signature": [
+				"struct robust_list_head *head",
+				"size_t len"
+			],
+			"symbol": "__ia32_sys_set_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 312,
+			"kconfig": "FUTEX",
+			"line": 48,
+			"name": "get_robust_list",
+			"number": 312,
+			"origname": "get_robust_list",
+			"signature": [
+				"int pid",
+				"struct robust_list_head **head_ptr",
+				"size_t *len_ptr"
+			],
+			"symbol": "__ia32_sys_get_robust_list"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 313,
+			"kconfig": null,
+			"line": 1621,
+			"name": "splice",
+			"number": 313,
+			"origname": "splice",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_splice"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 314,
+			"kconfig": null,
+			"line": 103,
+			"name": "sync_file_range",
+			"number": 314,
+			"origname": "ia32_sync_file_range",
+			"signature": [
+				"int fd",
+				"unsigned int off_low",
+				"unsigned int off_hi",
+				"unsigned int n_low",
+				"unsigned int n_hi",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_ia32_sync_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 315,
+			"kconfig": null,
+			"line": 1988,
+			"name": "tee",
+			"number": 315,
+			"origname": "tee",
+			"signature": [
+				"int fdin",
+				"int fdout",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_tee"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/splice.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 316,
+			"kconfig": null,
+			"line": 1583,
+			"name": "vmsplice",
+			"number": 316,
+			"origname": "vmsplice",
+			"signature": [
+				"int fd",
+				"const struct iovec *uiov",
+				"unsigned long nr_segs",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_vmsplice"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/migrate.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 317,
+			"kconfig": "MIGRATION",
+			"line": 2586,
+			"name": "move_pages",
+			"number": 317,
+			"origname": "move_pages",
+			"signature": [
+				"pid_t pid",
+				"unsigned long nr_pages",
+				"const void **pages",
+				"const int *nodes",
+				"int *status",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_move_pages"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 318,
+			"kconfig": null,
+			"line": 2822,
+			"name": "getcpu",
+			"number": 318,
+			"origname": "getcpu",
+			"signature": [
+				"unsigned *cpup",
+				"unsigned *nodep",
+				"struct getcpu_cache *unused"
+			],
+			"symbol": "__ia32_sys_getcpu"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 319,
+			"kconfig": "EPOLL",
+			"line": 2521,
+			"name": "epoll_pwait",
+			"number": 319,
+			"origname": "epoll_pwait",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"int timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_epoll_pwait"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 320,
+			"kconfig": null,
+			"line": 247,
+			"name": "utimensat",
+			"number": 320,
+			"origname": "utimensat_time32",
+			"signature": [
+				"unsigned int dfd",
+				"const char *filename",
+				"struct old_timespec32 *t",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_utimensat_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/signalfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 321,
+			"kconfig": "SIGNALFD",
+			"line": 319,
+			"name": "signalfd",
+			"number": 321,
+			"origname": "signalfd",
+			"signature": [
+				"int ufd",
+				"sigset_t *user_mask",
+				"size_t sizemask"
+			],
+			"symbol": "__ia32_sys_signalfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 322,
+			"kconfig": null,
+			"line": 395,
+			"name": "timerfd_create",
+			"number": 322,
+			"origname": "timerfd_create",
+			"signature": [
+				"int clockid",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_timerfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 323,
+			"kconfig": null,
+			"line": 429,
+			"name": "eventfd",
+			"number": 323,
+			"origname": "eventfd",
+			"signature": [
+				"unsigned int count"
+			],
+			"symbol": "__ia32_sys_eventfd"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/sys_ia32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 324,
+			"kconfig": null,
+			"line": 119,
+			"name": "fallocate",
+			"number": 324,
+			"origname": "ia32_fallocate",
+			"signature": [
+				"int fd",
+				"int mode",
+				"unsigned int offset_lo",
+				"unsigned int offset_hi",
+				"unsigned int len_lo",
+				"unsigned int len_hi"
+			],
+			"symbol": "__ia32_sys_ia32_fallocate"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 325,
+			"kconfig": null,
+			"line": 588,
+			"name": "timerfd_settime",
+			"number": 325,
+			"origname": "timerfd_settime32",
+			"signature": [
+				"int ufd",
+				"int flags",
+				"const struct old_itimerspec32 *utmr",
+				"struct old_itimerspec32 *otmr"
+			],
+			"symbol": "__ia32_sys_timerfd_settime32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 326,
+			"kconfig": null,
+			"line": 605,
+			"name": "timerfd_gettime",
+			"number": 326,
+			"origname": "timerfd_gettime32",
+			"signature": [
+				"int ufd",
+				"struct old_itimerspec32 *otmr"
+			],
+			"symbol": "__ia32_sys_timerfd_gettime32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/signalfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 327,
+			"kconfig": "SIGNALFD",
+			"line": 307,
+			"name": "signalfd4",
+			"number": 327,
+			"origname": "signalfd4",
+			"signature": [
+				"int ufd",
+				"sigset_t *user_mask",
+				"size_t sizemask",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_signalfd4"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 328,
+			"kconfig": null,
+			"line": 424,
+			"name": "eventfd2",
+			"number": 328,
+			"origname": "eventfd2",
+			"signature": [
+				"unsigned int count",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_eventfd2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 329,
+			"kconfig": "EPOLL",
+			"line": 2251,
+			"name": "epoll_create1",
+			"number": 329,
+			"origname": "epoll_create1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__ia32_sys_epoll_create1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 330,
+			"kconfig": null,
+			"line": 1370,
+			"name": "dup3",
+			"number": 330,
+			"origname": "dup3",
+			"signature": [
+				"unsigned int oldfd",
+				"unsigned int newfd",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_dup3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/pipe.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 331,
+			"kconfig": null,
+			"line": 1043,
+			"name": "pipe2",
+			"number": 331,
+			"origname": "pipe2",
+			"signature": [
+				"int *fildes",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_pipe2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/inotify/inotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 332,
+			"kconfig": "INOTIFY_USER",
+			"line": 719,
+			"name": "inotify_init1",
+			"number": 332,
+			"origname": "inotify_init1",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__ia32_sys_inotify_init1"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 333,
+			"kconfig": null,
+			"line": 1167,
+			"name": "preadv",
+			"number": 333,
+			"origname": "preadv",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__ia32_sys_preadv"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 334,
+			"kconfig": null,
+			"line": 1187,
+			"name": "pwritev",
+			"number": 334,
+			"origname": "pwritev",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h"
+			],
+			"symbol": "__ia32_sys_pwritev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 335,
+			"kconfig": null,
+			"line": 4228,
+			"name": "rt_tgsigqueueinfo",
+			"number": 335,
+			"origname": "rt_tgsigqueueinfo",
+			"signature": [
+				"pid_t tgid",
+				"pid_t pid",
+				"int sig",
+				"siginfo_t *uinfo"
+			],
+			"symbol": "__ia32_sys_rt_tgsigqueueinfo"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/events/core.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 336,
+			"kconfig": "PERF_EVENTS",
+			"line": 12798,
+			"name": "perf_event_open",
+			"number": 336,
+			"origname": "perf_event_open",
+			"signature": [
+				"struct perf_event_attr *attr_uptr",
+				"pid_t pid",
+				"int cpu",
+				"int group_fd",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_perf_event_open"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 337,
+			"kconfig": "NET",
+			"line": 3031,
+			"name": "recvmmsg",
+			"number": 337,
+			"origname": "recvmmsg_time32",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags",
+				"struct old_timespec32 *timeout"
+			],
+			"symbol": "__ia32_sys_recvmmsg_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 338,
+			"kconfig": "FANOTIFY",
+			"line": 1466,
+			"name": "fanotify_init",
+			"number": 338,
+			"origname": "fanotify_init",
+			"signature": [
+				"unsigned int flags",
+				"unsigned int event_f_flags"
+			],
+			"symbol": "__ia32_sys_fanotify_init"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/notify/fanotify/fanotify_user.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 339,
+			"kconfig": "FANOTIFY",
+			"line": 2012,
+			"name": "fanotify_mark",
+			"number": 339,
+			"origname": "fanotify_mark",
+			"signature": [
+				"int fanotify_fd",
+				"unsigned int flags",
+				"u32 mask_lo",
+				"u32 mask_hi",
+				"int dfd",
+				"const char *pathname"
+			],
+			"symbol": "__ia32_sys_fanotify_mark"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sys.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 340,
+			"kconfig": null,
+			"line": 1695,
+			"name": "prlimit64",
+			"number": 340,
+			"origname": "prlimit64",
+			"signature": [
+				"pid_t pid",
+				"unsigned int resource",
+				"const struct rlimit64 *new_rlim",
+				"struct rlimit64 *old_rlim"
+			],
+			"symbol": "__ia32_sys_prlimit64"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 341,
+			"kconfig": "FHANDLE",
+			"line": 129,
+			"name": "name_to_handle_at",
+			"number": 341,
+			"origname": "name_to_handle_at",
+			"signature": [
+				"int dfd",
+				"const char *name",
+				"struct file_handle *handle",
+				"void *mnt_id",
+				"int flag"
+			],
+			"symbol": "__ia32_sys_name_to_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fhandle.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 342,
+			"kconfig": "FHANDLE",
+			"line": 434,
+			"name": "open_by_handle_at",
+			"number": 342,
+			"origname": "open_by_handle_at",
+			"signature": [
+				"int mountdirfd",
+				"struct file_handle *handle",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_open_by_handle_at"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 343,
+			"kconfig": null,
+			"line": 1311,
+			"name": "clock_adjtime",
+			"number": 343,
+			"origname": "clock_adjtime32",
+			"signature": [
+				"clockid_t which_clock",
+				"struct old_timex32 *utp"
+			],
+			"symbol": "__ia32_sys_clock_adjtime32"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/sync.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 344,
+			"kconfig": null,
+			"line": 149,
+			"name": "syncfs",
+			"number": 344,
+			"origname": "syncfs",
+			"signature": [
+				"int fd"
+			],
+			"symbol": "__ia32_sys_syncfs"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 345,
+			"kconfig": "NET",
+			"line": 2740,
+			"name": "sendmmsg",
+			"number": 345,
+			"origname": "sendmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_sendmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/nsproxy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 346,
+			"kconfig": null,
+			"line": 546,
+			"name": "setns",
+			"number": 346,
+			"origname": "setns",
+			"signature": [
+				"int fd",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_setns"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 347,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 292,
+			"name": "process_vm_readv",
+			"number": 347,
+			"origname": "process_vm_readv",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_process_vm_readv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/process_vm_access.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 348,
+			"kconfig": "CROSS_MEMORY_ATTACH",
+			"line": 299,
+			"name": "process_vm_writev",
+			"number": 348,
+			"origname": "process_vm_writev",
+			"signature": [
+				"pid_t pid",
+				"const struct iovec *lvec",
+				"unsigned long liovcnt",
+				"const struct iovec *rvec",
+				"unsigned long riovcnt",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_process_vm_writev"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/kcmp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 349,
+			"kconfig": "KCMP",
+			"line": 135,
+			"name": "kcmp",
+			"number": 349,
+			"origname": "kcmp",
+			"signature": [
+				"pid_t pid1",
+				"pid_t pid2",
+				"int type",
+				"unsigned long idx1",
+				"unsigned long idx2"
+			],
+			"symbol": "__ia32_sys_kcmp"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/module/main.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 350,
+			"kconfig": "MODULES",
+			"line": 3669,
+			"name": "finit_module",
+			"number": 350,
+			"origname": "finit_module",
+			"signature": [
+				"int fd",
+				"const char *uargs",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_finit_module"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 351,
+			"kconfig": null,
+			"line": 981,
+			"name": "sched_setattr",
+			"number": 351,
+			"origname": "sched_setattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_sched_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 352,
+			"kconfig": null,
+			"line": 1081,
+			"name": "sched_getattr",
+			"number": 352,
+			"origname": "sched_getattr",
+			"signature": [
+				"pid_t pid",
+				"struct sched_attr *uattr",
+				"unsigned int usize",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_sched_getattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namei.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 353,
+			"kconfig": null,
+			"line": 5257,
+			"name": "renameat2",
+			"number": 353,
+			"origname": "renameat2",
+			"signature": [
+				"int olddfd",
+				"const char *oldname",
+				"int newdfd",
+				"const char *newname",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_renameat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/seccomp.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 354,
+			"kconfig": "SECCOMP",
+			"line": 2101,
+			"name": "seccomp",
+			"number": 354,
+			"origname": "seccomp",
+			"signature": [
+				"unsigned int op",
+				"unsigned int flags",
+				"void *uargs"
+			],
+			"symbol": "__ia32_sys_seccomp"
+		},
+		{
+			"esoteric": false,
+			"file": "drivers/char/random.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 355,
+			"kconfig": null,
+			"line": 1388,
+			"name": "getrandom",
+			"number": 355,
+			"origname": "getrandom",
+			"signature": [
+				"char *ubuf",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_getrandom"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/memfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 356,
+			"kconfig": "MEMFD_CREATE",
+			"line": 458,
+			"name": "memfd_create",
+			"number": 356,
+			"origname": "memfd_create",
+			"signature": [
+				"const char *uname",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_memfd_create"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/bpf/syscall.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 357,
+			"kconfig": "BPF_SYSCALL",
+			"line": 5900,
+			"name": "bpf",
+			"number": 357,
+			"origname": "bpf",
+			"signature": [
+				"int cmd",
+				"union bpf_attr *uattr",
+				"unsigned int size"
+			],
+			"symbol": "__ia32_sys_bpf"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/exec.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 358,
+			"kconfig": null,
+			"line": 2119,
+			"name": "execveat",
+			"number": 358,
+			"origname": "execveat",
+			"signature": [
+				"int fd",
+				"const char *filename",
+				"const char *const *argv",
+				"const char *const *envp",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_execveat"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 359,
+			"kconfig": "NET",
+			"line": 1702,
+			"name": "socket",
+			"number": 359,
+			"origname": "socket",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol"
+			],
+			"symbol": "__ia32_sys_socket"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 360,
+			"kconfig": "NET",
+			"line": 1803,
+			"name": "socketpair",
+			"number": 360,
+			"origname": "socketpair",
+			"signature": [
+				"int family",
+				"int type",
+				"int protocol",
+				"int *usockvec"
+			],
+			"symbol": "__ia32_sys_socketpair"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 361,
+			"kconfig": "NET",
+			"line": 1851,
+			"name": "bind",
+			"number": 361,
+			"origname": "bind",
+			"signature": [
+				"int fd",
+				"struct sockaddr *umyaddr",
+				"int addrlen"
+			],
+			"symbol": "__ia32_sys_bind"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 362,
+			"kconfig": "NET",
+			"line": 2067,
+			"name": "connect",
+			"number": 362,
+			"origname": "connect",
+			"signature": [
+				"int fd",
+				"struct sockaddr *uservaddr",
+				"int addrlen"
+			],
+			"symbol": "__ia32_sys_connect"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 363,
+			"kconfig": "NET",
+			"line": 1889,
+			"name": "listen",
+			"number": 363,
+			"origname": "listen",
+			"signature": [
+				"int fd",
+				"int backlog"
+			],
+			"symbol": "__ia32_sys_listen"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 364,
+			"kconfig": "NET",
+			"line": 2004,
+			"name": "accept4",
+			"number": 364,
+			"origname": "accept4",
+			"signature": [
+				"int fd",
+				"struct sockaddr *upeer_sockaddr",
+				"int *upeer_addrlen",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_accept4"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 365,
+			"kconfig": "NET",
+			"line": 2397,
+			"name": "getsockopt",
+			"number": 365,
+			"origname": "getsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int *optlen"
+			],
+			"symbol": "__ia32_sys_getsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 366,
+			"kconfig": "NET",
+			"line": 2331,
+			"name": "setsockopt",
+			"number": 366,
+			"origname": "setsockopt",
+			"signature": [
+				"int fd",
+				"int level",
+				"int optname",
+				"char *optval",
+				"int optlen"
+			],
+			"symbol": "__ia32_sys_setsockopt"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 367,
+			"kconfig": "NET",
+			"line": 2104,
+			"name": "getsockname",
+			"number": 367,
+			"origname": "getsockname",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__ia32_sys_getsockname"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 368,
+			"kconfig": "NET",
+			"line": 2141,
+			"name": "getpeername",
+			"number": 368,
+			"origname": "getpeername",
+			"signature": [
+				"int fd",
+				"struct sockaddr *usockaddr",
+				"int *usockaddr_len"
+			],
+			"symbol": "__ia32_sys_getpeername"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 369,
+			"kconfig": "NET",
+			"line": 2190,
+			"name": "sendto",
+			"number": 369,
+			"origname": "sendto",
+			"signature": [
+				"int fd",
+				"void *buff",
+				"size_t len",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int addr_len"
+			],
+			"symbol": "__ia32_sys_sendto"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 370,
+			"kconfig": "NET",
+			"line": 2662,
+			"name": "sendmsg",
+			"number": 370,
+			"origname": "sendmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_sendmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 371,
+			"kconfig": "NET",
+			"line": 2248,
+			"name": "recvfrom",
+			"number": 371,
+			"origname": "recvfrom",
+			"signature": [
+				"int fd",
+				"void *ubuf",
+				"size_t size",
+				"unsigned int flags",
+				"struct sockaddr *addr",
+				"int *addr_len"
+			],
+			"symbol": "__ia32_sys_recvfrom"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 372,
+			"kconfig": "NET",
+			"line": 2871,
+			"name": "recvmsg",
+			"number": 372,
+			"origname": "recvmsg",
+			"signature": [
+				"int fd",
+				"struct user_msghdr *msg",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_recvmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 373,
+			"kconfig": "NET",
+			"line": 2432,
+			"name": "shutdown",
+			"number": 373,
+			"origname": "shutdown",
+			"signature": [
+				"int fd",
+				"int how"
+			],
+			"symbol": "__ia32_sys_shutdown"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/userfaultfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 374,
+			"kconfig": "USERFAULTFD",
+			"line": 2155,
+			"name": "userfaultfd",
+			"number": 374,
+			"origname": "userfaultfd",
+			"signature": [
+				"int flags"
+			],
+			"symbol": "__ia32_sys_userfaultfd"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/membarrier.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 375,
+			"kconfig": "MEMBARRIER",
+			"line": 625,
+			"name": "membarrier",
+			"number": 375,
+			"origname": "membarrier",
+			"signature": [
+				"int cmd",
+				"unsigned int flags",
+				"int cpu_id"
+			],
+			"symbol": "__ia32_sys_membarrier"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mlock.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 376,
+			"kconfig": "MMU",
+			"line": 664,
+			"name": "mlock2",
+			"number": 376,
+			"origname": "mlock2",
+			"signature": [
+				"unsigned long start",
+				"size_t len",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_mlock2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 377,
+			"kconfig": null,
+			"line": 1637,
+			"name": "copy_file_range",
+			"number": 377,
+			"origname": "copy_file_range",
+			"signature": [
+				"int fd_in",
+				"loff_t *off_in",
+				"int fd_out",
+				"loff_t *off_out",
+				"size_t len",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_copy_file_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 378,
+			"kconfig": null,
+			"line": 1175,
+			"name": "preadv2",
+			"number": 378,
+			"origname": "preadv2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__ia32_sys_preadv2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/read_write.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 379,
+			"kconfig": null,
+			"line": 1195,
+			"name": "pwritev2",
+			"number": 379,
+			"origname": "pwritev2",
+			"signature": [
+				"unsigned long fd",
+				"const struct iovec *vec",
+				"unsigned long vlen",
+				"unsigned long pos_l",
+				"unsigned long pos_h",
+				"rwf_t flags"
+			],
+			"symbol": "__ia32_sys_pwritev2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/stat.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 383,
+			"kconfig": null,
+			"line": 799,
+			"name": "statx",
+			"number": 383,
+			"origname": "statx",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags",
+				"unsigned int mask",
+				"struct statx *buffer"
+			],
+			"symbol": "__ia32_sys_statx"
+		},
+		{
+			"esoteric": false,
+			"file": "arch/x86/kernel/process_32.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 384,
+			"kconfig": null,
+			"line": 219,
+			"name": "arch_prctl",
+			"number": 384,
+			"origname": "arch_prctl",
+			"signature": [
+				"int option",
+				"unsigned long arg2"
+			],
+			"symbol": "__ia32_sys_arch_prctl"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 385,
+			"kconfig": "AIO",
+			"line": 2310,
+			"name": "io_pgetevents",
+			"number": 385,
+			"origname": "io_pgetevents_time32",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct old_timespec32 *timeout",
+				"const struct __aio_sigset *usig"
+			],
+			"symbol": "__ia32_sys_io_pgetevents_time32"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/rseq.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 386,
+			"kconfig": "RSEQ",
+			"line": 452,
+			"name": "rseq",
+			"number": 386,
+			"origname": "rseq",
+			"signature": [
+				"struct rseq *rseq",
+				"u32 rseq_len",
+				"int flags",
+				"u32 sig"
+			],
+			"symbol": "__ia32_sys_rseq"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 393,
+			"kconfig": "SYSVIPC",
+			"line": 624,
+			"name": "semget",
+			"number": 393,
+			"origname": "semget",
+			"signature": [
+				"key_t key",
+				"int nsems",
+				"int semflg"
+			],
+			"symbol": "__ia32_sys_semget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 394,
+			"kconfig": "SYSVIPC",
+			"line": 1705,
+			"name": "semctl",
+			"number": 394,
+			"origname": "semctl",
+			"signature": [
+				"int semid",
+				"int semnum",
+				"int cmd",
+				"unsigned long arg"
+			],
+			"symbol": "__ia32_sys_semctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 395,
+			"kconfig": "SYSVIPC",
+			"line": 842,
+			"name": "shmget",
+			"number": 395,
+			"origname": "shmget",
+			"signature": [
+				"key_t key",
+				"size_t size",
+				"int shmflg"
+			],
+			"symbol": "__ia32_sys_shmget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 396,
+			"kconfig": "SYSVIPC",
+			"line": 1291,
+			"name": "shmctl",
+			"number": 396,
+			"origname": "shmctl",
+			"signature": [
+				"int shmid",
+				"int cmd",
+				"struct shmid_ds *buf"
+			],
+			"symbol": "__ia32_sys_shmctl"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 397,
+			"kconfig": "SYSVIPC",
+			"line": 1688,
+			"name": "shmat",
+			"number": 397,
+			"origname": "shmat",
+			"signature": [
+				"int shmid",
+				"char *shmaddr",
+				"int shmflg"
+			],
+			"symbol": "__ia32_sys_shmat"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/shm.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 398,
+			"kconfig": "SYSVIPC",
+			"line": 1829,
+			"name": "shmdt",
+			"number": 398,
+			"origname": "shmdt",
+			"signature": [
+				"char *shmaddr"
+			],
+			"symbol": "__ia32_sys_shmdt"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 399,
+			"kconfig": "SYSVIPC",
+			"line": 315,
+			"name": "msgget",
+			"number": 399,
+			"origname": "msgget",
+			"signature": [
+				"key_t key",
+				"int msgflg"
+			],
+			"symbol": "__ia32_sys_msgget"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 400,
+			"kconfig": "SYSVIPC",
+			"line": 971,
+			"name": "msgsnd",
+			"number": 400,
+			"origname": "msgsnd",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"int msgflg"
+			],
+			"symbol": "__ia32_sys_msgsnd"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 401,
+			"kconfig": "SYSVIPC",
+			"line": 1270,
+			"name": "msgrcv",
+			"number": 401,
+			"origname": "msgrcv",
+			"signature": [
+				"int msqid",
+				"struct msgbuf *msgp",
+				"size_t msgsz",
+				"long msgtyp",
+				"int msgflg"
+			],
+			"symbol": "__ia32_sys_msgrcv"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/msg.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 402,
+			"kconfig": "SYSVIPC",
+			"line": 640,
+			"name": "msgctl",
+			"number": 402,
+			"origname": "msgctl",
+			"signature": [
+				"int msqid",
+				"int cmd",
+				"struct msqid_ds *buf"
+			],
+			"symbol": "__ia32_sys_msgctl"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 403,
+			"kconfig": null,
+			"line": 1138,
+			"name": "clock_gettime",
+			"number": 403,
+			"origname": "clock_gettime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__ia32_sys_clock_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 404,
+			"kconfig": null,
+			"line": 1119,
+			"name": "clock_settime",
+			"number": 404,
+			"origname": "clock_settime",
+			"signature": [
+				"const clockid_t which_clock",
+				"const struct __kernel_timespec *tp"
+			],
+			"symbol": "__ia32_sys_clock_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 405,
+			"kconfig": null,
+			"line": 1168,
+			"name": "clock_adjtime",
+			"number": 405,
+			"origname": "clock_adjtime",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timex *utx"
+			],
+			"symbol": "__ia32_sys_clock_adjtime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 406,
+			"kconfig": null,
+			"line": 1258,
+			"name": "clock_getres",
+			"number": 406,
+			"origname": "clock_getres",
+			"signature": [
+				"const clockid_t which_clock",
+				"struct __kernel_timespec *tp"
+			],
+			"symbol": "__ia32_sys_clock_getres"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 407,
+			"kconfig": null,
+			"line": 1379,
+			"name": "clock_nanosleep",
+			"number": 407,
+			"origname": "clock_nanosleep",
+			"signature": [
+				"const clockid_t which_clock",
+				"int flags",
+				"const struct __kernel_timespec *rqtp",
+				"struct __kernel_timespec *rmtp"
+			],
+			"symbol": "__ia32_sys_clock_nanosleep"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 408,
+			"kconfig": "POSIX_TIMERS",
+			"line": 676,
+			"name": "timer_gettime",
+			"number": 408,
+			"origname": "timer_gettime",
+			"signature": [
+				"timer_t timer_id",
+				"struct __kernel_itimerspec *setting"
+			],
+			"symbol": "__ia32_sys_timer_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/time/posix-timers.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 409,
+			"kconfig": "POSIX_TIMERS",
+			"line": 914,
+			"name": "timer_settime",
+			"number": 409,
+			"origname": "timer_settime",
+			"signature": [
+				"timer_t timer_id",
+				"int flags",
+				"const struct __kernel_itimerspec *new_setting",
+				"struct __kernel_itimerspec *old_setting"
+			],
+			"symbol": "__ia32_sys_timer_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 410,
+			"kconfig": null,
+			"line": 578,
+			"name": "timerfd_gettime",
+			"number": 410,
+			"origname": "timerfd_gettime",
+			"signature": [
+				"int ufd",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__ia32_sys_timerfd_gettime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/timerfd.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 411,
+			"kconfig": null,
+			"line": 560,
+			"name": "timerfd_settime",
+			"number": 411,
+			"origname": "timerfd_settime",
+			"signature": [
+				"int ufd",
+				"int flags",
+				"const struct __kernel_itimerspec *utmr",
+				"struct __kernel_itimerspec *otmr"
+			],
+			"symbol": "__ia32_sys_timerfd_settime"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/utimes.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 412,
+			"kconfig": null,
+			"line": 143,
+			"name": "utimensat",
+			"number": 412,
+			"origname": "utimensat",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct __kernel_timespec *utimes",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_utimensat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 413,
+			"kconfig": null,
+			"line": 793,
+			"name": "pselect6",
+			"number": 413,
+			"origname": "pselect6",
+			"signature": [
+				"int n",
+				"fd_set *inp",
+				"fd_set *outp",
+				"fd_set *exp",
+				"struct __kernel_timespec *tsp",
+				"void *sig"
+			],
+			"symbol": "__ia32_sys_pselect6"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/select.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 414,
+			"kconfig": null,
+			"line": 1095,
+			"name": "ppoll",
+			"number": 414,
+			"origname": "ppoll",
+			"signature": [
+				"struct pollfd *ufds",
+				"unsigned int nfds",
+				"struct __kernel_timespec *tsp",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_ppoll"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/aio.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 416,
+			"kconfig": "AIO",
+			"line": 2275,
+			"name": "io_pgetevents",
+			"number": 416,
+			"origname": "io_pgetevents",
+			"signature": [
+				"aio_context_t ctx_id",
+				"long min_nr",
+				"long nr",
+				"struct io_event *events",
+				"struct __kernel_timespec *timeout",
+				"const struct __aio_sigset *usig"
+			],
+			"symbol": "__ia32_sys_io_pgetevents"
+		},
+		{
+			"esoteric": false,
+			"file": "net/socket.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 417,
+			"kconfig": "NET",
+			"line": 3020,
+			"name": "recvmmsg",
+			"number": 417,
+			"origname": "recvmmsg",
+			"signature": [
+				"int fd",
+				"struct mmsghdr *mmsg",
+				"unsigned int vlen",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout"
+			],
+			"symbol": "__ia32_sys_recvmmsg"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 418,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1258,
+			"name": "mq_timedsend",
+			"number": 418,
+			"origname": "mq_timedsend",
+			"signature": [
+				"mqd_t mqdes",
+				"const char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__ia32_sys_mq_timedsend"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/mqueue.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 419,
+			"kconfig": "POSIX_MQUEUE",
+			"line": 1272,
+			"name": "mq_timedreceive",
+			"number": 419,
+			"origname": "mq_timedreceive",
+			"signature": [
+				"mqd_t mqdes",
+				"char *u_msg_ptr",
+				"size_t msg_len",
+				"unsigned int *u_msg_prio",
+				"const struct __kernel_timespec *u_abs_timeout"
+			],
+			"symbol": "__ia32_sys_mq_timedreceive"
+		},
+		{
+			"esoteric": false,
+			"file": "ipc/sem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 420,
+			"kconfig": "SYSVIPC",
+			"line": 2268,
+			"name": "semtimedop",
+			"number": 420,
+			"origname": "semtimedop",
+			"signature": [
+				"int semid",
+				"struct sembuf *tsops",
+				"unsigned int nsops",
+				"const struct __kernel_timespec *timeout"
+			],
+			"symbol": "__ia32_sys_semtimedop"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 421,
+			"kconfig": null,
+			"line": 3806,
+			"name": "rt_sigtimedwait",
+			"number": 421,
+			"origname": "rt_sigtimedwait",
+			"signature": [
+				"const sigset_t *uthese",
+				"siginfo_t *uinfo",
+				"const struct __kernel_timespec *uts",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_rt_sigtimedwait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 422,
+			"kconfig": "FUTEX",
+			"line": 160,
+			"name": "futex",
+			"number": 422,
+			"origname": "futex",
+			"signature": [
+				"u32 *uaddr",
+				"int op",
+				"u32 val",
+				"const struct __kernel_timespec *utime",
+				"u32 *uaddr2",
+				"u32 val3"
+			],
+			"symbol": "__ia32_sys_futex"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/sched/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 423,
+			"kconfig": null,
+			"line": 1571,
+			"name": "sched_rr_get_interval",
+			"number": 423,
+			"origname": "sched_rr_get_interval",
+			"signature": [
+				"pid_t pid",
+				"struct __kernel_timespec *interval"
+			],
+			"symbol": "__ia32_sys_sched_rr_get_interval"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/signal.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 424,
+			"kconfig": null,
+			"line": 4026,
+			"name": "pidfd_send_signal",
+			"number": 424,
+			"origname": "pidfd_send_signal",
+			"signature": [
+				"int pidfd",
+				"int sig",
+				"siginfo_t *info",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_pidfd_send_signal"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 425,
+			"kconfig": "IO_URING",
+			"line": 3814,
+			"name": "io_uring_setup",
+			"number": 425,
+			"origname": "io_uring_setup",
+			"signature": [
+				"u32 entries",
+				"struct io_uring_params *params"
+			],
+			"symbol": "__ia32_sys_io_uring_setup"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/io_uring.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 426,
+			"kconfig": "IO_URING",
+			"line": 3307,
+			"name": "io_uring_enter",
+			"number": 426,
+			"origname": "io_uring_enter",
+			"signature": [
+				"unsigned int fd",
+				"u32 to_submit",
+				"u32 min_complete",
+				"u32 flags",
+				"const void *argp",
+				"size_t argsz"
+			],
+			"symbol": "__ia32_sys_io_uring_enter"
+		},
+		{
+			"esoteric": false,
+			"file": "io_uring/register.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 427,
+			"kconfig": "IO_URING",
+			"line": 896,
+			"name": "io_uring_register",
+			"number": 427,
+			"origname": "io_uring_register",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int opcode",
+				"void *arg",
+				"unsigned int nr_args"
+			],
+			"symbol": "__ia32_sys_io_uring_register"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 428,
+			"kconfig": null,
+			"line": 2892,
+			"name": "open_tree",
+			"number": 428,
+			"origname": "open_tree",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"unsigned flags"
+			],
+			"symbol": "__ia32_sys_open_tree"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 429,
+			"kconfig": null,
+			"line": 4280,
+			"name": "move_mount",
+			"number": 429,
+			"origname": "move_mount",
+			"signature": [
+				"int from_dfd",
+				"const char *from_pathname",
+				"int to_dfd",
+				"const char *to_pathname",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_move_mount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 430,
+			"kconfig": null,
+			"line": 114,
+			"name": "fsopen",
+			"number": 430,
+			"origname": "fsopen",
+			"signature": [
+				"const char *_fs_name",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_fsopen"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 431,
+			"kconfig": null,
+			"line": 344,
+			"name": "fsconfig",
+			"number": 431,
+			"origname": "fsconfig",
+			"signature": [
+				"int fd",
+				"unsigned int cmd",
+				"const char *_key",
+				"const void *_value",
+				"int aux"
+			],
+			"symbol": "__ia32_sys_fsconfig"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 432,
+			"kconfig": null,
+			"line": 4156,
+			"name": "fsmount",
+			"number": 432,
+			"origname": "fsmount",
+			"signature": [
+				"int fs_fd",
+				"unsigned int flags",
+				"unsigned int attr_flags"
+			],
+			"symbol": "__ia32_sys_fsmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/fsopen.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 433,
+			"kconfig": null,
+			"line": 157,
+			"name": "fspick",
+			"number": 433,
+			"origname": "fspick",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_fspick"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 434,
+			"kconfig": null,
+			"line": 626,
+			"name": "pidfd_open",
+			"number": 434,
+			"origname": "pidfd_open",
+			"signature": [
+				"pid_t pid",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_pidfd_open"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/fork.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 435,
+			"kconfig": null,
+			"line": 3098,
+			"name": "clone3",
+			"number": 435,
+			"origname": "clone3",
+			"signature": [
+				"struct clone_args *uargs",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_clone3"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/file.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 436,
+			"kconfig": null,
+			"line": 769,
+			"name": "close_range",
+			"number": 436,
+			"origname": "close_range",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int max_fd",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_close_range"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 437,
+			"kconfig": null,
+			"line": 1462,
+			"name": "openat2",
+			"number": 437,
+			"origname": "openat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"struct open_how *how",
+				"size_t usize"
+			],
+			"symbol": "__ia32_sys_openat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/pid.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 438,
+			"kconfig": null,
+			"line": 854,
+			"name": "pidfd_getfd",
+			"number": 438,
+			"origname": "pidfd_getfd",
+			"signature": [
+				"int pidfd",
+				"int fd",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_pidfd_getfd"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 439,
+			"kconfig": null,
+			"line": 540,
+			"name": "faccessat2",
+			"number": 439,
+			"origname": "faccessat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"int mode",
+				"int flags"
+			],
+			"symbol": "__ia32_sys_faccessat2"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/madvise.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 440,
+			"kconfig": "ADVISE_SYSCALLS",
+			"line": 1756,
+			"name": "process_madvise",
+			"number": 440,
+			"origname": "process_madvise",
+			"signature": [
+				"int pidfd",
+				"const struct iovec *vec",
+				"size_t vlen",
+				"int behavior",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_process_madvise"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/eventpoll.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 441,
+			"kconfig": "EPOLL",
+			"line": 2532,
+			"name": "epoll_pwait2",
+			"number": 441,
+			"origname": "epoll_pwait2",
+			"signature": [
+				"int epfd",
+				"struct epoll_event *events",
+				"int maxevents",
+				"const struct __kernel_timespec *timeout",
+				"const sigset_t *sigmask",
+				"size_t sigsetsize"
+			],
+			"symbol": "__ia32_sys_epoll_pwait2"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 442,
+			"kconfig": null,
+			"line": 4847,
+			"name": "mount_setattr",
+			"number": 442,
+			"origname": "mount_setattr",
+			"signature": [
+				"int dfd",
+				"const char *path",
+				"unsigned int flags",
+				"struct mount_attr *uattr",
+				"size_t usize"
+			],
+			"symbol": "__ia32_sys_mount_setattr"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/quota/quota.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 443,
+			"kconfig": "QUOTACTL",
+			"line": 973,
+			"name": "quotactl_fd",
+			"number": 443,
+			"origname": "quotactl_fd",
+			"signature": [
+				"unsigned int fd",
+				"unsigned int cmd",
+				"qid_t id",
+				"void *addr"
+			],
+			"symbol": "__ia32_sys_quotactl_fd"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 444,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 180,
+			"name": "landlock_create_ruleset",
+			"number": 444,
+			"origname": "landlock_create_ruleset",
+			"signature": [
+				"const struct landlock_ruleset_attr *const attr",
+				"const size_t size",
+				"const __u32 flags"
+			],
+			"symbol": "__ia32_sys_landlock_create_ruleset"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 445,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 398,
+			"name": "landlock_add_rule",
+			"number": 445,
+			"origname": "landlock_add_rule",
+			"signature": [
+				"const int ruleset_fd",
+				"const enum landlock_rule_type rule_type",
+				"const void *const rule_attr",
+				"const __u32 flags"
+			],
+			"symbol": "__ia32_sys_landlock_add_rule"
+		},
+		{
+			"esoteric": false,
+			"file": "security/landlock/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 446,
+			"kconfig": "SECURITY_LANDLOCK",
+			"line": 451,
+			"name": "landlock_restrict_self",
+			"number": 446,
+			"origname": "landlock_restrict_self",
+			"signature": [
+				"const int ruleset_fd",
+				"const __u32 flags"
+			],
+			"symbol": "__ia32_sys_landlock_restrict_self"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/secretmem.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 447,
+			"kconfig": "SECRETMEM",
+			"line": 232,
+			"name": "memfd_secret",
+			"number": 447,
+			"origname": "memfd_secret",
+			"signature": [
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_memfd_secret"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/oom_kill.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 448,
+			"kconfig": "MMU",
+			"line": 1204,
+			"name": "process_mrelease",
+			"number": 448,
+			"origname": "process_mrelease",
+			"signature": [
+				"int pidfd",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_process_mrelease"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 449,
+			"kconfig": "FUTEX",
+			"line": 290,
+			"name": "futex_waitv",
+			"number": 449,
+			"origname": "futex_waitv",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int nr_futexes",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__ia32_sys_futex_waitv"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/mempolicy.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 450,
+			"kconfig": "NUMA",
+			"line": 1540,
+			"name": "set_mempolicy_home_node",
+			"number": 450,
+			"origname": "set_mempolicy_home_node",
+			"signature": [
+				"unsigned long start",
+				"unsigned long len",
+				"unsigned long home_node",
+				"unsigned long flags"
+			],
+			"symbol": "__ia32_sys_set_mempolicy_home_node"
+		},
+		{
+			"esoteric": false,
+			"file": "mm/filemap.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 451,
+			"kconfig": "CACHESTAT_SYSCALL",
+			"line": 4498,
+			"name": "cachestat",
+			"number": 451,
+			"origname": "cachestat",
+			"signature": [
+				"unsigned int fd",
+				"struct cachestat_range *cstat_range",
+				"struct cachestat *cstat",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_cachestat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/open.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 452,
+			"kconfig": null,
+			"line": 700,
+			"name": "fchmodat2",
+			"number": 452,
+			"origname": "fchmodat2",
+			"signature": [
+				"int dfd",
+				"const char *filename",
+				"umode_t mode",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_fchmodat2"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 454,
+			"kconfig": "FUTEX",
+			"line": 338,
+			"name": "futex_wake",
+			"number": 454,
+			"origname": "futex_wake",
+			"signature": [
+				"void *uaddr",
+				"unsigned long mask",
+				"int nr",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_futex_wake"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 455,
+			"kconfig": "FUTEX",
+			"line": 370,
+			"name": "futex_wait",
+			"number": 455,
+			"origname": "futex_wait",
+			"signature": [
+				"void *uaddr",
+				"unsigned long val",
+				"unsigned long mask",
+				"unsigned int flags",
+				"struct __kernel_timespec *timeout",
+				"clockid_t clockid"
+			],
+			"symbol": "__ia32_sys_futex_wait"
+		},
+		{
+			"esoteric": false,
+			"file": "kernel/futex/syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 456,
+			"kconfig": "FUTEX",
+			"line": 414,
+			"name": "futex_requeue",
+			"number": 456,
+			"origname": "futex_requeue",
+			"signature": [
+				"struct futex_waitv *waiters",
+				"unsigned int flags",
+				"int nr_wake",
+				"int nr_requeue"
+			],
+			"symbol": "__ia32_sys_futex_requeue"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 457,
+			"kconfig": null,
+			"line": 5508,
+			"name": "statmount",
+			"number": 457,
+			"origname": "statmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"struct statmount *buf",
+				"size_t bufsize",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_statmount"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/namespace.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 458,
+			"kconfig": null,
+			"line": 5615,
+			"name": "listmount",
+			"number": 458,
+			"origname": "listmount",
+			"signature": [
+				"const struct mnt_id_req *req",
+				"u64 *mnt_ids",
+				"size_t nr_mnt_ids",
+				"unsigned int flags"
+			],
+			"symbol": "__ia32_sys_listmount"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 459,
+			"kconfig": "SECURITY",
+			"line": 77,
+			"name": "lsm_get_self_attr",
+			"number": 459,
+			"origname": "lsm_get_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__ia32_sys_lsm_get_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 460,
+			"kconfig": "SECURITY",
+			"line": 55,
+			"name": "lsm_set_self_attr",
+			"number": 460,
+			"origname": "lsm_set_self_attr",
+			"signature": [
+				"unsigned int attr",
+				"struct lsm_ctx *ctx",
+				"u32 size",
+				"u32 flags"
+			],
+			"symbol": "__ia32_sys_lsm_set_self_attr"
+		},
+		{
+			"esoteric": false,
+			"file": "security/lsm_syscalls.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 461,
+			"kconfig": "SECURITY",
+			"line": 96,
+			"name": "lsm_list_modules",
+			"number": 461,
+			"origname": "lsm_list_modules",
+			"signature": [
+				"u64 *ids",
+				"u32 *size",
+				"u32 flags"
+			],
+			"symbol": "__ia32_sys_lsm_list_modules"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 463,
+			"kconfig": null,
+			"line": 719,
+			"name": "setxattrat",
+			"number": 463,
+			"origname": "setxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"const struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__ia32_sys_setxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 464,
+			"kconfig": null,
+			"line": 863,
+			"name": "getxattrat",
+			"number": 464,
+			"origname": "getxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name",
+				"struct xattr_args *uargs",
+				"size_t usize"
+			],
+			"symbol": "__ia32_sys_getxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 465,
+			"kconfig": null,
+			"line": 991,
+			"name": "listxattrat",
+			"number": 465,
+			"origname": "listxattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"char *list",
+				"size_t size"
+			],
+			"symbol": "__ia32_sys_listxattrat"
+		},
+		{
+			"esoteric": false,
+			"file": "fs/xattr.c",
+			"good_location": true,
+			"grepped_location": false,
+			"index": 466,
+			"kconfig": null,
+			"line": 1091,
+			"name": "removexattrat",
+			"number": 466,
+			"origname": "removexattrat",
+			"signature": [
+				"int dfd",
+				"const char *pathname",
+				"unsigned int at_flags",
+				"const char *name"
+			],
+			"symbol": "__ia32_sys_removexattrat"
+		}
+	],
+	"systrack_version": "0.7"
+}

--- a/libdebug/utils/syscall_data/i386.json
+++ b/libdebug/utils/syscall_data/i386.json
@@ -1,7672 +1,3776 @@
 {
-	"kernel": {
-		"abi": {
-			"bits": 32,
-			"calling_convention": {
-				"parameters": [
-					"ebx",
-					"ecx",
-					"edx",
-					"esi",
-					"edi",
-					"ebp"
-				],
-				"syscall_nr": "eax"
-			},
-			"compat": false,
-			"name": "ia32"
-		},
-		"architecture": {
-			"bits": 32,
-			"name": "x86"
-		},
-		"syscall_table_symbol": "sys_call_table",
-		"version": "v6.14",
-		"version_source": "vmlinux"
-	},
-	"syscalls": [
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 0,
-			"kconfig": null,
-			"line": 3177,
-			"name": "restart_syscall",
-			"number": 0,
-			"origname": "restart_syscall",
-			"signature": [],
-			"symbol": "__ia32_sys_restart_syscall"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 1,
-			"kconfig": null,
-			"line": 1052,
-			"name": "exit",
-			"number": 1,
-			"origname": "exit",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__ia32_sys_exit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 2,
-			"kconfig": "MMU",
-			"line": 2897,
-			"name": "fork",
-			"number": 2,
-			"origname": "fork",
-			"signature": [],
-			"symbol": "__ia32_sys_fork"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 3,
-			"kconfig": null,
-			"line": 715,
-			"name": "read",
-			"number": 3,
-			"origname": "read",
-			"signature": [
-				"unsigned int fd",
-				"char *buf",
-				"size_t count"
-			],
-			"symbol": "__ia32_sys_read"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 4,
-			"kconfig": null,
-			"line": 739,
-			"name": "write",
-			"number": 4,
-			"origname": "write",
-			"signature": [
-				"unsigned int fd",
-				"const char *buf",
-				"size_t count"
-			],
-			"symbol": "__ia32_sys_write"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 5,
-			"kconfig": null,
-			"line": 1447,
-			"name": "open",
-			"number": 5,
-			"origname": "open",
-			"signature": [
-				"const char *filename",
-				"int flags",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_open"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 6,
-			"kconfig": null,
-			"line": 1565,
-			"name": "close",
-			"number": 6,
-			"origname": "close",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__ia32_sys_close"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 7,
-			"kconfig": null,
-			"line": 1893,
-			"name": "waitpid",
-			"number": 7,
-			"origname": "waitpid",
-			"signature": [
-				"pid_t pid",
-				"int *stat_addr",
-				"int options"
-			],
-			"symbol": "__ia32_sys_waitpid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 8,
-			"kconfig": null,
-			"line": 1515,
-			"name": "creat",
-			"number": 8,
-			"origname": "creat",
-			"signature": [
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_creat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 9,
-			"kconfig": null,
-			"line": 4897,
-			"name": "link",
-			"number": 9,
-			"origname": "link",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__ia32_sys_link"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 10,
-			"kconfig": null,
-			"line": 4635,
-			"name": "unlink",
-			"number": 10,
-			"origname": "unlink",
-			"signature": [
-				"const char *pathname"
-			],
-			"symbol": "__ia32_sys_unlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 11,
-			"kconfig": null,
-			"line": 2111,
-			"name": "execve",
-			"number": 11,
-			"origname": "execve",
-			"signature": [
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp"
-			],
-			"symbol": "__ia32_sys_execve"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 12,
-			"kconfig": null,
-			"line": 551,
-			"name": "chdir",
-			"number": 12,
-			"origname": "chdir",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__ia32_sys_chdir"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 13,
-			"kconfig": null,
-			"line": 105,
-			"name": "time",
-			"number": 13,
-			"origname": "time32",
-			"signature": [
-				"old_time32_t *tloc"
-			],
-			"symbol": "__ia32_sys_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 14,
-			"kconfig": null,
-			"line": 4272,
-			"name": "mknod",
-			"number": 14,
-			"origname": "mknod",
-			"signature": [
-				"const char *filename",
-				"umode_t mode",
-				"unsigned dev"
-			],
-			"symbol": "__ia32_sys_mknod"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 15,
-			"kconfig": null,
-			"line": 712,
-			"name": "chmod",
-			"number": 15,
-			"origname": "chmod",
-			"signature": [
-				"const char *filename",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_chmod"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 16,
-			"kconfig": "UID16",
-			"line": 28,
-			"name": "lchown16",
-			"number": 16,
-			"origname": "lchown16",
-			"signature": [
-				"const char *filename",
-				"old_uid_t user",
-				"old_gid_t group"
-			],
-			"symbol": "__ia32_sys_lchown16"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 18,
-			"kconfig": null,
-			"line": 417,
-			"name": "stat",
-			"number": 18,
-			"origname": "stat",
-			"signature": [
-				"const char *filename",
-				"struct __old_kernel_stat *statbuf"
-			],
-			"symbol": "__ia32_sys_stat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 19,
-			"kconfig": null,
-			"line": 403,
-			"name": "lseek",
-			"number": 19,
-			"origname": "lseek",
-			"signature": [
-				"unsigned int fd",
-				"off_t offset",
-				"unsigned int whence"
-			],
-			"symbol": "__ia32_sys_lseek"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 20,
-			"kconfig": null,
-			"line": 969,
-			"name": "getpid",
-			"number": 20,
-			"origname": "getpid",
-			"signature": [],
-			"symbol": "__ia32_sys_getpid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 21,
-			"kconfig": null,
-			"line": 4088,
-			"name": "mount",
-			"number": 21,
-			"origname": "mount",
-			"signature": [
-				"char *dev_name",
-				"char *dir_name",
-				"char *type",
-				"unsigned long flags",
-				"void *data"
-			],
-			"symbol": "__ia32_sys_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 22,
-			"kconfig": null,
-			"line": 2087,
-			"name": "oldumount",
-			"number": 22,
-			"origname": "oldumount",
-			"signature": [
-				"char *name"
-			],
-			"symbol": "__ia32_sys_oldumount"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 23,
-			"kconfig": "UID16",
-			"line": 53,
-			"name": "setuid16",
-			"number": 23,
-			"origname": "setuid16",
-			"signature": [
-				"old_uid_t uid"
-			],
-			"symbol": "__ia32_sys_setuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 24,
-			"kconfig": "UID16",
-			"line": 203,
-			"name": "getuid16",
-			"number": 24,
-			"origname": "getuid16",
-			"signature": [],
-			"symbol": "__ia32_sys_getuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 25,
-			"kconfig": null,
-			"line": 119,
-			"name": "stime",
-			"number": 25,
-			"origname": "stime32",
-			"signature": [
-				"old_time32_t *tptr"
-			],
-			"symbol": "__ia32_sys_stime32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/ptrace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 26,
-			"kconfig": null,
-			"line": 1258,
-			"name": "ptrace",
-			"number": 26,
-			"origname": "ptrace",
-			"signature": [
-				"long request",
-				"long pid",
-				"unsigned long addr",
-				"unsigned long data"
-			],
-			"symbol": "__ia32_sys_ptrace"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 27,
-			"kconfig": null,
-			"line": 326,
-			"name": "alarm",
-			"number": 27,
-			"origname": "alarm",
-			"signature": [
-				"unsigned int seconds"
-			],
-			"symbol": "__ia32_sys_alarm"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 28,
-			"kconfig": null,
-			"line": 443,
-			"name": "fstat",
-			"number": 28,
-			"origname": "fstat",
-			"signature": [
-				"unsigned int fd",
-				"struct __old_kernel_stat *statbuf"
-			],
-			"symbol": "__ia32_sys_fstat"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 29,
-			"kconfig": null,
-			"line": 4799,
-			"name": "pause",
-			"number": 29,
-			"origname": "pause",
-			"signature": [],
-			"symbol": "__ia32_sys_pause"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 30,
-			"kconfig": null,
-			"line": 231,
-			"name": "utime",
-			"number": 30,
-			"origname": "utime32",
-			"signature": [
-				"const char *filename",
-				"struct old_utimbuf32 *t"
-			],
-			"symbol": "__ia32_sys_utime32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 33,
-			"kconfig": null,
-			"line": 546,
-			"name": "access",
-			"number": 33,
-			"origname": "access",
-			"signature": [
-				"const char *filename",
-				"int mode"
-			],
-			"symbol": "__ia32_sys_access"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 34,
-			"kconfig": null,
-			"line": 153,
-			"name": "nice",
-			"number": 34,
-			"origname": "nice",
-			"signature": [
-				"int increment"
-			],
-			"symbol": "__ia32_sys_nice"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 36,
-			"kconfig": null,
-			"line": 111,
-			"name": "sync",
-			"number": 36,
-			"origname": "sync",
-			"signature": [],
-			"symbol": "__ia32_sys_sync"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 37,
-			"kconfig": null,
-			"line": 3951,
-			"name": "kill",
-			"number": 37,
-			"origname": "kill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__ia32_sys_kill"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 38,
-			"kconfig": null,
-			"line": 5271,
-			"name": "rename",
-			"number": 38,
-			"origname": "rename",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__ia32_sys_rename"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 39,
-			"kconfig": null,
-			"line": 4354,
-			"name": "mkdir",
-			"number": 39,
-			"origname": "mkdir",
-			"signature": [
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_mkdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 40,
-			"kconfig": null,
-			"line": 4472,
-			"name": "rmdir",
-			"number": 40,
-			"origname": "rmdir",
-			"signature": [
-				"const char *pathname"
-			],
-			"symbol": "__ia32_sys_rmdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 41,
-			"kconfig": null,
-			"line": 1394,
-			"name": "dup",
-			"number": 41,
-			"origname": "dup",
-			"signature": [
-				"unsigned int fildes"
-			],
-			"symbol": "__ia32_sys_dup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/pipe.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 42,
-			"kconfig": null,
-			"line": 1048,
-			"name": "pipe",
-			"number": 42,
-			"origname": "pipe",
-			"signature": [
-				"int *fildes"
-			],
-			"symbol": "__ia32_sys_pipe"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 43,
-			"kconfig": null,
-			"line": 1034,
-			"name": "times",
-			"number": 43,
-			"origname": "times",
-			"signature": [
-				"struct tms *tbuf"
-			],
-			"symbol": "__ia32_sys_times"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 45,
-			"kconfig": null,
-			"line": 115,
-			"name": "brk",
-			"number": 45,
-			"origname": "brk",
-			"signature": [
-				"unsigned long brk"
-			],
-			"symbol": "__ia32_sys_brk"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 46,
-			"kconfig": "UID16",
-			"line": 43,
-			"name": "setgid16",
-			"number": 46,
-			"origname": "setgid16",
-			"signature": [
-				"old_gid_t gid"
-			],
-			"symbol": "__ia32_sys_setgid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 47,
-			"kconfig": "UID16",
-			"line": 213,
-			"name": "getgid16",
-			"number": 47,
-			"origname": "getgid16",
-			"signature": [],
-			"symbol": "__ia32_sys_getgid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 48,
-			"kconfig": null,
-			"line": 4782,
-			"name": "signal",
-			"number": 48,
-			"origname": "signal",
-			"signature": [
-				"int sig",
-				"__sighandler_t handler"
-			],
-			"symbol": "__ia32_sys_signal"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 49,
-			"kconfig": "UID16",
-			"line": 208,
-			"name": "geteuid16",
-			"number": 49,
-			"origname": "geteuid16",
-			"signature": [],
-			"symbol": "__ia32_sys_geteuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 50,
-			"kconfig": "UID16",
-			"line": 218,
-			"name": "getegid16",
-			"number": 50,
-			"origname": "getegid16",
-			"signature": [],
-			"symbol": "__ia32_sys_getegid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/acct.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 51,
-			"kconfig": "BSD_PROCESS_ACCT",
-			"line": 314,
-			"name": "acct",
-			"number": 51,
-			"origname": "acct",
-			"signature": [
-				"const char *name"
-			],
-			"symbol": "__ia32_sys_acct"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 52,
-			"kconfig": null,
-			"line": 2077,
-			"name": "umount",
-			"number": 52,
-			"origname": "umount",
-			"signature": [
-				"char *name",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_umount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/ioctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 54,
-			"kconfig": null,
-			"line": 892,
-			"name": "ioctl",
-			"number": 54,
-			"origname": "ioctl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__ia32_sys_ioctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fcntl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 55,
-			"kconfig": null,
-			"line": 576,
-			"name": "fcntl",
-			"number": 55,
-			"origname": "fcntl",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__ia32_sys_fcntl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 57,
-			"kconfig": null,
-			"line": 1084,
-			"name": "setpgid",
-			"number": 57,
-			"origname": "setpgid",
-			"signature": [
-				"pid_t pid",
-				"pid_t pgid"
-			],
-			"symbol": "__ia32_sys_setpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 59,
-			"kconfig": null,
-			"line": 1358,
-			"name": "olduname",
-			"number": 59,
-			"origname": "olduname",
-			"signature": [
-				"struct oldold_utsname *name"
-			],
-			"symbol": "__ia32_sys_olduname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 60,
-			"kconfig": null,
-			"line": 1908,
-			"name": "umask",
-			"number": 60,
-			"origname": "umask",
-			"signature": [
-				"int mask"
-			],
-			"symbol": "__ia32_sys_umask"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 61,
-			"kconfig": null,
-			"line": 594,
-			"name": "chroot",
-			"number": 61,
-			"origname": "chroot",
-			"signature": [
-				"const char *filename"
-			],
-			"symbol": "__ia32_sys_chroot"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 62,
-			"kconfig": null,
-			"line": 246,
-			"name": "ustat",
-			"number": 62,
-			"origname": "ustat",
-			"signature": [
-				"unsigned dev",
-				"struct ustat *ubuf"
-			],
-			"symbol": "__ia32_sys_ustat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 63,
-			"kconfig": null,
-			"line": 1375,
-			"name": "dup2",
-			"number": 63,
-			"origname": "dup2",
-			"signature": [
-				"unsigned int oldfd",
-				"unsigned int newfd"
-			],
-			"symbol": "__ia32_sys_dup2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 64,
-			"kconfig": null,
-			"line": 986,
-			"name": "getppid",
-			"number": 64,
-			"origname": "getppid",
-			"signature": [],
-			"symbol": "__ia32_sys_getppid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 65,
-			"kconfig": null,
-			"line": 1190,
-			"name": "getpgrp",
-			"number": 65,
-			"origname": "getpgrp",
-			"signature": [],
-			"symbol": "__ia32_sys_getpgrp"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 66,
-			"kconfig": null,
-			"line": 1269,
-			"name": "setsid",
-			"number": 66,
-			"origname": "setsid",
-			"signature": [],
-			"symbol": "__ia32_sys_setsid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 67,
-			"kconfig": null,
-			"line": 4678,
-			"name": "sigaction",
-			"number": 67,
-			"origname": "sigaction",
-			"signature": [
-				"int sig",
-				"const struct old_sigaction *act",
-				"struct old_sigaction *oact"
-			],
-			"symbol": "__ia32_sys_sigaction"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 68,
-			"kconfig": "SGETMASK_SYSCALL",
-			"line": 4760,
-			"name": "sgetmask",
-			"number": 68,
-			"origname": "sgetmask",
-			"signature": [],
-			"symbol": "__ia32_sys_sgetmask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 69,
-			"kconfig": "SGETMASK_SYSCALL",
-			"line": 4766,
-			"name": "ssetmask",
-			"number": 69,
-			"origname": "ssetmask",
-			"signature": [
-				"int newmask"
-			],
-			"symbol": "__ia32_sys_ssetmask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 70,
-			"kconfig": "UID16",
-			"line": 48,
-			"name": "setreuid16",
-			"number": 70,
-			"origname": "setreuid16",
-			"signature": [
-				"old_uid_t ruid",
-				"old_uid_t euid"
-			],
-			"symbol": "__ia32_sys_setreuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 71,
-			"kconfig": "UID16",
-			"line": 38,
-			"name": "setregid16",
-			"number": 71,
-			"origname": "setregid16",
-			"signature": [
-				"old_gid_t rgid",
-				"old_gid_t egid"
-			],
-			"symbol": "__ia32_sys_setregid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 72,
-			"kconfig": null,
-			"line": 4866,
-			"name": "sigsuspend",
-			"number": 72,
-			"origname": "sigsuspend",
-			"signature": [
-				"int unused1",
-				"int unused2",
-				"old_sigset_t mask"
-			],
-			"symbol": "__ia32_sys_sigsuspend"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 73,
-			"kconfig": null,
-			"line": 4519,
-			"name": "sigpending",
-			"number": 73,
-			"origname": "sigpending",
-			"signature": [
-				"old_sigset_t *uset"
-			],
-			"symbol": "__ia32_sys_sigpending"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 74,
-			"kconfig": null,
-			"line": 1385,
-			"name": "sethostname",
-			"number": 74,
-			"origname": "sethostname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__ia32_sys_sethostname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 75,
-			"kconfig": null,
-			"line": 1742,
-			"name": "setrlimit",
-			"number": 75,
-			"origname": "setrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__ia32_sys_setrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 76,
-			"kconfig": null,
-			"line": 1594,
-			"name": "getrlimit",
-			"number": 76,
-			"origname": "old_getrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__ia32_sys_old_getrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 77,
-			"kconfig": null,
-			"line": 1882,
-			"name": "getrusage",
-			"number": 77,
-			"origname": "getrusage",
-			"signature": [
-				"int who",
-				"struct rusage *ru"
-			],
-			"symbol": "__ia32_sys_getrusage"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 78,
-			"kconfig": null,
-			"line": 140,
-			"name": "gettimeofday",
-			"number": 78,
-			"origname": "gettimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__ia32_sys_gettimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 79,
-			"kconfig": null,
-			"line": 199,
-			"name": "settimeofday",
-			"number": 79,
-			"origname": "settimeofday",
-			"signature": [
-				"struct __kernel_old_timeval *tv",
-				"struct timezone *tz"
-			],
-			"symbol": "__ia32_sys_settimeofday"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 80,
-			"kconfig": "UID16",
-			"line": 154,
-			"name": "getgroups16",
-			"number": 80,
-			"origname": "getgroups16",
-			"signature": [
-				"int gidsetsize",
-				"old_gid_t *grouplist"
-			],
-			"symbol": "__ia32_sys_getgroups16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 81,
-			"kconfig": "UID16",
-			"line": 177,
-			"name": "setgroups16",
-			"number": 81,
-			"origname": "setgroups16",
-			"signature": [
-				"int gidsetsize",
-				"old_gid_t *grouplist"
-			],
-			"symbol": "__ia32_sys_setgroups16"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 82,
-			"kconfig": null,
-			"line": 828,
-			"name": "select",
-			"number": 82,
-			"origname": "old_select",
-			"signature": [
-				"struct sel_arg_struct *arg"
-			],
-			"symbol": "__ia32_sys_old_select"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 83,
-			"kconfig": null,
-			"line": 4716,
-			"name": "symlink",
-			"number": 83,
-			"origname": "symlink",
-			"signature": [
-				"const char *oldname",
-				"const char *newname"
-			],
-			"symbol": "__ia32_sys_symlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 84,
-			"kconfig": null,
-			"line": 430,
-			"name": "lstat",
-			"number": 84,
-			"origname": "lstat",
-			"signature": [
-				"const char *filename",
-				"struct __old_kernel_stat *statbuf"
-			],
-			"symbol": "__ia32_sys_lstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 85,
-			"kconfig": null,
-			"line": 598,
-			"name": "readlink",
-			"number": 85,
-			"origname": "readlink",
-			"signature": [
-				"const char *path",
-				"char *buf",
-				"int bufsiz"
-			],
-			"symbol": "__ia32_sys_readlink"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 86,
-			"kconfig": "USELIB",
-			"line": 125,
-			"name": "uselib",
-			"number": 86,
-			"origname": "uselib",
-			"signature": [
-				"const char *library"
-			],
-			"symbol": "__ia32_sys_uselib"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 87,
-			"kconfig": "SWAP",
-			"line": 3266,
-			"name": "swapon",
-			"number": 87,
-			"origname": "swapon",
-			"signature": [
-				"const char *specialfile",
-				"int swap_flags"
-			],
-			"symbol": "__ia32_sys_swapon"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/reboot.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 88,
-			"kconfig": null,
-			"line": 722,
-			"name": "reboot",
-			"number": 88,
-			"origname": "reboot",
-			"signature": [
-				"int magic1",
-				"int magic2",
-				"unsigned int cmd",
-				"void *arg"
-			],
-			"symbol": "__ia32_sys_reboot"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 89,
-			"kconfig": null,
-			"line": 218,
-			"name": "readdir",
-			"number": 89,
-			"origname": "old_readdir",
-			"signature": [
-				"unsigned int fd",
-				"struct old_linux_dirent *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__ia32_sys_old_readdir"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 90,
-			"kconfig": null,
-			"line": 631,
-			"name": "mmap",
-			"number": 90,
-			"origname": "old_mmap",
-			"signature": [
-				"struct mmap_arg_struct *arg"
-			],
-			"symbol": "__ia32_sys_old_mmap"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 91,
-			"kconfig": null,
-			"line": 1081,
-			"name": "munmap",
-			"number": 91,
-			"origname": "munmap",
-			"signature": [
-				"unsigned long addr",
-				"size_t len"
-			],
-			"symbol": "__ia32_sys_munmap"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 92,
-			"kconfig": null,
-			"line": 148,
-			"name": "truncate",
-			"number": 92,
-			"origname": "truncate",
-			"signature": [
-				"const char *path",
-				"long length"
-			],
-			"symbol": "__ia32_sys_truncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 93,
-			"kconfig": null,
-			"line": 210,
-			"name": "ftruncate",
-			"number": 93,
-			"origname": "ftruncate",
-			"signature": [
-				"unsigned int fd",
-				"off_t length"
-			],
-			"symbol": "__ia32_sys_ftruncate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 94,
-			"kconfig": null,
-			"line": 663,
-			"name": "fchmod",
-			"number": 94,
-			"origname": "fchmod",
-			"signature": [
-				"unsigned int fd",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_fchmod"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 95,
-			"kconfig": "UID16",
-			"line": 33,
-			"name": "fchown16",
-			"number": 95,
-			"origname": "fchown16",
-			"signature": [
-				"unsigned int fd",
-				"old_uid_t user",
-				"old_gid_t group"
-			],
-			"symbol": "__ia32_sys_fchown16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 96,
-			"kconfig": null,
-			"line": 299,
-			"name": "getpriority",
-			"number": 96,
-			"origname": "getpriority",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__ia32_sys_getpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 97,
-			"kconfig": null,
-			"line": 229,
-			"name": "setpriority",
-			"number": 97,
-			"origname": "setpriority",
-			"signature": [
-				"int which",
-				"int who",
-				"int niceval"
-			],
-			"symbol": "__ia32_sys_setpriority"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 99,
-			"kconfig": null,
-			"line": 190,
-			"name": "statfs",
-			"number": 99,
-			"origname": "statfs",
-			"signature": [
-				"const char *pathname",
-				"struct statfs *buf"
-			],
-			"symbol": "__ia32_sys_statfs"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 100,
-			"kconfig": null,
-			"line": 211,
-			"name": "fstatfs",
-			"number": 100,
-			"origname": "fstatfs",
-			"signature": [
-				"unsigned int fd",
-				"struct statfs *buf"
-			],
-			"symbol": "__ia32_sys_fstatfs"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ioport.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 101,
-			"kconfig": "X86_IOPL_IOPERM",
-			"line": 152,
-			"name": "ioperm",
-			"number": 101,
-			"origname": "ioperm",
-			"signature": [
-				"unsigned long from",
-				"unsigned long num",
-				"int turn_on"
-			],
-			"symbol": "__ia32_sys_ioperm"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 102,
-			"kconfig": "NET",
-			"line": 3062,
-			"name": "socketcall",
-			"number": 102,
-			"origname": "socketcall",
-			"signature": [
-				"int call",
-				"unsigned long *args"
-			],
-			"symbol": "__ia32_sys_socketcall"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/printk/printk.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 103,
-			"kconfig": null,
-			"line": 1875,
-			"name": "syslog",
-			"number": 103,
-			"origname": "syslog",
-			"signature": [
-				"int type",
-				"char *buf",
-				"int len"
-			],
-			"symbol": "__ia32_sys_syslog"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 104,
-			"kconfig": null,
-			"line": 352,
-			"name": "setitimer",
-			"number": 104,
-			"origname": "setitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value",
-				"struct __kernel_old_itimerval *ovalue"
-			],
-			"symbol": "__ia32_sys_setitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/itimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 105,
-			"kconfig": null,
-			"line": 113,
-			"name": "getitimer",
-			"number": 105,
-			"origname": "getitimer",
-			"signature": [
-				"int which",
-				"struct __kernel_old_itimerval *value"
-			],
-			"symbol": "__ia32_sys_getitimer"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 106,
-			"kconfig": null,
-			"line": 501,
-			"name": "newstat",
-			"number": 106,
-			"origname": "newstat",
-			"signature": [
-				"const char *filename",
-				"struct stat *statbuf"
-			],
-			"symbol": "__ia32_sys_newstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 107,
-			"kconfig": null,
-			"line": 512,
-			"name": "newlstat",
-			"number": 107,
-			"origname": "newlstat",
-			"signature": [
-				"const char *filename",
-				"struct stat *statbuf"
-			],
-			"symbol": "__ia32_sys_newlstat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 108,
-			"kconfig": null,
-			"line": 539,
-			"name": "newfstat",
-			"number": 108,
-			"origname": "newfstat",
-			"signature": [
-				"unsigned int fd",
-				"struct stat *statbuf"
-			],
-			"symbol": "__ia32_sys_newfstat"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 109,
-			"kconfig": null,
-			"line": 1338,
-			"name": "uname",
-			"number": 109,
-			"origname": "uname",
-			"signature": [
-				"struct old_utsname *name"
-			],
-			"symbol": "__ia32_sys_uname"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ioport.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 110,
-			"kconfig": "X86_IOPL_IOPERM",
-			"line": 173,
-			"name": "iopl",
-			"number": 110,
-			"origname": "iopl",
-			"signature": [
-				"unsigned int level"
-			],
-			"symbol": "__ia32_sys_iopl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 111,
-			"kconfig": null,
-			"line": 1596,
-			"name": "vhangup",
-			"number": 111,
-			"origname": "vhangup",
-			"signature": [],
-			"symbol": "__ia32_sys_vhangup"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/vm86_32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 113,
-			"kconfig": "X86_LEGACY_VM86",
-			"line": 170,
-			"name": "vm86old",
-			"number": 113,
-			"origname": "vm86old",
-			"signature": [
-				"struct vm86_struct *user_vm86"
-			],
-			"symbol": "__ia32_sys_vm86old"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 114,
-			"kconfig": null,
-			"line": 1874,
-			"name": "wait4",
-			"number": 114,
-			"origname": "wait4",
-			"signature": [
-				"pid_t upid",
-				"int *stat_addr",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__ia32_sys_wait4"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/swapfile.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 115,
-			"kconfig": "SWAP",
-			"line": 2652,
-			"name": "swapoff",
-			"number": 115,
-			"origname": "swapoff",
-			"signature": [
-				"const char *specialfile"
-			],
-			"symbol": "__ia32_sys_swapoff"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 116,
-			"kconfig": null,
-			"line": 2902,
-			"name": "sysinfo",
-			"number": 116,
-			"origname": "sysinfo",
-			"signature": [
-				"struct sysinfo *info"
-			],
-			"symbol": "__ia32_sys_sysinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/syscall.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 117,
-			"kconfig": "SYSVIPC",
-			"line": 110,
-			"name": "ipc",
-			"number": 117,
-			"origname": "ipc",
-			"signature": [
-				"unsigned int call",
-				"int first",
-				"unsigned long second",
-				"unsigned long third",
-				"void *ptr",
-				"long fifth"
-			],
-			"symbol": "__ia32_sys_ipc"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 118,
-			"kconfig": null,
-			"line": 215,
-			"name": "fsync",
-			"number": 118,
-			"origname": "fsync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__ia32_sys_fsync"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/signal_32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 119,
-			"kconfig": null,
-			"line": 125,
-			"name": "sigreturn",
-			"number": 119,
-			"origname": "sigreturn",
-			"signature": [],
-			"symbol": "__ia32_sys_sigreturn"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 120,
-			"kconfig": null,
-			"line": 2926,
-			"name": "clone",
-			"number": 120,
-			"origname": "clone",
-			"signature": [
-				"unsigned long clone_flags",
-				"unsigned long newsp",
-				"int *parent_tidptr",
-				"unsigned long tls",
-				"int *child_tidptr"
-			],
-			"symbol": "__ia32_sys_clone"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 121,
-			"kconfig": null,
-			"line": 1439,
-			"name": "setdomainname",
-			"number": 121,
-			"origname": "setdomainname",
-			"signature": [
-				"char *name",
-				"int len"
-			],
-			"symbol": "__ia32_sys_setdomainname"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 122,
-			"kconfig": null,
-			"line": 1317,
-			"name": "newuname",
-			"number": 122,
-			"origname": "newuname",
-			"signature": [
-				"struct new_utsname *name"
-			],
-			"symbol": "__ia32_sys_newuname"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/ldt.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 123,
-			"kconfig": "MODIFY_LDT_SYSCALL",
-			"line": 667,
-			"name": "modify_ldt",
-			"number": 123,
-			"origname": "modify_ldt",
-			"signature": [
-				"int func",
-				"void *ptr",
-				"unsigned long bytecount"
-			],
-			"symbol": "__ia32_sys_modify_ldt"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/time.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 124,
-			"kconfig": null,
-			"line": 349,
-			"name": "adjtimex",
-			"number": 124,
-			"origname": "adjtimex_time32",
-			"signature": [
-				"struct old_timex32 *utp"
-			],
-			"symbol": "__ia32_sys_adjtimex_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mprotect.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 125,
-			"kconfig": "MMU",
-			"line": 858,
-			"name": "mprotect",
-			"number": 125,
-			"origname": "mprotect",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned long prot"
-			],
-			"symbol": "__ia32_sys_mprotect"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 126,
-			"kconfig": null,
-			"line": 4558,
-			"name": "sigprocmask",
-			"number": 126,
-			"origname": "sigprocmask",
-			"signature": [
-				"int how",
-				"old_sigset_t *nset",
-				"old_sigset_t *oset"
-			],
-			"symbol": "__ia32_sys_sigprocmask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 128,
-			"kconfig": "MODULES",
-			"line": 3515,
-			"name": "init_module",
-			"number": 128,
-			"origname": "init_module",
-			"signature": [
-				"void *umod",
-				"unsigned long len",
-				"const char *uargs"
-			],
-			"symbol": "__ia32_sys_init_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 129,
-			"kconfig": "MODULE_UNLOAD",
-			"line": 732,
-			"name": "delete_module",
-			"number": 129,
-			"origname": "delete_module",
-			"signature": [
-				"const char *name_user",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_delete_module"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 131,
-			"kconfig": "QUOTACTL",
-			"line": 917,
-			"name": "quotactl",
-			"number": 131,
-			"origname": "quotactl",
-			"signature": [
-				"unsigned int cmd",
-				"const char *special",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__ia32_sys_quotactl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 132,
-			"kconfig": null,
-			"line": 1183,
-			"name": "getpgid",
-			"number": 132,
-			"origname": "getpgid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__ia32_sys_getpgid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 133,
-			"kconfig": null,
-			"line": 577,
-			"name": "fchdir",
-			"number": 133,
-			"origname": "fchdir",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__ia32_sys_fchdir"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/filesystems.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 135,
-			"kconfig": "SYSFS_SYSCALL",
-			"line": 191,
-			"name": "sysfs",
-			"number": 135,
-			"origname": "sysfs",
-			"signature": [
-				"int option",
-				"unsigned long arg1",
-				"unsigned long arg2"
-			],
-			"symbol": "__ia32_sys_sysfs"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exec_domain.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 136,
-			"kconfig": null,
-			"line": 38,
-			"name": "personality",
-			"number": 136,
-			"origname": "personality",
-			"signature": [
-				"unsigned int personality"
-			],
-			"symbol": "__ia32_sys_personality"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 138,
-			"kconfig": "UID16",
-			"line": 104,
-			"name": "setfsuid16",
-			"number": 138,
-			"origname": "setfsuid16",
-			"signature": [
-				"old_uid_t uid"
-			],
-			"symbol": "__ia32_sys_setfsuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 139,
-			"kconfig": "UID16",
-			"line": 109,
-			"name": "setfsgid16",
-			"number": 139,
-			"origname": "setfsgid16",
-			"signature": [
-				"old_gid_t gid"
-			],
-			"symbol": "__ia32_sys_setfsgid16"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 140,
-			"kconfig": null,
-			"line": 417,
-			"name": "llseek",
-			"number": 140,
-			"origname": "llseek",
-			"signature": [
-				"unsigned int fd",
-				"unsigned long offset_high",
-				"unsigned long offset_low",
-				"loff_t *result",
-				"unsigned int whence"
-			],
-			"symbol": "__ia32_sys_llseek"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 141,
-			"kconfig": null,
-			"line": 308,
-			"name": "getdents",
-			"number": 141,
-			"origname": "getdents",
-			"signature": [
-				"unsigned int fd",
-				"struct linux_dirent *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__ia32_sys_getdents"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 142,
-			"kconfig": null,
-			"line": 722,
-			"name": "select",
-			"number": 142,
-			"origname": "select",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct __kernel_old_timeval *tvp"
-			],
-			"symbol": "__ia32_sys_select"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/locks.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 143,
-			"kconfig": null,
-			"line": 2135,
-			"name": "flock",
-			"number": 143,
-			"origname": "flock",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd"
-			],
-			"symbol": "__ia32_sys_flock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/msync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 144,
-			"kconfig": "MMU",
-			"line": 32,
-			"name": "msync",
-			"number": 144,
-			"origname": "msync",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_msync"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 145,
-			"kconfig": null,
-			"line": 1155,
-			"name": "readv",
-			"number": 145,
-			"origname": "readv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__ia32_sys_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 146,
-			"kconfig": null,
-			"line": 1161,
-			"name": "writev",
-			"number": 146,
-			"origname": "writev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen"
-			],
-			"symbol": "__ia32_sys_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 147,
-			"kconfig": null,
-			"line": 1197,
-			"name": "getsid",
-			"number": 147,
-			"origname": "getsid",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__ia32_sys_getsid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 148,
-			"kconfig": null,
-			"line": 220,
-			"name": "fdatasync",
-			"number": 148,
-			"origname": "fdatasync",
-			"signature": [
-				"unsigned int fd"
-			],
-			"symbol": "__ia32_sys_fdatasync"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 150,
-			"kconfig": "MMU",
-			"line": 659,
-			"name": "mlock",
-			"number": 150,
-			"origname": "mlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__ia32_sys_mlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 151,
-			"kconfig": "MMU",
-			"line": 677,
-			"name": "munlock",
-			"number": 151,
-			"origname": "munlock",
-			"signature": [
-				"unsigned long start",
-				"size_t len"
-			],
-			"symbol": "__ia32_sys_munlock"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 152,
-			"kconfig": "MMU",
-			"line": 745,
-			"name": "mlockall",
-			"number": 152,
-			"origname": "mlockall",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__ia32_sys_mlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 153,
-			"kconfig": "MMU",
-			"line": 774,
-			"name": "munlockall",
-			"number": 153,
-			"origname": "munlockall",
-			"signature": [],
-			"symbol": "__ia32_sys_munlockall"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 154,
-			"kconfig": null,
-			"line": 970,
-			"name": "sched_setparam",
-			"number": 154,
-			"origname": "sched_setparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__ia32_sys_sched_setparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 155,
-			"kconfig": null,
-			"line": 1046,
-			"name": "sched_getparam",
-			"number": 155,
-			"origname": "sched_getparam",
-			"signature": [
-				"pid_t pid",
-				"struct sched_param *param"
-			],
-			"symbol": "__ia32_sys_sched_getparam"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 156,
-			"kconfig": null,
-			"line": 955,
-			"name": "sched_setscheduler",
-			"number": 156,
-			"origname": "sched_setscheduler",
-			"signature": [
-				"pid_t pid",
-				"int policy",
-				"struct sched_param *param"
-			],
-			"symbol": "__ia32_sys_sched_setscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 157,
-			"kconfig": null,
-			"line": 1016,
-			"name": "sched_getscheduler",
-			"number": 157,
-			"origname": "sched_getscheduler",
-			"signature": [
-				"pid_t pid"
-			],
-			"symbol": "__ia32_sys_sched_getscheduler"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 158,
-			"kconfig": null,
-			"line": 1377,
-			"name": "sched_yield",
-			"number": 158,
-			"origname": "sched_yield",
-			"signature": [],
-			"symbol": "__ia32_sys_sched_yield"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 159,
-			"kconfig": null,
-			"line": 1485,
-			"name": "sched_get_priority_max",
-			"number": 159,
-			"origname": "sched_get_priority_max",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__ia32_sys_sched_get_priority_max"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 160,
-			"kconfig": null,
-			"line": 1513,
-			"name": "sched_get_priority_min",
-			"number": 160,
-			"origname": "sched_get_priority_min",
-			"signature": [
-				"int policy"
-			],
-			"symbol": "__ia32_sys_sched_get_priority_min"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 161,
-			"kconfig": null,
-			"line": 1584,
-			"name": "sched_rr_get_interval",
-			"number": 161,
-			"origname": "sched_rr_get_interval_time32",
-			"signature": [
-				"pid_t pid",
-				"struct old_timespec32 *interval"
-			],
-			"symbol": "__ia32_sys_sched_rr_get_interval_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/hrtimer.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 162,
-			"kconfig": null,
-			"line": 2231,
-			"name": "nanosleep",
-			"number": 162,
-			"origname": "nanosleep_time32",
-			"signature": [
-				"struct old_timespec32 *rqtp",
-				"struct old_timespec32 *rmtp"
-			],
-			"symbol": "__ia32_sys_nanosleep_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mremap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 163,
-			"kconfig": null,
-			"line": 1045,
-			"name": "mremap",
-			"number": 163,
-			"origname": "mremap",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long old_len",
-				"unsigned long new_len",
-				"unsigned long flags",
-				"unsigned long new_addr"
-			],
-			"symbol": "__ia32_sys_mremap"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 164,
-			"kconfig": "UID16",
-			"line": 58,
-			"name": "setresuid16",
-			"number": 164,
-			"origname": "setresuid16",
-			"signature": [
-				"old_uid_t ruid",
-				"old_uid_t euid",
-				"old_uid_t suid"
-			],
-			"symbol": "__ia32_sys_setresuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 165,
-			"kconfig": "UID16",
-			"line": 64,
-			"name": "getresuid16",
-			"number": 165,
-			"origname": "getresuid16",
-			"signature": [
-				"old_uid_t *ruidp",
-				"old_uid_t *euidp",
-				"old_uid_t *suidp"
-			],
-			"symbol": "__ia32_sys_getresuid16"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/vm86_32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 166,
-			"kconfig": "X86_LEGACY_VM86",
-			"line": 176,
-			"name": "vm86",
-			"number": 166,
-			"origname": "vm86",
-			"signature": [
-				"unsigned long cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__ia32_sys_vm86"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 168,
-			"kconfig": null,
-			"line": 1062,
-			"name": "poll",
-			"number": 168,
-			"origname": "poll",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"int timeout_msecs"
-			],
-			"symbol": "__ia32_sys_poll"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 170,
-			"kconfig": "UID16",
-			"line": 81,
-			"name": "setresgid16",
-			"number": 170,
-			"origname": "setresgid16",
-			"signature": [
-				"old_gid_t rgid",
-				"old_gid_t egid",
-				"old_gid_t sgid"
-			],
-			"symbol": "__ia32_sys_setresgid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 171,
-			"kconfig": "UID16",
-			"line": 87,
-			"name": "getresgid16",
-			"number": 171,
-			"origname": "getresgid16",
-			"signature": [
-				"old_gid_t *rgidp",
-				"old_gid_t *egidp",
-				"old_gid_t *sgidp"
-			],
-			"symbol": "__ia32_sys_getresgid16"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 172,
-			"kconfig": null,
-			"line": 2469,
-			"name": "prctl",
-			"number": 172,
-			"origname": "prctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__ia32_sys_prctl"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/signal_32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 173,
-			"kconfig": null,
-			"line": 148,
-			"name": "rt_sigreturn",
-			"number": 173,
-			"origname": "rt_sigreturn",
-			"signature": [],
-			"symbol": "__ia32_sys_rt_sigreturn"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 174,
-			"kconfig": null,
-			"line": 4606,
-			"name": "rt_sigaction",
-			"number": 174,
-			"origname": "rt_sigaction",
-			"signature": [
-				"int sig",
-				"const struct sigaction *act",
-				"struct sigaction *oact",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigaction"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 175,
-			"kconfig": null,
-			"line": 3320,
-			"name": "rt_sigprocmask",
-			"number": 175,
-			"origname": "rt_sigprocmask",
-			"signature": [
-				"int how",
-				"sigset_t *nset",
-				"sigset_t *oset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigprocmask"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 176,
-			"kconfig": null,
-			"line": 3392,
-			"name": "rt_sigpending",
-			"number": 176,
-			"origname": "rt_sigpending",
-			"signature": [
-				"sigset_t *uset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigpending"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 177,
-			"kconfig": null,
-			"line": 3839,
-			"name": "rt_sigtimedwait",
-			"number": 177,
-			"origname": "rt_sigtimedwait_time32",
-			"signature": [
-				"const sigset_t *uthese",
-				"siginfo_t *uinfo",
-				"const struct old_timespec32 *uts",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigtimedwait_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 178,
-			"kconfig": null,
-			"line": 4188,
-			"name": "rt_sigqueueinfo",
-			"number": 178,
-			"origname": "rt_sigqueueinfo",
-			"signature": [
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__ia32_sys_rt_sigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 179,
-			"kconfig": null,
-			"line": 4829,
-			"name": "rt_sigsuspend",
-			"number": 179,
-			"origname": "rt_sigsuspend",
-			"signature": [
-				"sigset_t *unewset",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigsuspend"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 180,
-			"kconfig": null,
-			"line": 68,
-			"name": "pread64",
-			"number": 180,
-			"origname": "ia32_pread64",
-			"signature": [
-				"unsigned int fd",
-				"char *ubuf",
-				"u32 count",
-				"u32 poslo",
-				"u32 poshi"
-			],
-			"symbol": "__ia32_sys_ia32_pread64"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 181,
-			"kconfig": null,
-			"line": 75,
-			"name": "pwrite64",
-			"number": 181,
-			"origname": "ia32_pwrite64",
-			"signature": [
-				"unsigned int fd",
-				"const char *ubuf",
-				"u32 count",
-				"u32 poslo",
-				"u32 poshi"
-			],
-			"symbol": "__ia32_sys_ia32_pwrite64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/uid16.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 182,
-			"kconfig": "UID16",
-			"line": 23,
-			"name": "chown16",
-			"number": 182,
-			"origname": "chown16",
-			"signature": [
-				"const char *filename",
-				"old_uid_t user",
-				"old_gid_t group"
-			],
-			"symbol": "__ia32_sys_chown16"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/d_path.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 183,
-			"kconfig": null,
-			"line": 412,
-			"name": "getcwd",
-			"number": 183,
-			"origname": "getcwd",
-			"signature": [
-				"char *buf",
-				"unsigned long size"
-			],
-			"symbol": "__ia32_sys_getcwd"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 184,
-			"kconfig": "MULTIUSER",
-			"line": 137,
-			"name": "capget",
-			"number": 184,
-			"origname": "capget",
-			"signature": [
-				"cap_user_header_t header",
-				"cap_user_data_t dataptr"
-			],
-			"symbol": "__ia32_sys_capget"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/capability.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 185,
-			"kconfig": "MULTIUSER",
-			"line": 216,
-			"name": "capset",
-			"number": 185,
-			"origname": "capset",
-			"signature": [
-				"cap_user_header_t header",
-				"const cap_user_data_t data"
-			],
-			"symbol": "__ia32_sys_capset"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 186,
-			"kconfig": null,
-			"line": 4423,
-			"name": "sigaltstack",
-			"number": 186,
-			"origname": "sigaltstack",
-			"signature": [
-				"const stack_t *uss",
-				"stack_t *uoss"
-			],
-			"symbol": "__ia32_sys_sigaltstack"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 187,
-			"kconfig": null,
-			"line": 1391,
-			"name": "sendfile",
-			"number": 187,
-			"origname": "sendfile",
-			"signature": [
-				"int out_fd",
-				"int in_fd",
-				"off_t *offset",
-				"size_t count"
-			],
-			"symbol": "__ia32_sys_sendfile"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 190,
-			"kconfig": null,
-			"line": 2913,
-			"name": "vfork",
-			"number": 190,
-			"origname": "vfork",
-			"signature": [],
-			"symbol": "__ia32_sys_vfork"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 191,
-			"kconfig": null,
-			"line": 1529,
-			"name": "getrlimit",
-			"number": 191,
-			"origname": "getrlimit",
-			"signature": [
-				"unsigned int resource",
-				"struct rlimit *rlim"
-			],
-			"symbol": "__ia32_sys_getrlimit"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 192,
-			"kconfig": null,
-			"line": 614,
-			"name": "mmap_pgoff",
-			"number": 192,
-			"origname": "mmap_pgoff",
-			"signature": [
-				"unsigned long addr",
-				"unsigned long len",
-				"unsigned long prot",
-				"unsigned long flags",
-				"unsigned long fd",
-				"unsigned long pgoff"
-			],
-			"symbol": "__ia32_sys_mmap_pgoff"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 193,
-			"kconfig": null,
-			"line": 54,
-			"name": "truncate64",
-			"number": 193,
-			"origname": "ia32_truncate64",
-			"signature": [
-				"const char *filename",
-				"unsigned long offset_low",
-				"unsigned long offset_high"
-			],
-			"symbol": "__ia32_sys_ia32_truncate64"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 194,
-			"kconfig": null,
-			"line": 61,
-			"name": "ftruncate64",
-			"number": 194,
-			"origname": "ia32_ftruncate64",
-			"signature": [
-				"unsigned int fd",
-				"unsigned long offset_low",
-				"unsigned long offset_high"
-			],
-			"symbol": "__ia32_sys_ia32_ftruncate64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 195,
-			"kconfig": null,
-			"line": 647,
-			"name": "stat64",
-			"number": 195,
-			"origname": "stat64",
-			"signature": [
-				"const char *filename",
-				"struct stat64 *statbuf"
-			],
-			"symbol": "__ia32_sys_stat64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 196,
-			"kconfig": null,
-			"line": 659,
-			"name": "lstat64",
-			"number": 196,
-			"origname": "lstat64",
-			"signature": [
-				"const char *filename",
-				"struct stat64 *statbuf"
-			],
-			"symbol": "__ia32_sys_lstat64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 197,
-			"kconfig": null,
-			"line": 671,
-			"name": "fstat64",
-			"number": 197,
-			"origname": "fstat64",
-			"signature": [
-				"unsigned long fd",
-				"struct stat64 *statbuf"
-			],
-			"symbol": "__ia32_sys_fstat64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 198,
-			"kconfig": null,
-			"line": 836,
-			"name": "lchown",
-			"number": 198,
-			"origname": "lchown",
-			"signature": [
-				"const char *filename",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__ia32_sys_lchown"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 199,
-			"kconfig": null,
-			"line": 997,
-			"name": "getuid",
-			"number": 199,
-			"origname": "getuid",
-			"signature": [],
-			"symbol": "__ia32_sys_getuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 200,
-			"kconfig": null,
-			"line": 1009,
-			"name": "getgid",
-			"number": 200,
-			"origname": "getgid",
-			"signature": [],
-			"symbol": "__ia32_sys_getgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 201,
-			"kconfig": null,
-			"line": 1003,
-			"name": "geteuid",
-			"number": 201,
-			"origname": "geteuid",
-			"signature": [],
-			"symbol": "__ia32_sys_geteuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 202,
-			"kconfig": null,
-			"line": 1015,
-			"name": "getegid",
-			"number": 202,
-			"origname": "getegid",
-			"signature": [],
-			"symbol": "__ia32_sys_getegid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 203,
-			"kconfig": "MULTIUSER",
-			"line": 605,
-			"name": "setreuid",
-			"number": 203,
-			"origname": "setreuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid"
-			],
-			"symbol": "__ia32_sys_setreuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 204,
-			"kconfig": "MULTIUSER",
-			"line": 439,
-			"name": "setregid",
-			"number": 204,
-			"origname": "setregid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid"
-			],
-			"symbol": "__ia32_sys_setregid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 205,
-			"kconfig": "MULTIUSER",
-			"line": 161,
-			"name": "getgroups",
-			"number": 205,
-			"origname": "getgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__ia32_sys_getgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/groups.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 206,
-			"kconfig": "MULTIUSER",
-			"line": 198,
-			"name": "setgroups",
-			"number": 206,
-			"origname": "setgroups",
-			"signature": [
-				"int gidsetsize",
-				"gid_t *grouplist"
-			],
-			"symbol": "__ia32_sys_setgroups"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 207,
-			"kconfig": null,
-			"line": 865,
-			"name": "fchown",
-			"number": 207,
-			"origname": "fchown",
-			"signature": [
-				"unsigned int fd",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__ia32_sys_fchown"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 208,
-			"kconfig": "MULTIUSER",
-			"line": 753,
-			"name": "setresuid",
-			"number": 208,
-			"origname": "setresuid",
-			"signature": [
-				"uid_t ruid",
-				"uid_t euid",
-				"uid_t suid"
-			],
-			"symbol": "__ia32_sys_setresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 209,
-			"kconfig": "MULTIUSER",
-			"line": 758,
-			"name": "getresuid",
-			"number": 209,
-			"origname": "getresuid",
-			"signature": [
-				"uid_t *ruidp",
-				"uid_t *euidp",
-				"uid_t *suidp"
-			],
-			"symbol": "__ia32_sys_getresuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 210,
-			"kconfig": "MULTIUSER",
-			"line": 842,
-			"name": "setresgid",
-			"number": 210,
-			"origname": "setresgid",
-			"signature": [
-				"gid_t rgid",
-				"gid_t egid",
-				"gid_t sgid"
-			],
-			"symbol": "__ia32_sys_setresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 211,
-			"kconfig": "MULTIUSER",
-			"line": 847,
-			"name": "getresgid",
-			"number": 211,
-			"origname": "getresgid",
-			"signature": [
-				"gid_t *rgidp",
-				"gid_t *egidp",
-				"gid_t *sgidp"
-			],
-			"symbol": "__ia32_sys_getresgid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 212,
-			"kconfig": null,
-			"line": 831,
-			"name": "chown",
-			"number": 212,
-			"origname": "chown",
-			"signature": [
-				"const char *filename",
-				"uid_t user",
-				"gid_t group"
-			],
-			"symbol": "__ia32_sys_chown"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 213,
-			"kconfig": "MULTIUSER",
-			"line": 668,
-			"name": "setuid",
-			"number": 213,
-			"origname": "setuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__ia32_sys_setuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 214,
-			"kconfig": "MULTIUSER",
-			"line": 485,
-			"name": "setgid",
-			"number": 214,
-			"origname": "setgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__ia32_sys_setgid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 215,
-			"kconfig": "MULTIUSER",
-			"line": 910,
-			"name": "setfsuid",
-			"number": 215,
-			"origname": "setfsuid",
-			"signature": [
-				"uid_t uid"
-			],
-			"symbol": "__ia32_sys_setfsuid"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 216,
-			"kconfig": "MULTIUSER",
-			"line": 954,
-			"name": "setfsgid",
-			"number": 216,
-			"origname": "setfsgid",
-			"signature": [
-				"gid_t gid"
-			],
-			"symbol": "__ia32_sys_setfsgid"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 217,
-			"kconfig": null,
-			"line": 4388,
-			"name": "pivot_root",
-			"number": 217,
-			"origname": "pivot_root",
-			"signature": [
-				"const char *new_root",
-				"const char *put_old"
-			],
-			"symbol": "__ia32_sys_pivot_root"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mincore.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 218,
-			"kconfig": "MMU",
-			"line": 232,
-			"name": "mincore",
-			"number": 218,
-			"origname": "mincore",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"unsigned char *vec"
-			],
-			"symbol": "__ia32_sys_mincore"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 219,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1712,
-			"name": "madvise",
-			"number": 219,
-			"origname": "madvise",
-			"signature": [
-				"unsigned long start",
-				"size_t len_in",
-				"int behavior"
-			],
-			"symbol": "__ia32_sys_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/readdir.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 220,
-			"kconfig": null,
-			"line": 389,
-			"name": "getdents64",
-			"number": 220,
-			"origname": "getdents64",
-			"signature": [
-				"unsigned int fd",
-				"struct linux_dirent64 *dirent",
-				"unsigned int count"
-			],
-			"symbol": "__ia32_sys_getdents64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fcntl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 221,
-			"kconfig": null,
-			"line": 597,
-			"name": "fcntl64",
-			"number": 221,
-			"origname": "fcntl64",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__ia32_sys_fcntl64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 224,
-			"kconfig": null,
-			"line": 975,
-			"name": "gettid",
-			"number": 224,
-			"origname": "gettid",
-			"signature": [],
-			"symbol": "__ia32_sys_gettid"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 225,
-			"kconfig": null,
-			"line": 97,
-			"name": "readahead",
-			"number": 225,
-			"origname": "ia32_readahead",
-			"signature": [
-				"int fd",
-				"unsigned int off_lo",
-				"unsigned int off_hi",
-				"size_t count"
-			],
-			"symbol": "__ia32_sys_ia32_readahead"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 226,
-			"kconfig": null,
-			"line": 743,
-			"name": "setxattr",
-			"number": 226,
-			"origname": "setxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_setxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 227,
-			"kconfig": null,
-			"line": 750,
-			"name": "lsetxattr",
-			"number": 227,
-			"origname": "lsetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_lsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 228,
-			"kconfig": null,
-			"line": 758,
-			"name": "fsetxattr",
-			"number": 228,
-			"origname": "fsetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"const void *value",
-				"size_t size",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_fsetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 229,
-			"kconfig": null,
-			"line": 888,
-			"name": "getxattr",
-			"number": 229,
-			"origname": "getxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_getxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 230,
-			"kconfig": null,
-			"line": 894,
-			"name": "lgetxattr",
-			"number": 230,
-			"origname": "lgetxattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_lgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 231,
-			"kconfig": null,
-			"line": 901,
-			"name": "fgetxattr",
-			"number": 231,
-			"origname": "fgetxattr",
-			"signature": [
-				"int fd",
-				"const char *name",
-				"void *value",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_fgetxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 232,
-			"kconfig": null,
-			"line": 998,
-			"name": "listxattr",
-			"number": 232,
-			"origname": "listxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_listxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 233,
-			"kconfig": null,
-			"line": 1004,
-			"name": "llistxattr",
-			"number": 233,
-			"origname": "llistxattr",
-			"signature": [
-				"const char *pathname",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_llistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 234,
-			"kconfig": null,
-			"line": 1010,
-			"name": "flistxattr",
-			"number": 234,
-			"origname": "flistxattr",
-			"signature": [
-				"int fd",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_flistxattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 235,
-			"kconfig": null,
-			"line": 1097,
-			"name": "removexattr",
-			"number": 235,
-			"origname": "removexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__ia32_sys_removexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 236,
-			"kconfig": null,
-			"line": 1103,
-			"name": "lremovexattr",
-			"number": 236,
-			"origname": "lremovexattr",
-			"signature": [
-				"const char *pathname",
-				"const char *name"
-			],
-			"symbol": "__ia32_sys_lremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 237,
-			"kconfig": null,
-			"line": 1109,
-			"name": "fremovexattr",
-			"number": 237,
-			"origname": "fremovexattr",
-			"signature": [
-				"int fd",
-				"const char *name"
-			],
-			"symbol": "__ia32_sys_fremovexattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 238,
-			"kconfig": null,
-			"line": 4160,
-			"name": "tkill",
-			"number": 238,
-			"origname": "tkill",
-			"signature": [
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__ia32_sys_tkill"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 239,
-			"kconfig": null,
-			"line": 1410,
-			"name": "sendfile64",
-			"number": 239,
-			"origname": "sendfile64",
-			"signature": [
-				"int out_fd",
-				"int in_fd",
-				"loff_t *offset",
-				"size_t count"
-			],
-			"symbol": "__ia32_sys_sendfile64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 240,
-			"kconfig": "FUTEX",
-			"line": 492,
-			"name": "futex",
-			"number": 240,
-			"origname": "futex_time32",
-			"signature": [
-				"u32 *uaddr",
-				"int op",
-				"u32 val",
-				"const struct old_timespec32 *utime",
-				"u32 *uaddr2",
-				"u32 val3"
-			],
-			"symbol": "__ia32_sys_futex_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 241,
-			"kconfig": null,
-			"line": 1279,
-			"name": "sched_setaffinity",
-			"number": 241,
-			"origname": "sched_setaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__ia32_sys_sched_setaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 242,
-			"kconfig": null,
-			"line": 1324,
-			"name": "sched_getaffinity",
-			"number": 242,
-			"origname": "sched_getaffinity",
-			"signature": [
-				"pid_t pid",
-				"unsigned int len",
-				"unsigned long *user_mask_ptr"
-			],
-			"symbol": "__ia32_sys_sched_getaffinity"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/tls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 243,
-			"kconfig": null,
-			"line": 186,
-			"name": "set_thread_area",
-			"number": 243,
-			"origname": "set_thread_area",
-			"signature": [
-				"struct user_desc *u_info"
-			],
-			"symbol": "__ia32_sys_set_thread_area"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/tls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 244,
-			"kconfig": null,
-			"line": 238,
-			"name": "get_thread_area",
-			"number": 244,
-			"origname": "get_thread_area",
-			"signature": [
-				"struct user_desc *u_info"
-			],
-			"symbol": "__ia32_sys_get_thread_area"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 245,
-			"kconfig": "AIO",
-			"line": 1382,
-			"name": "io_setup",
-			"number": 245,
-			"origname": "io_setup",
-			"signature": [
-				"unsigned nr_events",
-				"aio_context_t *ctxp"
-			],
-			"symbol": "__ia32_sys_io_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 246,
-			"kconfig": "AIO",
-			"line": 1451,
-			"name": "io_destroy",
-			"number": 246,
-			"origname": "io_destroy",
-			"signature": [
-				"aio_context_t ctx"
-			],
-			"symbol": "__ia32_sys_io_destroy"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 247,
-			"kconfig": "AIO",
-			"line": 2348,
-			"name": "io_getevents",
-			"number": 247,
-			"origname": "io_getevents_time32",
-			"signature": [
-				"__u32 ctx_id",
-				"__s32 min_nr",
-				"__s32 nr",
-				"struct io_event *events",
-				"struct old_timespec32 *timeout"
-			],
-			"symbol": "__ia32_sys_io_getevents_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 248,
-			"kconfig": "AIO",
-			"line": 2081,
-			"name": "io_submit",
-			"number": 248,
-			"origname": "io_submit",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long nr",
-				"struct iocb **iocbpp"
-			],
-			"symbol": "__ia32_sys_io_submit"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 249,
-			"kconfig": "AIO",
-			"line": 2175,
-			"name": "io_cancel",
-			"number": 249,
-			"origname": "io_cancel",
-			"signature": [
-				"aio_context_t ctx_id",
-				"struct iocb *iocb",
-				"struct io_event *result"
-			],
-			"symbol": "__ia32_sys_io_cancel"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 250,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 112,
-			"name": "fadvise64",
-			"number": 250,
-			"origname": "ia32_fadvise64",
-			"signature": [
-				"int fd",
-				"unsigned int offset_lo",
-				"unsigned int offset_hi",
-				"size_t len",
-				"int advice"
-			],
-			"symbol": "__ia32_sys_ia32_fadvise64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 252,
-			"kconfig": null,
-			"line": 1096,
-			"name": "exit_group",
-			"number": 252,
-			"origname": "exit_group",
-			"signature": [
-				"int error_code"
-			],
-			"symbol": "__ia32_sys_exit_group"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 254,
-			"kconfig": "EPOLL",
-			"line": 2256,
-			"name": "epoll_create",
-			"number": 254,
-			"origname": "epoll_create",
-			"signature": [
-				"int size"
-			],
-			"symbol": "__ia32_sys_epoll_create"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 255,
-			"kconfig": "EPOLL",
-			"line": 2436,
-			"name": "epoll_ctl",
-			"number": 255,
-			"origname": "epoll_ctl",
-			"signature": [
-				"int epfd",
-				"int op",
-				"int fd",
-				"struct epoll_event *event"
-			],
-			"symbol": "__ia32_sys_epoll_ctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 256,
-			"kconfig": "EPOLL",
-			"line": 2487,
-			"name": "epoll_wait",
-			"number": 256,
-			"origname": "epoll_wait",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"int timeout"
-			],
-			"symbol": "__ia32_sys_epoll_wait"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mmap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 257,
-			"kconfig": "MMU",
-			"line": 1091,
-			"name": "remap_file_pages",
-			"number": 257,
-			"origname": "remap_file_pages",
-			"signature": [
-				"unsigned long start",
-				"unsigned long size",
-				"unsigned long prot",
-				"unsigned long pgoff",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_remap_file_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 258,
-			"kconfig": null,
-			"line": 1949,
-			"name": "set_tid_address",
-			"number": 258,
-			"origname": "set_tid_address",
-			"signature": [
-				"int *tidptr"
-			],
-			"symbol": "__ia32_sys_set_tid_address"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 259,
-			"kconfig": "POSIX_TIMERS",
-			"line": 480,
-			"name": "timer_create",
-			"number": 259,
-			"origname": "timer_create",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct sigevent *timer_event_spec",
-				"timer_t *created_timer_id"
-			],
-			"symbol": "__ia32_sys_timer_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 260,
-			"kconfig": "POSIX_TIMERS",
-			"line": 937,
-			"name": "timer_settime",
-			"number": 260,
-			"origname": "timer_settime32",
-			"signature": [
-				"timer_t timer_id",
-				"int flags",
-				"struct old_itimerspec32 *new",
-				"struct old_itimerspec32 *old"
-			],
-			"symbol": "__ia32_sys_timer_settime32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 261,
-			"kconfig": "POSIX_TIMERS",
-			"line": 691,
-			"name": "timer_gettime",
-			"number": 261,
-			"origname": "timer_gettime32",
-			"signature": [
-				"timer_t timer_id",
-				"struct old_itimerspec32 *setting"
-			],
-			"symbol": "__ia32_sys_timer_gettime32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 262,
-			"kconfig": "POSIX_TIMERS",
-			"line": 724,
-			"name": "timer_getoverrun",
-			"number": 262,
-			"origname": "timer_getoverrun",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__ia32_sys_timer_getoverrun"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 263,
-			"kconfig": "POSIX_TIMERS",
-			"line": 994,
-			"name": "timer_delete",
-			"number": 263,
-			"origname": "timer_delete",
-			"signature": [
-				"timer_t timer_id"
-			],
-			"symbol": "__ia32_sys_timer_delete"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 264,
-			"kconfig": null,
-			"line": 1278,
-			"name": "clock_settime",
-			"number": 264,
-			"origname": "clock_settime32",
-			"signature": [
-				"clockid_t which_clock",
-				"struct old_timespec32 *tp"
-			],
-			"symbol": "__ia32_sys_clock_settime32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 265,
-			"kconfig": null,
-			"line": 1293,
-			"name": "clock_gettime",
-			"number": 265,
-			"origname": "clock_gettime32",
-			"signature": [
-				"clockid_t which_clock",
-				"struct old_timespec32 *tp"
-			],
-			"symbol": "__ia32_sys_clock_gettime32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 266,
-			"kconfig": null,
-			"line": 1329,
-			"name": "clock_getres",
-			"number": 266,
-			"origname": "clock_getres_time32",
-			"signature": [
-				"clockid_t which_clock",
-				"struct old_timespec32 *tp"
-			],
-			"symbol": "__ia32_sys_clock_getres_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 267,
-			"kconfig": null,
-			"line": 1407,
-			"name": "clock_nanosleep",
-			"number": 267,
-			"origname": "clock_nanosleep_time32",
-			"signature": [
-				"clockid_t which_clock",
-				"int flags",
-				"struct old_timespec32 *rqtp",
-				"struct old_timespec32 *rmtp"
-			],
-			"symbol": "__ia32_sys_clock_nanosleep_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 268,
-			"kconfig": null,
-			"line": 199,
-			"name": "statfs64",
-			"number": 268,
-			"origname": "statfs64",
-			"signature": [
-				"const char *pathname",
-				"size_t sz",
-				"struct statfs64 *buf"
-			],
-			"symbol": "__ia32_sys_statfs64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/statfs.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 269,
-			"kconfig": null,
-			"line": 220,
-			"name": "fstatfs64",
-			"number": 269,
-			"origname": "fstatfs64",
-			"signature": [
-				"unsigned int fd",
-				"size_t sz",
-				"struct statfs64 *buf"
-			],
-			"symbol": "__ia32_sys_fstatfs64"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 270,
-			"kconfig": null,
-			"line": 4144,
-			"name": "tgkill",
-			"number": 270,
-			"origname": "tgkill",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig"
-			],
-			"symbol": "__ia32_sys_tgkill"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 271,
-			"kconfig": null,
-			"line": 290,
-			"name": "utimes",
-			"number": 271,
-			"origname": "utimes_time32",
-			"signature": [
-				"const char *filename",
-				"struct old_timeval32 *t"
-			],
-			"symbol": "__ia32_sys_utimes_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 272,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 87,
-			"name": "fadvise64_64",
-			"number": 272,
-			"origname": "ia32_fadvise64_64",
-			"signature": [
-				"int fd",
-				"__u32 offset_low",
-				"__u32 offset_high",
-				"__u32 len_low",
-				"__u32 len_high",
-				"int advice"
-			],
-			"symbol": "__ia32_sys_ia32_fadvise64_64"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 274,
-			"kconfig": "NUMA",
-			"line": 1607,
-			"name": "mbind",
-			"number": 274,
-			"origname": "mbind",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_mbind"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 275,
-			"kconfig": "NUMA",
-			"line": 1764,
-			"name": "get_mempolicy",
-			"number": 275,
-			"origname": "get_mempolicy",
-			"signature": [
-				"int *policy",
-				"unsigned long *nmask",
-				"unsigned long maxnode",
-				"unsigned long addr",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_get_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 276,
-			"kconfig": "NUMA",
-			"line": 1634,
-			"name": "set_mempolicy",
-			"number": 276,
-			"origname": "set_mempolicy",
-			"signature": [
-				"int mode",
-				"const unsigned long *nmask",
-				"unsigned long maxnode"
-			],
-			"symbol": "__ia32_sys_set_mempolicy"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 277,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 944,
-			"name": "mq_open",
-			"number": 277,
-			"origname": "mq_open",
-			"signature": [
-				"const char *u_name",
-				"int oflag",
-				"umode_t mode",
-				"struct mq_attr *u_attr"
-			],
-			"symbol": "__ia32_sys_mq_open"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 278,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 954,
-			"name": "mq_unlink",
-			"number": 278,
-			"origname": "mq_unlink",
-			"signature": [
-				"const char *u_name"
-			],
-			"symbol": "__ia32_sys_mq_unlink"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 279,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1582,
-			"name": "mq_timedsend",
-			"number": 279,
-			"origname": "mq_timedsend_time32",
-			"signature": [
-				"mqd_t mqdes",
-				"const char *u_msg_ptr",
-				"unsigned int msg_len",
-				"unsigned int msg_prio",
-				"const struct old_timespec32 *u_abs_timeout"
-			],
-			"symbol": "__ia32_sys_mq_timedsend_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 280,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1597,
-			"name": "mq_timedreceive",
-			"number": 280,
-			"origname": "mq_timedreceive_time32",
-			"signature": [
-				"mqd_t mqdes",
-				"char *u_msg_ptr",
-				"unsigned int msg_len",
-				"unsigned int *u_msg_prio",
-				"const struct old_timespec32 *u_abs_timeout"
-			],
-			"symbol": "__ia32_sys_mq_timedreceive_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 281,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1400,
-			"name": "mq_notify",
-			"number": 281,
-			"origname": "mq_notify",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct sigevent *u_notification"
-			],
-			"symbol": "__ia32_sys_mq_notify"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 282,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1452,
-			"name": "mq_getsetattr",
-			"number": 282,
-			"origname": "mq_getsetattr",
-			"signature": [
-				"mqd_t mqdes",
-				"const struct mq_attr *u_mqstat",
-				"struct mq_attr *u_omqstat"
-			],
-			"symbol": "__ia32_sys_mq_getsetattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kexec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 283,
-			"kconfig": "KEXEC",
-			"line": 242,
-			"name": "kexec_load",
-			"number": 283,
-			"origname": "kexec_load",
-			"signature": [
-				"unsigned long entry",
-				"unsigned long nr_segments",
-				"struct kexec_segment *segments",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_kexec_load"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/exit.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 284,
-			"kconfig": null,
-			"line": 1782,
-			"name": "waitid",
-			"number": 284,
-			"origname": "waitid",
-			"signature": [
-				"int which",
-				"pid_t upid",
-				"struct siginfo *infop",
-				"int options",
-				"struct rusage *ru"
-			],
-			"symbol": "__ia32_sys_waitid"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 286,
-			"kconfig": "KEYS",
-			"line": 74,
-			"name": "add_key",
-			"number": 286,
-			"origname": "add_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const void *_payload",
-				"size_t plen",
-				"key_serial_t ringid"
-			],
-			"symbol": "__ia32_sys_add_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 287,
-			"kconfig": "KEYS",
-			"line": 167,
-			"name": "request_key",
-			"number": 287,
-			"origname": "request_key",
-			"signature": [
-				"const char *_type",
-				"const char *_description",
-				"const char *_callout_info",
-				"key_serial_t destringid"
-			],
-			"symbol": "__ia32_sys_request_key"
-		},
-		{
-			"esoteric": false,
-			"file": "security/keys/keyctl.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 288,
-			"kconfig": "KEYS",
-			"line": 1874,
-			"name": "keyctl",
-			"number": 288,
-			"origname": "keyctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2",
-				"unsigned long arg3",
-				"unsigned long arg4",
-				"unsigned long arg5"
-			],
-			"symbol": "__ia32_sys_keyctl"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 289,
-			"kconfig": "BLOCK",
-			"line": 69,
-			"name": "ioprio_set",
-			"number": 289,
-			"origname": "ioprio_set",
-			"signature": [
-				"int which",
-				"int who",
-				"int ioprio"
-			],
-			"symbol": "__ia32_sys_ioprio_set"
-		},
-		{
-			"esoteric": false,
-			"file": "block/ioprio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 290,
-			"kconfig": "BLOCK",
-			"line": 184,
-			"name": "ioprio_get",
-			"number": 290,
-			"origname": "ioprio_get",
-			"signature": [
-				"int which",
-				"int who"
-			],
-			"symbol": "__ia32_sys_ioprio_get"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 291,
-			"kconfig": "INOTIFY_USER",
-			"line": 724,
-			"name": "inotify_init",
-			"number": 291,
-			"origname": "inotify_init",
-			"signature": [],
-			"symbol": "__ia32_sys_inotify_init"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 292,
-			"kconfig": "INOTIFY_USER",
-			"line": 729,
-			"name": "inotify_add_watch",
-			"number": 292,
-			"origname": "inotify_add_watch",
-			"signature": [
-				"int fd",
-				"const char *pathname",
-				"u32 mask"
-			],
-			"symbol": "__ia32_sys_inotify_add_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 293,
-			"kconfig": "INOTIFY_USER",
-			"line": 786,
-			"name": "inotify_rm_watch",
-			"number": 293,
-			"origname": "inotify_rm_watch",
-			"signature": [
-				"int fd",
-				"__s32 wd"
-			],
-			"symbol": "__ia32_sys_inotify_rm_watch"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 294,
-			"kconfig": "MIGRATION",
-			"line": 1727,
-			"name": "migrate_pages",
-			"number": 294,
-			"origname": "migrate_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long maxnode",
-				"const unsigned long *old_nodes",
-				"const unsigned long *new_nodes"
-			],
-			"symbol": "__ia32_sys_migrate_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 295,
-			"kconfig": null,
-			"line": 1454,
-			"name": "openat",
-			"number": 295,
-			"origname": "openat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int flags",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_openat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 296,
-			"kconfig": null,
-			"line": 4349,
-			"name": "mkdirat",
-			"number": 296,
-			"origname": "mkdirat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_mkdirat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 297,
-			"kconfig": null,
-			"line": 4266,
-			"name": "mknodat",
-			"number": 297,
-			"origname": "mknodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int dev"
-			],
-			"symbol": "__ia32_sys_mknodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 298,
-			"kconfig": null,
-			"line": 825,
-			"name": "fchownat",
-			"number": 298,
-			"origname": "fchownat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"uid_t user",
-				"gid_t group",
-				"int flag"
-			],
-			"symbol": "__ia32_sys_fchownat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 299,
-			"kconfig": null,
-			"line": 283,
-			"name": "futimesat",
-			"number": 299,
-			"origname": "futimesat_time32",
-			"signature": [
-				"unsigned int dfd",
-				"const char *filename",
-				"struct old_timeval32 *t"
-			],
-			"symbol": "__ia32_sys_futimesat_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 300,
-			"kconfig": null,
-			"line": 682,
-			"name": "fstatat64",
-			"number": 300,
-			"origname": "fstatat64",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct stat64 *statbuf",
-				"int flag"
-			],
-			"symbol": "__ia32_sys_fstatat64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 301,
-			"kconfig": null,
-			"line": 4625,
-			"name": "unlinkat",
-			"number": 301,
-			"origname": "unlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"int flag"
-			],
-			"symbol": "__ia32_sys_unlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 302,
-			"kconfig": null,
-			"line": 5264,
-			"name": "renameat",
-			"number": 302,
-			"origname": "renameat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__ia32_sys_renameat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 303,
-			"kconfig": null,
-			"line": 4890,
-			"name": "linkat",
-			"number": 303,
-			"origname": "linkat",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_linkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 304,
-			"kconfig": null,
-			"line": 4710,
-			"name": "symlinkat",
-			"number": 304,
-			"origname": "symlinkat",
-			"signature": [
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname"
-			],
-			"symbol": "__ia32_sys_symlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 305,
-			"kconfig": null,
-			"line": 592,
-			"name": "readlinkat",
-			"number": 305,
-			"origname": "readlinkat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"char *buf",
-				"int bufsiz"
-			],
-			"symbol": "__ia32_sys_readlinkat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 306,
-			"kconfig": null,
-			"line": 706,
-			"name": "fchmodat",
-			"number": 306,
-			"origname": "fchmodat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode"
-			],
-			"symbol": "__ia32_sys_fchmodat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 307,
-			"kconfig": null,
-			"line": 535,
-			"name": "faccessat",
-			"number": 307,
-			"origname": "faccessat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode"
-			],
-			"symbol": "__ia32_sys_faccessat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 308,
-			"kconfig": null,
-			"line": 807,
-			"name": "pselect6",
-			"number": 308,
-			"origname": "pselect6_time32",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct old_timespec32 *tsp",
-				"void *sig"
-			],
-			"symbol": "__ia32_sys_pselect6_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 309,
-			"kconfig": null,
-			"line": 1121,
-			"name": "ppoll",
-			"number": 309,
-			"origname": "ppoll_time32",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"struct old_timespec32 *tsp",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_ppoll_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 310,
-			"kconfig": null,
-			"line": 3411,
-			"name": "unshare",
-			"number": 310,
-			"origname": "unshare",
-			"signature": [
-				"unsigned long unshare_flags"
-			],
-			"symbol": "__ia32_sys_unshare"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 311,
-			"kconfig": "FUTEX",
-			"line": 28,
-			"name": "set_robust_list",
-			"number": 311,
-			"origname": "set_robust_list",
-			"signature": [
-				"struct robust_list_head *head",
-				"size_t len"
-			],
-			"symbol": "__ia32_sys_set_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 312,
-			"kconfig": "FUTEX",
-			"line": 48,
-			"name": "get_robust_list",
-			"number": 312,
-			"origname": "get_robust_list",
-			"signature": [
-				"int pid",
-				"struct robust_list_head **head_ptr",
-				"size_t *len_ptr"
-			],
-			"symbol": "__ia32_sys_get_robust_list"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 313,
-			"kconfig": null,
-			"line": 1621,
-			"name": "splice",
-			"number": 313,
-			"origname": "splice",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_splice"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 314,
-			"kconfig": null,
-			"line": 103,
-			"name": "sync_file_range",
-			"number": 314,
-			"origname": "ia32_sync_file_range",
-			"signature": [
-				"int fd",
-				"unsigned int off_low",
-				"unsigned int off_hi",
-				"unsigned int n_low",
-				"unsigned int n_hi",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_ia32_sync_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 315,
-			"kconfig": null,
-			"line": 1988,
-			"name": "tee",
-			"number": 315,
-			"origname": "tee",
-			"signature": [
-				"int fdin",
-				"int fdout",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_tee"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/splice.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 316,
-			"kconfig": null,
-			"line": 1583,
-			"name": "vmsplice",
-			"number": 316,
-			"origname": "vmsplice",
-			"signature": [
-				"int fd",
-				"const struct iovec *uiov",
-				"unsigned long nr_segs",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_vmsplice"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/migrate.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 317,
-			"kconfig": "MIGRATION",
-			"line": 2586,
-			"name": "move_pages",
-			"number": 317,
-			"origname": "move_pages",
-			"signature": [
-				"pid_t pid",
-				"unsigned long nr_pages",
-				"const void **pages",
-				"const int *nodes",
-				"int *status",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_move_pages"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 318,
-			"kconfig": null,
-			"line": 2822,
-			"name": "getcpu",
-			"number": 318,
-			"origname": "getcpu",
-			"signature": [
-				"unsigned *cpup",
-				"unsigned *nodep",
-				"struct getcpu_cache *unused"
-			],
-			"symbol": "__ia32_sys_getcpu"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 319,
-			"kconfig": "EPOLL",
-			"line": 2521,
-			"name": "epoll_pwait",
-			"number": 319,
-			"origname": "epoll_pwait",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"int timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_epoll_pwait"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 320,
-			"kconfig": null,
-			"line": 247,
-			"name": "utimensat",
-			"number": 320,
-			"origname": "utimensat_time32",
-			"signature": [
-				"unsigned int dfd",
-				"const char *filename",
-				"struct old_timespec32 *t",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_utimensat_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/signalfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 321,
-			"kconfig": "SIGNALFD",
-			"line": 319,
-			"name": "signalfd",
-			"number": 321,
-			"origname": "signalfd",
-			"signature": [
-				"int ufd",
-				"sigset_t *user_mask",
-				"size_t sizemask"
-			],
-			"symbol": "__ia32_sys_signalfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 322,
-			"kconfig": null,
-			"line": 395,
-			"name": "timerfd_create",
-			"number": 322,
-			"origname": "timerfd_create",
-			"signature": [
-				"int clockid",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_timerfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 323,
-			"kconfig": null,
-			"line": 429,
-			"name": "eventfd",
-			"number": 323,
-			"origname": "eventfd",
-			"signature": [
-				"unsigned int count"
-			],
-			"symbol": "__ia32_sys_eventfd"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/sys_ia32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 324,
-			"kconfig": null,
-			"line": 119,
-			"name": "fallocate",
-			"number": 324,
-			"origname": "ia32_fallocate",
-			"signature": [
-				"int fd",
-				"int mode",
-				"unsigned int offset_lo",
-				"unsigned int offset_hi",
-				"unsigned int len_lo",
-				"unsigned int len_hi"
-			],
-			"symbol": "__ia32_sys_ia32_fallocate"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 325,
-			"kconfig": null,
-			"line": 588,
-			"name": "timerfd_settime",
-			"number": 325,
-			"origname": "timerfd_settime32",
-			"signature": [
-				"int ufd",
-				"int flags",
-				"const struct old_itimerspec32 *utmr",
-				"struct old_itimerspec32 *otmr"
-			],
-			"symbol": "__ia32_sys_timerfd_settime32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 326,
-			"kconfig": null,
-			"line": 605,
-			"name": "timerfd_gettime",
-			"number": 326,
-			"origname": "timerfd_gettime32",
-			"signature": [
-				"int ufd",
-				"struct old_itimerspec32 *otmr"
-			],
-			"symbol": "__ia32_sys_timerfd_gettime32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/signalfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 327,
-			"kconfig": "SIGNALFD",
-			"line": 307,
-			"name": "signalfd4",
-			"number": 327,
-			"origname": "signalfd4",
-			"signature": [
-				"int ufd",
-				"sigset_t *user_mask",
-				"size_t sizemask",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_signalfd4"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 328,
-			"kconfig": null,
-			"line": 424,
-			"name": "eventfd2",
-			"number": 328,
-			"origname": "eventfd2",
-			"signature": [
-				"unsigned int count",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_eventfd2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 329,
-			"kconfig": "EPOLL",
-			"line": 2251,
-			"name": "epoll_create1",
-			"number": 329,
-			"origname": "epoll_create1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__ia32_sys_epoll_create1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 330,
-			"kconfig": null,
-			"line": 1370,
-			"name": "dup3",
-			"number": 330,
-			"origname": "dup3",
-			"signature": [
-				"unsigned int oldfd",
-				"unsigned int newfd",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_dup3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/pipe.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 331,
-			"kconfig": null,
-			"line": 1043,
-			"name": "pipe2",
-			"number": 331,
-			"origname": "pipe2",
-			"signature": [
-				"int *fildes",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_pipe2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/inotify/inotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 332,
-			"kconfig": "INOTIFY_USER",
-			"line": 719,
-			"name": "inotify_init1",
-			"number": 332,
-			"origname": "inotify_init1",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__ia32_sys_inotify_init1"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 333,
-			"kconfig": null,
-			"line": 1167,
-			"name": "preadv",
-			"number": 333,
-			"origname": "preadv",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__ia32_sys_preadv"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 334,
-			"kconfig": null,
-			"line": 1187,
-			"name": "pwritev",
-			"number": 334,
-			"origname": "pwritev",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h"
-			],
-			"symbol": "__ia32_sys_pwritev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 335,
-			"kconfig": null,
-			"line": 4228,
-			"name": "rt_tgsigqueueinfo",
-			"number": 335,
-			"origname": "rt_tgsigqueueinfo",
-			"signature": [
-				"pid_t tgid",
-				"pid_t pid",
-				"int sig",
-				"siginfo_t *uinfo"
-			],
-			"symbol": "__ia32_sys_rt_tgsigqueueinfo"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/events/core.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 336,
-			"kconfig": "PERF_EVENTS",
-			"line": 12798,
-			"name": "perf_event_open",
-			"number": 336,
-			"origname": "perf_event_open",
-			"signature": [
-				"struct perf_event_attr *attr_uptr",
-				"pid_t pid",
-				"int cpu",
-				"int group_fd",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_perf_event_open"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 337,
-			"kconfig": "NET",
-			"line": 3031,
-			"name": "recvmmsg",
-			"number": 337,
-			"origname": "recvmmsg_time32",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags",
-				"struct old_timespec32 *timeout"
-			],
-			"symbol": "__ia32_sys_recvmmsg_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 338,
-			"kconfig": "FANOTIFY",
-			"line": 1466,
-			"name": "fanotify_init",
-			"number": 338,
-			"origname": "fanotify_init",
-			"signature": [
-				"unsigned int flags",
-				"unsigned int event_f_flags"
-			],
-			"symbol": "__ia32_sys_fanotify_init"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/notify/fanotify/fanotify_user.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 339,
-			"kconfig": "FANOTIFY",
-			"line": 2012,
-			"name": "fanotify_mark",
-			"number": 339,
-			"origname": "fanotify_mark",
-			"signature": [
-				"int fanotify_fd",
-				"unsigned int flags",
-				"u32 mask_lo",
-				"u32 mask_hi",
-				"int dfd",
-				"const char *pathname"
-			],
-			"symbol": "__ia32_sys_fanotify_mark"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sys.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 340,
-			"kconfig": null,
-			"line": 1695,
-			"name": "prlimit64",
-			"number": 340,
-			"origname": "prlimit64",
-			"signature": [
-				"pid_t pid",
-				"unsigned int resource",
-				"const struct rlimit64 *new_rlim",
-				"struct rlimit64 *old_rlim"
-			],
-			"symbol": "__ia32_sys_prlimit64"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 341,
-			"kconfig": "FHANDLE",
-			"line": 129,
-			"name": "name_to_handle_at",
-			"number": 341,
-			"origname": "name_to_handle_at",
-			"signature": [
-				"int dfd",
-				"const char *name",
-				"struct file_handle *handle",
-				"void *mnt_id",
-				"int flag"
-			],
-			"symbol": "__ia32_sys_name_to_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fhandle.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 342,
-			"kconfig": "FHANDLE",
-			"line": 434,
-			"name": "open_by_handle_at",
-			"number": 342,
-			"origname": "open_by_handle_at",
-			"signature": [
-				"int mountdirfd",
-				"struct file_handle *handle",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_open_by_handle_at"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 343,
-			"kconfig": null,
-			"line": 1311,
-			"name": "clock_adjtime",
-			"number": 343,
-			"origname": "clock_adjtime32",
-			"signature": [
-				"clockid_t which_clock",
-				"struct old_timex32 *utp"
-			],
-			"symbol": "__ia32_sys_clock_adjtime32"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/sync.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 344,
-			"kconfig": null,
-			"line": 149,
-			"name": "syncfs",
-			"number": 344,
-			"origname": "syncfs",
-			"signature": [
-				"int fd"
-			],
-			"symbol": "__ia32_sys_syncfs"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 345,
-			"kconfig": "NET",
-			"line": 2740,
-			"name": "sendmmsg",
-			"number": 345,
-			"origname": "sendmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_sendmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/nsproxy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 346,
-			"kconfig": null,
-			"line": 546,
-			"name": "setns",
-			"number": 346,
-			"origname": "setns",
-			"signature": [
-				"int fd",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_setns"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 347,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 292,
-			"name": "process_vm_readv",
-			"number": 347,
-			"origname": "process_vm_readv",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_process_vm_readv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/process_vm_access.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 348,
-			"kconfig": "CROSS_MEMORY_ATTACH",
-			"line": 299,
-			"name": "process_vm_writev",
-			"number": 348,
-			"origname": "process_vm_writev",
-			"signature": [
-				"pid_t pid",
-				"const struct iovec *lvec",
-				"unsigned long liovcnt",
-				"const struct iovec *rvec",
-				"unsigned long riovcnt",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_process_vm_writev"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/kcmp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 349,
-			"kconfig": "KCMP",
-			"line": 135,
-			"name": "kcmp",
-			"number": 349,
-			"origname": "kcmp",
-			"signature": [
-				"pid_t pid1",
-				"pid_t pid2",
-				"int type",
-				"unsigned long idx1",
-				"unsigned long idx2"
-			],
-			"symbol": "__ia32_sys_kcmp"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/module/main.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 350,
-			"kconfig": "MODULES",
-			"line": 3669,
-			"name": "finit_module",
-			"number": 350,
-			"origname": "finit_module",
-			"signature": [
-				"int fd",
-				"const char *uargs",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_finit_module"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 351,
-			"kconfig": null,
-			"line": 981,
-			"name": "sched_setattr",
-			"number": 351,
-			"origname": "sched_setattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_sched_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 352,
-			"kconfig": null,
-			"line": 1081,
-			"name": "sched_getattr",
-			"number": 352,
-			"origname": "sched_getattr",
-			"signature": [
-				"pid_t pid",
-				"struct sched_attr *uattr",
-				"unsigned int usize",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_sched_getattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namei.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 353,
-			"kconfig": null,
-			"line": 5257,
-			"name": "renameat2",
-			"number": 353,
-			"origname": "renameat2",
-			"signature": [
-				"int olddfd",
-				"const char *oldname",
-				"int newdfd",
-				"const char *newname",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_renameat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/seccomp.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 354,
-			"kconfig": "SECCOMP",
-			"line": 2101,
-			"name": "seccomp",
-			"number": 354,
-			"origname": "seccomp",
-			"signature": [
-				"unsigned int op",
-				"unsigned int flags",
-				"void *uargs"
-			],
-			"symbol": "__ia32_sys_seccomp"
-		},
-		{
-			"esoteric": false,
-			"file": "drivers/char/random.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 355,
-			"kconfig": null,
-			"line": 1388,
-			"name": "getrandom",
-			"number": 355,
-			"origname": "getrandom",
-			"signature": [
-				"char *ubuf",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_getrandom"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/memfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 356,
-			"kconfig": "MEMFD_CREATE",
-			"line": 458,
-			"name": "memfd_create",
-			"number": 356,
-			"origname": "memfd_create",
-			"signature": [
-				"const char *uname",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_memfd_create"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/bpf/syscall.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 357,
-			"kconfig": "BPF_SYSCALL",
-			"line": 5900,
-			"name": "bpf",
-			"number": 357,
-			"origname": "bpf",
-			"signature": [
-				"int cmd",
-				"union bpf_attr *uattr",
-				"unsigned int size"
-			],
-			"symbol": "__ia32_sys_bpf"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/exec.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 358,
-			"kconfig": null,
-			"line": 2119,
-			"name": "execveat",
-			"number": 358,
-			"origname": "execveat",
-			"signature": [
-				"int fd",
-				"const char *filename",
-				"const char *const *argv",
-				"const char *const *envp",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_execveat"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 359,
-			"kconfig": "NET",
-			"line": 1702,
-			"name": "socket",
-			"number": 359,
-			"origname": "socket",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol"
-			],
-			"symbol": "__ia32_sys_socket"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 360,
-			"kconfig": "NET",
-			"line": 1803,
-			"name": "socketpair",
-			"number": 360,
-			"origname": "socketpair",
-			"signature": [
-				"int family",
-				"int type",
-				"int protocol",
-				"int *usockvec"
-			],
-			"symbol": "__ia32_sys_socketpair"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 361,
-			"kconfig": "NET",
-			"line": 1851,
-			"name": "bind",
-			"number": 361,
-			"origname": "bind",
-			"signature": [
-				"int fd",
-				"struct sockaddr *umyaddr",
-				"int addrlen"
-			],
-			"symbol": "__ia32_sys_bind"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 362,
-			"kconfig": "NET",
-			"line": 2067,
-			"name": "connect",
-			"number": 362,
-			"origname": "connect",
-			"signature": [
-				"int fd",
-				"struct sockaddr *uservaddr",
-				"int addrlen"
-			],
-			"symbol": "__ia32_sys_connect"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 363,
-			"kconfig": "NET",
-			"line": 1889,
-			"name": "listen",
-			"number": 363,
-			"origname": "listen",
-			"signature": [
-				"int fd",
-				"int backlog"
-			],
-			"symbol": "__ia32_sys_listen"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 364,
-			"kconfig": "NET",
-			"line": 2004,
-			"name": "accept4",
-			"number": 364,
-			"origname": "accept4",
-			"signature": [
-				"int fd",
-				"struct sockaddr *upeer_sockaddr",
-				"int *upeer_addrlen",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_accept4"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 365,
-			"kconfig": "NET",
-			"line": 2397,
-			"name": "getsockopt",
-			"number": 365,
-			"origname": "getsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int *optlen"
-			],
-			"symbol": "__ia32_sys_getsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 366,
-			"kconfig": "NET",
-			"line": 2331,
-			"name": "setsockopt",
-			"number": 366,
-			"origname": "setsockopt",
-			"signature": [
-				"int fd",
-				"int level",
-				"int optname",
-				"char *optval",
-				"int optlen"
-			],
-			"symbol": "__ia32_sys_setsockopt"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 367,
-			"kconfig": "NET",
-			"line": 2104,
-			"name": "getsockname",
-			"number": 367,
-			"origname": "getsockname",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__ia32_sys_getsockname"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 368,
-			"kconfig": "NET",
-			"line": 2141,
-			"name": "getpeername",
-			"number": 368,
-			"origname": "getpeername",
-			"signature": [
-				"int fd",
-				"struct sockaddr *usockaddr",
-				"int *usockaddr_len"
-			],
-			"symbol": "__ia32_sys_getpeername"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 369,
-			"kconfig": "NET",
-			"line": 2190,
-			"name": "sendto",
-			"number": 369,
-			"origname": "sendto",
-			"signature": [
-				"int fd",
-				"void *buff",
-				"size_t len",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int addr_len"
-			],
-			"symbol": "__ia32_sys_sendto"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 370,
-			"kconfig": "NET",
-			"line": 2662,
-			"name": "sendmsg",
-			"number": 370,
-			"origname": "sendmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_sendmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 371,
-			"kconfig": "NET",
-			"line": 2248,
-			"name": "recvfrom",
-			"number": 371,
-			"origname": "recvfrom",
-			"signature": [
-				"int fd",
-				"void *ubuf",
-				"size_t size",
-				"unsigned int flags",
-				"struct sockaddr *addr",
-				"int *addr_len"
-			],
-			"symbol": "__ia32_sys_recvfrom"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 372,
-			"kconfig": "NET",
-			"line": 2871,
-			"name": "recvmsg",
-			"number": 372,
-			"origname": "recvmsg",
-			"signature": [
-				"int fd",
-				"struct user_msghdr *msg",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_recvmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 373,
-			"kconfig": "NET",
-			"line": 2432,
-			"name": "shutdown",
-			"number": 373,
-			"origname": "shutdown",
-			"signature": [
-				"int fd",
-				"int how"
-			],
-			"symbol": "__ia32_sys_shutdown"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/userfaultfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 374,
-			"kconfig": "USERFAULTFD",
-			"line": 2155,
-			"name": "userfaultfd",
-			"number": 374,
-			"origname": "userfaultfd",
-			"signature": [
-				"int flags"
-			],
-			"symbol": "__ia32_sys_userfaultfd"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/membarrier.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 375,
-			"kconfig": "MEMBARRIER",
-			"line": 625,
-			"name": "membarrier",
-			"number": 375,
-			"origname": "membarrier",
-			"signature": [
-				"int cmd",
-				"unsigned int flags",
-				"int cpu_id"
-			],
-			"symbol": "__ia32_sys_membarrier"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mlock.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 376,
-			"kconfig": "MMU",
-			"line": 664,
-			"name": "mlock2",
-			"number": 376,
-			"origname": "mlock2",
-			"signature": [
-				"unsigned long start",
-				"size_t len",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_mlock2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 377,
-			"kconfig": null,
-			"line": 1637,
-			"name": "copy_file_range",
-			"number": 377,
-			"origname": "copy_file_range",
-			"signature": [
-				"int fd_in",
-				"loff_t *off_in",
-				"int fd_out",
-				"loff_t *off_out",
-				"size_t len",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_copy_file_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 378,
-			"kconfig": null,
-			"line": 1175,
-			"name": "preadv2",
-			"number": 378,
-			"origname": "preadv2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__ia32_sys_preadv2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/read_write.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 379,
-			"kconfig": null,
-			"line": 1195,
-			"name": "pwritev2",
-			"number": 379,
-			"origname": "pwritev2",
-			"signature": [
-				"unsigned long fd",
-				"const struct iovec *vec",
-				"unsigned long vlen",
-				"unsigned long pos_l",
-				"unsigned long pos_h",
-				"rwf_t flags"
-			],
-			"symbol": "__ia32_sys_pwritev2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/stat.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 383,
-			"kconfig": null,
-			"line": 799,
-			"name": "statx",
-			"number": 383,
-			"origname": "statx",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags",
-				"unsigned int mask",
-				"struct statx *buffer"
-			],
-			"symbol": "__ia32_sys_statx"
-		},
-		{
-			"esoteric": false,
-			"file": "arch/x86/kernel/process_32.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 384,
-			"kconfig": null,
-			"line": 219,
-			"name": "arch_prctl",
-			"number": 384,
-			"origname": "arch_prctl",
-			"signature": [
-				"int option",
-				"unsigned long arg2"
-			],
-			"symbol": "__ia32_sys_arch_prctl"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 385,
-			"kconfig": "AIO",
-			"line": 2310,
-			"name": "io_pgetevents",
-			"number": 385,
-			"origname": "io_pgetevents_time32",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct old_timespec32 *timeout",
-				"const struct __aio_sigset *usig"
-			],
-			"symbol": "__ia32_sys_io_pgetevents_time32"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/rseq.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 386,
-			"kconfig": "RSEQ",
-			"line": 452,
-			"name": "rseq",
-			"number": 386,
-			"origname": "rseq",
-			"signature": [
-				"struct rseq *rseq",
-				"u32 rseq_len",
-				"int flags",
-				"u32 sig"
-			],
-			"symbol": "__ia32_sys_rseq"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 393,
-			"kconfig": "SYSVIPC",
-			"line": 624,
-			"name": "semget",
-			"number": 393,
-			"origname": "semget",
-			"signature": [
-				"key_t key",
-				"int nsems",
-				"int semflg"
-			],
-			"symbol": "__ia32_sys_semget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 394,
-			"kconfig": "SYSVIPC",
-			"line": 1705,
-			"name": "semctl",
-			"number": 394,
-			"origname": "semctl",
-			"signature": [
-				"int semid",
-				"int semnum",
-				"int cmd",
-				"unsigned long arg"
-			],
-			"symbol": "__ia32_sys_semctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 395,
-			"kconfig": "SYSVIPC",
-			"line": 842,
-			"name": "shmget",
-			"number": 395,
-			"origname": "shmget",
-			"signature": [
-				"key_t key",
-				"size_t size",
-				"int shmflg"
-			],
-			"symbol": "__ia32_sys_shmget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 396,
-			"kconfig": "SYSVIPC",
-			"line": 1291,
-			"name": "shmctl",
-			"number": 396,
-			"origname": "shmctl",
-			"signature": [
-				"int shmid",
-				"int cmd",
-				"struct shmid_ds *buf"
-			],
-			"symbol": "__ia32_sys_shmctl"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 397,
-			"kconfig": "SYSVIPC",
-			"line": 1688,
-			"name": "shmat",
-			"number": 397,
-			"origname": "shmat",
-			"signature": [
-				"int shmid",
-				"char *shmaddr",
-				"int shmflg"
-			],
-			"symbol": "__ia32_sys_shmat"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/shm.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 398,
-			"kconfig": "SYSVIPC",
-			"line": 1829,
-			"name": "shmdt",
-			"number": 398,
-			"origname": "shmdt",
-			"signature": [
-				"char *shmaddr"
-			],
-			"symbol": "__ia32_sys_shmdt"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 399,
-			"kconfig": "SYSVIPC",
-			"line": 315,
-			"name": "msgget",
-			"number": 399,
-			"origname": "msgget",
-			"signature": [
-				"key_t key",
-				"int msgflg"
-			],
-			"symbol": "__ia32_sys_msgget"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 400,
-			"kconfig": "SYSVIPC",
-			"line": 971,
-			"name": "msgsnd",
-			"number": 400,
-			"origname": "msgsnd",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"int msgflg"
-			],
-			"symbol": "__ia32_sys_msgsnd"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 401,
-			"kconfig": "SYSVIPC",
-			"line": 1270,
-			"name": "msgrcv",
-			"number": 401,
-			"origname": "msgrcv",
-			"signature": [
-				"int msqid",
-				"struct msgbuf *msgp",
-				"size_t msgsz",
-				"long msgtyp",
-				"int msgflg"
-			],
-			"symbol": "__ia32_sys_msgrcv"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/msg.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 402,
-			"kconfig": "SYSVIPC",
-			"line": 640,
-			"name": "msgctl",
-			"number": 402,
-			"origname": "msgctl",
-			"signature": [
-				"int msqid",
-				"int cmd",
-				"struct msqid_ds *buf"
-			],
-			"symbol": "__ia32_sys_msgctl"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 403,
-			"kconfig": null,
-			"line": 1138,
-			"name": "clock_gettime",
-			"number": 403,
-			"origname": "clock_gettime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__ia32_sys_clock_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 404,
-			"kconfig": null,
-			"line": 1119,
-			"name": "clock_settime",
-			"number": 404,
-			"origname": "clock_settime",
-			"signature": [
-				"const clockid_t which_clock",
-				"const struct __kernel_timespec *tp"
-			],
-			"symbol": "__ia32_sys_clock_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 405,
-			"kconfig": null,
-			"line": 1168,
-			"name": "clock_adjtime",
-			"number": 405,
-			"origname": "clock_adjtime",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timex *utx"
-			],
-			"symbol": "__ia32_sys_clock_adjtime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 406,
-			"kconfig": null,
-			"line": 1258,
-			"name": "clock_getres",
-			"number": 406,
-			"origname": "clock_getres",
-			"signature": [
-				"const clockid_t which_clock",
-				"struct __kernel_timespec *tp"
-			],
-			"symbol": "__ia32_sys_clock_getres"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 407,
-			"kconfig": null,
-			"line": 1379,
-			"name": "clock_nanosleep",
-			"number": 407,
-			"origname": "clock_nanosleep",
-			"signature": [
-				"const clockid_t which_clock",
-				"int flags",
-				"const struct __kernel_timespec *rqtp",
-				"struct __kernel_timespec *rmtp"
-			],
-			"symbol": "__ia32_sys_clock_nanosleep"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 408,
-			"kconfig": "POSIX_TIMERS",
-			"line": 676,
-			"name": "timer_gettime",
-			"number": 408,
-			"origname": "timer_gettime",
-			"signature": [
-				"timer_t timer_id",
-				"struct __kernel_itimerspec *setting"
-			],
-			"symbol": "__ia32_sys_timer_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/time/posix-timers.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 409,
-			"kconfig": "POSIX_TIMERS",
-			"line": 914,
-			"name": "timer_settime",
-			"number": 409,
-			"origname": "timer_settime",
-			"signature": [
-				"timer_t timer_id",
-				"int flags",
-				"const struct __kernel_itimerspec *new_setting",
-				"struct __kernel_itimerspec *old_setting"
-			],
-			"symbol": "__ia32_sys_timer_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 410,
-			"kconfig": null,
-			"line": 578,
-			"name": "timerfd_gettime",
-			"number": 410,
-			"origname": "timerfd_gettime",
-			"signature": [
-				"int ufd",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__ia32_sys_timerfd_gettime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/timerfd.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 411,
-			"kconfig": null,
-			"line": 560,
-			"name": "timerfd_settime",
-			"number": 411,
-			"origname": "timerfd_settime",
-			"signature": [
-				"int ufd",
-				"int flags",
-				"const struct __kernel_itimerspec *utmr",
-				"struct __kernel_itimerspec *otmr"
-			],
-			"symbol": "__ia32_sys_timerfd_settime"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/utimes.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 412,
-			"kconfig": null,
-			"line": 143,
-			"name": "utimensat",
-			"number": 412,
-			"origname": "utimensat",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct __kernel_timespec *utimes",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_utimensat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 413,
-			"kconfig": null,
-			"line": 793,
-			"name": "pselect6",
-			"number": 413,
-			"origname": "pselect6",
-			"signature": [
-				"int n",
-				"fd_set *inp",
-				"fd_set *outp",
-				"fd_set *exp",
-				"struct __kernel_timespec *tsp",
-				"void *sig"
-			],
-			"symbol": "__ia32_sys_pselect6"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/select.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 414,
-			"kconfig": null,
-			"line": 1095,
-			"name": "ppoll",
-			"number": 414,
-			"origname": "ppoll",
-			"signature": [
-				"struct pollfd *ufds",
-				"unsigned int nfds",
-				"struct __kernel_timespec *tsp",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_ppoll"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/aio.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 416,
-			"kconfig": "AIO",
-			"line": 2275,
-			"name": "io_pgetevents",
-			"number": 416,
-			"origname": "io_pgetevents",
-			"signature": [
-				"aio_context_t ctx_id",
-				"long min_nr",
-				"long nr",
-				"struct io_event *events",
-				"struct __kernel_timespec *timeout",
-				"const struct __aio_sigset *usig"
-			],
-			"symbol": "__ia32_sys_io_pgetevents"
-		},
-		{
-			"esoteric": false,
-			"file": "net/socket.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 417,
-			"kconfig": "NET",
-			"line": 3020,
-			"name": "recvmmsg",
-			"number": 417,
-			"origname": "recvmmsg",
-			"signature": [
-				"int fd",
-				"struct mmsghdr *mmsg",
-				"unsigned int vlen",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout"
-			],
-			"symbol": "__ia32_sys_recvmmsg"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 418,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1258,
-			"name": "mq_timedsend",
-			"number": 418,
-			"origname": "mq_timedsend",
-			"signature": [
-				"mqd_t mqdes",
-				"const char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__ia32_sys_mq_timedsend"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/mqueue.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 419,
-			"kconfig": "POSIX_MQUEUE",
-			"line": 1272,
-			"name": "mq_timedreceive",
-			"number": 419,
-			"origname": "mq_timedreceive",
-			"signature": [
-				"mqd_t mqdes",
-				"char *u_msg_ptr",
-				"size_t msg_len",
-				"unsigned int *u_msg_prio",
-				"const struct __kernel_timespec *u_abs_timeout"
-			],
-			"symbol": "__ia32_sys_mq_timedreceive"
-		},
-		{
-			"esoteric": false,
-			"file": "ipc/sem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 420,
-			"kconfig": "SYSVIPC",
-			"line": 2268,
-			"name": "semtimedop",
-			"number": 420,
-			"origname": "semtimedop",
-			"signature": [
-				"int semid",
-				"struct sembuf *tsops",
-				"unsigned int nsops",
-				"const struct __kernel_timespec *timeout"
-			],
-			"symbol": "__ia32_sys_semtimedop"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 421,
-			"kconfig": null,
-			"line": 3806,
-			"name": "rt_sigtimedwait",
-			"number": 421,
-			"origname": "rt_sigtimedwait",
-			"signature": [
-				"const sigset_t *uthese",
-				"siginfo_t *uinfo",
-				"const struct __kernel_timespec *uts",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_rt_sigtimedwait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 422,
-			"kconfig": "FUTEX",
-			"line": 160,
-			"name": "futex",
-			"number": 422,
-			"origname": "futex",
-			"signature": [
-				"u32 *uaddr",
-				"int op",
-				"u32 val",
-				"const struct __kernel_timespec *utime",
-				"u32 *uaddr2",
-				"u32 val3"
-			],
-			"symbol": "__ia32_sys_futex"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/sched/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 423,
-			"kconfig": null,
-			"line": 1571,
-			"name": "sched_rr_get_interval",
-			"number": 423,
-			"origname": "sched_rr_get_interval",
-			"signature": [
-				"pid_t pid",
-				"struct __kernel_timespec *interval"
-			],
-			"symbol": "__ia32_sys_sched_rr_get_interval"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/signal.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 424,
-			"kconfig": null,
-			"line": 4026,
-			"name": "pidfd_send_signal",
-			"number": 424,
-			"origname": "pidfd_send_signal",
-			"signature": [
-				"int pidfd",
-				"int sig",
-				"siginfo_t *info",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_pidfd_send_signal"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 425,
-			"kconfig": "IO_URING",
-			"line": 3814,
-			"name": "io_uring_setup",
-			"number": 425,
-			"origname": "io_uring_setup",
-			"signature": [
-				"u32 entries",
-				"struct io_uring_params *params"
-			],
-			"symbol": "__ia32_sys_io_uring_setup"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/io_uring.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 426,
-			"kconfig": "IO_URING",
-			"line": 3307,
-			"name": "io_uring_enter",
-			"number": 426,
-			"origname": "io_uring_enter",
-			"signature": [
-				"unsigned int fd",
-				"u32 to_submit",
-				"u32 min_complete",
-				"u32 flags",
-				"const void *argp",
-				"size_t argsz"
-			],
-			"symbol": "__ia32_sys_io_uring_enter"
-		},
-		{
-			"esoteric": false,
-			"file": "io_uring/register.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 427,
-			"kconfig": "IO_URING",
-			"line": 896,
-			"name": "io_uring_register",
-			"number": 427,
-			"origname": "io_uring_register",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int opcode",
-				"void *arg",
-				"unsigned int nr_args"
-			],
-			"symbol": "__ia32_sys_io_uring_register"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 428,
-			"kconfig": null,
-			"line": 2892,
-			"name": "open_tree",
-			"number": 428,
-			"origname": "open_tree",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"unsigned flags"
-			],
-			"symbol": "__ia32_sys_open_tree"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 429,
-			"kconfig": null,
-			"line": 4280,
-			"name": "move_mount",
-			"number": 429,
-			"origname": "move_mount",
-			"signature": [
-				"int from_dfd",
-				"const char *from_pathname",
-				"int to_dfd",
-				"const char *to_pathname",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_move_mount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 430,
-			"kconfig": null,
-			"line": 114,
-			"name": "fsopen",
-			"number": 430,
-			"origname": "fsopen",
-			"signature": [
-				"const char *_fs_name",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_fsopen"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 431,
-			"kconfig": null,
-			"line": 344,
-			"name": "fsconfig",
-			"number": 431,
-			"origname": "fsconfig",
-			"signature": [
-				"int fd",
-				"unsigned int cmd",
-				"const char *_key",
-				"const void *_value",
-				"int aux"
-			],
-			"symbol": "__ia32_sys_fsconfig"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 432,
-			"kconfig": null,
-			"line": 4156,
-			"name": "fsmount",
-			"number": 432,
-			"origname": "fsmount",
-			"signature": [
-				"int fs_fd",
-				"unsigned int flags",
-				"unsigned int attr_flags"
-			],
-			"symbol": "__ia32_sys_fsmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/fsopen.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 433,
-			"kconfig": null,
-			"line": 157,
-			"name": "fspick",
-			"number": 433,
-			"origname": "fspick",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_fspick"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 434,
-			"kconfig": null,
-			"line": 626,
-			"name": "pidfd_open",
-			"number": 434,
-			"origname": "pidfd_open",
-			"signature": [
-				"pid_t pid",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_pidfd_open"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/fork.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 435,
-			"kconfig": null,
-			"line": 3098,
-			"name": "clone3",
-			"number": 435,
-			"origname": "clone3",
-			"signature": [
-				"struct clone_args *uargs",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_clone3"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/file.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 436,
-			"kconfig": null,
-			"line": 769,
-			"name": "close_range",
-			"number": 436,
-			"origname": "close_range",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int max_fd",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_close_range"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 437,
-			"kconfig": null,
-			"line": 1462,
-			"name": "openat2",
-			"number": 437,
-			"origname": "openat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"struct open_how *how",
-				"size_t usize"
-			],
-			"symbol": "__ia32_sys_openat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/pid.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 438,
-			"kconfig": null,
-			"line": 854,
-			"name": "pidfd_getfd",
-			"number": 438,
-			"origname": "pidfd_getfd",
-			"signature": [
-				"int pidfd",
-				"int fd",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_pidfd_getfd"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 439,
-			"kconfig": null,
-			"line": 540,
-			"name": "faccessat2",
-			"number": 439,
-			"origname": "faccessat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"int mode",
-				"int flags"
-			],
-			"symbol": "__ia32_sys_faccessat2"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/madvise.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 440,
-			"kconfig": "ADVISE_SYSCALLS",
-			"line": 1756,
-			"name": "process_madvise",
-			"number": 440,
-			"origname": "process_madvise",
-			"signature": [
-				"int pidfd",
-				"const struct iovec *vec",
-				"size_t vlen",
-				"int behavior",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_process_madvise"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/eventpoll.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 441,
-			"kconfig": "EPOLL",
-			"line": 2532,
-			"name": "epoll_pwait2",
-			"number": 441,
-			"origname": "epoll_pwait2",
-			"signature": [
-				"int epfd",
-				"struct epoll_event *events",
-				"int maxevents",
-				"const struct __kernel_timespec *timeout",
-				"const sigset_t *sigmask",
-				"size_t sigsetsize"
-			],
-			"symbol": "__ia32_sys_epoll_pwait2"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 442,
-			"kconfig": null,
-			"line": 4847,
-			"name": "mount_setattr",
-			"number": 442,
-			"origname": "mount_setattr",
-			"signature": [
-				"int dfd",
-				"const char *path",
-				"unsigned int flags",
-				"struct mount_attr *uattr",
-				"size_t usize"
-			],
-			"symbol": "__ia32_sys_mount_setattr"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/quota/quota.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 443,
-			"kconfig": "QUOTACTL",
-			"line": 973,
-			"name": "quotactl_fd",
-			"number": 443,
-			"origname": "quotactl_fd",
-			"signature": [
-				"unsigned int fd",
-				"unsigned int cmd",
-				"qid_t id",
-				"void *addr"
-			],
-			"symbol": "__ia32_sys_quotactl_fd"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 444,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 180,
-			"name": "landlock_create_ruleset",
-			"number": 444,
-			"origname": "landlock_create_ruleset",
-			"signature": [
-				"const struct landlock_ruleset_attr *const attr",
-				"const size_t size",
-				"const __u32 flags"
-			],
-			"symbol": "__ia32_sys_landlock_create_ruleset"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 445,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 398,
-			"name": "landlock_add_rule",
-			"number": 445,
-			"origname": "landlock_add_rule",
-			"signature": [
-				"const int ruleset_fd",
-				"const enum landlock_rule_type rule_type",
-				"const void *const rule_attr",
-				"const __u32 flags"
-			],
-			"symbol": "__ia32_sys_landlock_add_rule"
-		},
-		{
-			"esoteric": false,
-			"file": "security/landlock/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 446,
-			"kconfig": "SECURITY_LANDLOCK",
-			"line": 451,
-			"name": "landlock_restrict_self",
-			"number": 446,
-			"origname": "landlock_restrict_self",
-			"signature": [
-				"const int ruleset_fd",
-				"const __u32 flags"
-			],
-			"symbol": "__ia32_sys_landlock_restrict_self"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/secretmem.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 447,
-			"kconfig": "SECRETMEM",
-			"line": 232,
-			"name": "memfd_secret",
-			"number": 447,
-			"origname": "memfd_secret",
-			"signature": [
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_memfd_secret"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/oom_kill.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 448,
-			"kconfig": "MMU",
-			"line": 1204,
-			"name": "process_mrelease",
-			"number": 448,
-			"origname": "process_mrelease",
-			"signature": [
-				"int pidfd",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_process_mrelease"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 449,
-			"kconfig": "FUTEX",
-			"line": 290,
-			"name": "futex_waitv",
-			"number": 449,
-			"origname": "futex_waitv",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int nr_futexes",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__ia32_sys_futex_waitv"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/mempolicy.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 450,
-			"kconfig": "NUMA",
-			"line": 1540,
-			"name": "set_mempolicy_home_node",
-			"number": 450,
-			"origname": "set_mempolicy_home_node",
-			"signature": [
-				"unsigned long start",
-				"unsigned long len",
-				"unsigned long home_node",
-				"unsigned long flags"
-			],
-			"symbol": "__ia32_sys_set_mempolicy_home_node"
-		},
-		{
-			"esoteric": false,
-			"file": "mm/filemap.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 451,
-			"kconfig": "CACHESTAT_SYSCALL",
-			"line": 4498,
-			"name": "cachestat",
-			"number": 451,
-			"origname": "cachestat",
-			"signature": [
-				"unsigned int fd",
-				"struct cachestat_range *cstat_range",
-				"struct cachestat *cstat",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_cachestat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/open.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 452,
-			"kconfig": null,
-			"line": 700,
-			"name": "fchmodat2",
-			"number": 452,
-			"origname": "fchmodat2",
-			"signature": [
-				"int dfd",
-				"const char *filename",
-				"umode_t mode",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_fchmodat2"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 454,
-			"kconfig": "FUTEX",
-			"line": 338,
-			"name": "futex_wake",
-			"number": 454,
-			"origname": "futex_wake",
-			"signature": [
-				"void *uaddr",
-				"unsigned long mask",
-				"int nr",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_futex_wake"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 455,
-			"kconfig": "FUTEX",
-			"line": 370,
-			"name": "futex_wait",
-			"number": 455,
-			"origname": "futex_wait",
-			"signature": [
-				"void *uaddr",
-				"unsigned long val",
-				"unsigned long mask",
-				"unsigned int flags",
-				"struct __kernel_timespec *timeout",
-				"clockid_t clockid"
-			],
-			"symbol": "__ia32_sys_futex_wait"
-		},
-		{
-			"esoteric": false,
-			"file": "kernel/futex/syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 456,
-			"kconfig": "FUTEX",
-			"line": 414,
-			"name": "futex_requeue",
-			"number": 456,
-			"origname": "futex_requeue",
-			"signature": [
-				"struct futex_waitv *waiters",
-				"unsigned int flags",
-				"int nr_wake",
-				"int nr_requeue"
-			],
-			"symbol": "__ia32_sys_futex_requeue"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 457,
-			"kconfig": null,
-			"line": 5508,
-			"name": "statmount",
-			"number": 457,
-			"origname": "statmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"struct statmount *buf",
-				"size_t bufsize",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_statmount"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/namespace.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 458,
-			"kconfig": null,
-			"line": 5615,
-			"name": "listmount",
-			"number": 458,
-			"origname": "listmount",
-			"signature": [
-				"const struct mnt_id_req *req",
-				"u64 *mnt_ids",
-				"size_t nr_mnt_ids",
-				"unsigned int flags"
-			],
-			"symbol": "__ia32_sys_listmount"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 459,
-			"kconfig": "SECURITY",
-			"line": 77,
-			"name": "lsm_get_self_attr",
-			"number": 459,
-			"origname": "lsm_get_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__ia32_sys_lsm_get_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 460,
-			"kconfig": "SECURITY",
-			"line": 55,
-			"name": "lsm_set_self_attr",
-			"number": 460,
-			"origname": "lsm_set_self_attr",
-			"signature": [
-				"unsigned int attr",
-				"struct lsm_ctx *ctx",
-				"u32 size",
-				"u32 flags"
-			],
-			"symbol": "__ia32_sys_lsm_set_self_attr"
-		},
-		{
-			"esoteric": false,
-			"file": "security/lsm_syscalls.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 461,
-			"kconfig": "SECURITY",
-			"line": 96,
-			"name": "lsm_list_modules",
-			"number": 461,
-			"origname": "lsm_list_modules",
-			"signature": [
-				"u64 *ids",
-				"u32 *size",
-				"u32 flags"
-			],
-			"symbol": "__ia32_sys_lsm_list_modules"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 463,
-			"kconfig": null,
-			"line": 719,
-			"name": "setxattrat",
-			"number": 463,
-			"origname": "setxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"const struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__ia32_sys_setxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 464,
-			"kconfig": null,
-			"line": 863,
-			"name": "getxattrat",
-			"number": 464,
-			"origname": "getxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name",
-				"struct xattr_args *uargs",
-				"size_t usize"
-			],
-			"symbol": "__ia32_sys_getxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 465,
-			"kconfig": null,
-			"line": 991,
-			"name": "listxattrat",
-			"number": 465,
-			"origname": "listxattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"char *list",
-				"size_t size"
-			],
-			"symbol": "__ia32_sys_listxattrat"
-		},
-		{
-			"esoteric": false,
-			"file": "fs/xattr.c",
-			"good_location": true,
-			"grepped_location": false,
-			"index": 466,
-			"kconfig": null,
-			"line": 1091,
-			"name": "removexattrat",
-			"number": 466,
-			"origname": "removexattrat",
-			"signature": [
-				"int dfd",
-				"const char *pathname",
-				"unsigned int at_flags",
-				"const char *name"
-			],
-			"symbol": "__ia32_sys_removexattrat"
-		}
-	],
-	"systrack_version": "0.7"
+    "syscalls": [
+        {
+            "name": "restart_syscall",
+            "number": 0,
+            "signature": []
+        },
+        {
+            "name": "exit",
+            "number": 1,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "fork",
+            "number": 2,
+            "signature": []
+        },
+        {
+            "name": "read",
+            "number": 3,
+            "signature": [
+                "unsigned int fd",
+                "char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "write",
+            "number": 4,
+            "signature": [
+                "unsigned int fd",
+                "const char *buf",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "open",
+            "number": 5,
+            "signature": [
+                "const char *filename",
+                "int flags",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "close",
+            "number": 6,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "waitpid",
+            "number": 7,
+            "signature": [
+                "pid_t pid",
+                "int *stat_addr",
+                "int options"
+            ]
+        },
+        {
+            "name": "creat",
+            "number": 8,
+            "signature": [
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "link",
+            "number": 9,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "unlink",
+            "number": 10,
+            "signature": [
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "execve",
+            "number": 11,
+            "signature": [
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp"
+            ]
+        },
+        {
+            "name": "chdir",
+            "number": 12,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "time",
+            "number": 13,
+            "signature": [
+                "old_time32_t *tloc"
+            ]
+        },
+        {
+            "name": "mknod",
+            "number": 14,
+            "signature": [
+                "const char *filename",
+                "umode_t mode",
+                "unsigned dev"
+            ]
+        },
+        {
+            "name": "chmod",
+            "number": 15,
+            "signature": [
+                "const char *filename",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "lchown16",
+            "number": 16,
+            "signature": [
+                "const char *filename",
+                "old_uid_t user",
+                "old_gid_t group"
+            ]
+        },
+        {
+            "name": "stat",
+            "number": 18,
+            "signature": [
+                "const char *filename",
+                "struct __old_kernel_stat *statbuf"
+            ]
+        },
+        {
+            "name": "lseek",
+            "number": 19,
+            "signature": [
+                "unsigned int fd",
+                "off_t offset",
+                "unsigned int whence"
+            ]
+        },
+        {
+            "name": "getpid",
+            "number": 20,
+            "signature": []
+        },
+        {
+            "name": "mount",
+            "number": 21,
+            "signature": [
+                "char *dev_name",
+                "char *dir_name",
+                "char *type",
+                "unsigned long flags",
+                "void *data"
+            ]
+        },
+        {
+            "name": "oldumount",
+            "number": 22,
+            "signature": [
+                "char *name"
+            ]
+        },
+        {
+            "name": "setuid16",
+            "number": 23,
+            "signature": [
+                "old_uid_t uid"
+            ]
+        },
+        {
+            "name": "getuid16",
+            "number": 24,
+            "signature": []
+        },
+        {
+            "name": "stime",
+            "number": 25,
+            "signature": [
+                "old_time32_t *tptr"
+            ]
+        },
+        {
+            "name": "ptrace",
+            "number": 26,
+            "signature": [
+                "long request",
+                "long pid",
+                "unsigned long addr",
+                "unsigned long data"
+            ]
+        },
+        {
+            "name": "alarm",
+            "number": 27,
+            "signature": [
+                "unsigned int seconds"
+            ]
+        },
+        {
+            "name": "fstat",
+            "number": 28,
+            "signature": [
+                "unsigned int fd",
+                "struct __old_kernel_stat *statbuf"
+            ]
+        },
+        {
+            "name": "pause",
+            "number": 29,
+            "signature": []
+        },
+        {
+            "name": "utime",
+            "number": 30,
+            "signature": [
+                "const char *filename",
+                "struct old_utimbuf32 *t"
+            ]
+        },
+        {
+            "name": "access",
+            "number": 33,
+            "signature": [
+                "const char *filename",
+                "int mode"
+            ]
+        },
+        {
+            "name": "nice",
+            "number": 34,
+            "signature": [
+                "int increment"
+            ]
+        },
+        {
+            "name": "sync",
+            "number": 36,
+            "signature": []
+        },
+        {
+            "name": "kill",
+            "number": 37,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "rename",
+            "number": 38,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "mkdir",
+            "number": 39,
+            "signature": [
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "rmdir",
+            "number": 40,
+            "signature": [
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "dup",
+            "number": 41,
+            "signature": [
+                "unsigned int fildes"
+            ]
+        },
+        {
+            "name": "pipe",
+            "number": 42,
+            "signature": [
+                "int *fildes"
+            ]
+        },
+        {
+            "name": "times",
+            "number": 43,
+            "signature": [
+                "struct tms *tbuf"
+            ]
+        },
+        {
+            "name": "brk",
+            "number": 45,
+            "signature": [
+                "unsigned long brk"
+            ]
+        },
+        {
+            "name": "setgid16",
+            "number": 46,
+            "signature": [
+                "old_gid_t gid"
+            ]
+        },
+        {
+            "name": "getgid16",
+            "number": 47,
+            "signature": []
+        },
+        {
+            "name": "signal",
+            "number": 48,
+            "signature": [
+                "int sig",
+                "__sighandler_t handler"
+            ]
+        },
+        {
+            "name": "geteuid16",
+            "number": 49,
+            "signature": []
+        },
+        {
+            "name": "getegid16",
+            "number": 50,
+            "signature": []
+        },
+        {
+            "name": "acct",
+            "number": 51,
+            "signature": [
+                "const char *name"
+            ]
+        },
+        {
+            "name": "umount",
+            "number": 52,
+            "signature": [
+                "char *name",
+                "int flags"
+            ]
+        },
+        {
+            "name": "ioctl",
+            "number": 54,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "fcntl",
+            "number": 55,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "setpgid",
+            "number": 57,
+            "signature": [
+                "pid_t pid",
+                "pid_t pgid"
+            ]
+        },
+        {
+            "name": "olduname",
+            "number": 59,
+            "signature": [
+                "struct oldold_utsname *name"
+            ]
+        },
+        {
+            "name": "umask",
+            "number": 60,
+            "signature": [
+                "int mask"
+            ]
+        },
+        {
+            "name": "chroot",
+            "number": 61,
+            "signature": [
+                "const char *filename"
+            ]
+        },
+        {
+            "name": "ustat",
+            "number": 62,
+            "signature": [
+                "unsigned dev",
+                "struct ustat *ubuf"
+            ]
+        },
+        {
+            "name": "dup2",
+            "number": 63,
+            "signature": [
+                "unsigned int oldfd",
+                "unsigned int newfd"
+            ]
+        },
+        {
+            "name": "getppid",
+            "number": 64,
+            "signature": []
+        },
+        {
+            "name": "getpgrp",
+            "number": 65,
+            "signature": []
+        },
+        {
+            "name": "setsid",
+            "number": 66,
+            "signature": []
+        },
+        {
+            "name": "sigaction",
+            "number": 67,
+            "signature": [
+                "int sig",
+                "const struct old_sigaction *act",
+                "struct old_sigaction *oact"
+            ]
+        },
+        {
+            "name": "sgetmask",
+            "number": 68,
+            "signature": []
+        },
+        {
+            "name": "ssetmask",
+            "number": 69,
+            "signature": [
+                "int newmask"
+            ]
+        },
+        {
+            "name": "setreuid16",
+            "number": 70,
+            "signature": [
+                "old_uid_t ruid",
+                "old_uid_t euid"
+            ]
+        },
+        {
+            "name": "setregid16",
+            "number": 71,
+            "signature": [
+                "old_gid_t rgid",
+                "old_gid_t egid"
+            ]
+        },
+        {
+            "name": "sigsuspend",
+            "number": 72,
+            "signature": [
+                "int unused1",
+                "int unused2",
+                "old_sigset_t mask"
+            ]
+        },
+        {
+            "name": "sigpending",
+            "number": 73,
+            "signature": [
+                "old_sigset_t *uset"
+            ]
+        },
+        {
+            "name": "sethostname",
+            "number": 74,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "setrlimit",
+            "number": 75,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "getrlimit",
+            "number": 76,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "getrusage",
+            "number": 77,
+            "signature": [
+                "int who",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "gettimeofday",
+            "number": 78,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "settimeofday",
+            "number": 79,
+            "signature": [
+                "struct __kernel_old_timeval *tv",
+                "struct timezone *tz"
+            ]
+        },
+        {
+            "name": "getgroups16",
+            "number": 80,
+            "signature": [
+                "int gidsetsize",
+                "old_gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "setgroups16",
+            "number": 81,
+            "signature": [
+                "int gidsetsize",
+                "old_gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "select",
+            "number": 82,
+            "signature": [
+                "struct sel_arg_struct *arg"
+            ]
+        },
+        {
+            "name": "symlink",
+            "number": 83,
+            "signature": [
+                "const char *oldname",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "lstat",
+            "number": 84,
+            "signature": [
+                "const char *filename",
+                "struct __old_kernel_stat *statbuf"
+            ]
+        },
+        {
+            "name": "readlink",
+            "number": 85,
+            "signature": [
+                "const char *path",
+                "char *buf",
+                "int bufsiz"
+            ]
+        },
+        {
+            "name": "uselib",
+            "number": 86,
+            "signature": [
+                "const char *library"
+            ]
+        },
+        {
+            "name": "swapon",
+            "number": 87,
+            "signature": [
+                "const char *specialfile",
+                "int swap_flags"
+            ]
+        },
+        {
+            "name": "reboot",
+            "number": 88,
+            "signature": [
+                "int magic1",
+                "int magic2",
+                "unsigned int cmd",
+                "void *arg"
+            ]
+        },
+        {
+            "name": "readdir",
+            "number": 89,
+            "signature": [
+                "unsigned int fd",
+                "struct old_linux_dirent *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "mmap",
+            "number": 90,
+            "signature": [
+                "struct mmap_arg_struct *arg"
+            ]
+        },
+        {
+            "name": "munmap",
+            "number": 91,
+            "signature": [
+                "unsigned long addr",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "truncate",
+            "number": 92,
+            "signature": [
+                "const char *path",
+                "long length"
+            ]
+        },
+        {
+            "name": "ftruncate",
+            "number": 93,
+            "signature": [
+                "unsigned int fd",
+                "off_t length"
+            ]
+        },
+        {
+            "name": "fchmod",
+            "number": 94,
+            "signature": [
+                "unsigned int fd",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "fchown16",
+            "number": 95,
+            "signature": [
+                "unsigned int fd",
+                "old_uid_t user",
+                "old_gid_t group"
+            ]
+        },
+        {
+            "name": "getpriority",
+            "number": 96,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "setpriority",
+            "number": 97,
+            "signature": [
+                "int which",
+                "int who",
+                "int niceval"
+            ]
+        },
+        {
+            "name": "statfs",
+            "number": 99,
+            "signature": [
+                "const char *pathname",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "fstatfs",
+            "number": 100,
+            "signature": [
+                "unsigned int fd",
+                "struct statfs *buf"
+            ]
+        },
+        {
+            "name": "ioperm",
+            "number": 101,
+            "signature": [
+                "unsigned long from",
+                "unsigned long num",
+                "int turn_on"
+            ]
+        },
+        {
+            "name": "socketcall",
+            "number": 102,
+            "signature": [
+                "int call",
+                "unsigned long *args"
+            ]
+        },
+        {
+            "name": "syslog",
+            "number": 103,
+            "signature": [
+                "int type",
+                "char *buf",
+                "int len"
+            ]
+        },
+        {
+            "name": "setitimer",
+            "number": 104,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value",
+                "struct __kernel_old_itimerval *ovalue"
+            ]
+        },
+        {
+            "name": "getitimer",
+            "number": 105,
+            "signature": [
+                "int which",
+                "struct __kernel_old_itimerval *value"
+            ]
+        },
+        {
+            "name": "newstat",
+            "number": 106,
+            "signature": [
+                "const char *filename",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "newlstat",
+            "number": 107,
+            "signature": [
+                "const char *filename",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "newfstat",
+            "number": 108,
+            "signature": [
+                "unsigned int fd",
+                "struct stat *statbuf"
+            ]
+        },
+        {
+            "name": "uname",
+            "number": 109,
+            "signature": [
+                "struct old_utsname *name"
+            ]
+        },
+        {
+            "name": "iopl",
+            "number": 110,
+            "signature": [
+                "unsigned int level"
+            ]
+        },
+        {
+            "name": "vhangup",
+            "number": 111,
+            "signature": []
+        },
+        {
+            "name": "vm86old",
+            "number": 113,
+            "signature": [
+                "struct vm86_struct *user_vm86"
+            ]
+        },
+        {
+            "name": "wait4",
+            "number": 114,
+            "signature": [
+                "pid_t upid",
+                "int *stat_addr",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "swapoff",
+            "number": 115,
+            "signature": [
+                "const char *specialfile"
+            ]
+        },
+        {
+            "name": "sysinfo",
+            "number": 116,
+            "signature": [
+                "struct sysinfo *info"
+            ]
+        },
+        {
+            "name": "ipc",
+            "number": 117,
+            "signature": [
+                "unsigned int call",
+                "int first",
+                "unsigned long second",
+                "unsigned long third",
+                "void *ptr",
+                "long fifth"
+            ]
+        },
+        {
+            "name": "fsync",
+            "number": 118,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "sigreturn",
+            "number": 119,
+            "signature": []
+        },
+        {
+            "name": "clone",
+            "number": 120,
+            "signature": [
+                "unsigned long clone_flags",
+                "unsigned long newsp",
+                "int *parent_tidptr",
+                "unsigned long tls",
+                "int *child_tidptr"
+            ]
+        },
+        {
+            "name": "setdomainname",
+            "number": 121,
+            "signature": [
+                "char *name",
+                "int len"
+            ]
+        },
+        {
+            "name": "newuname",
+            "number": 122,
+            "signature": [
+                "struct new_utsname *name"
+            ]
+        },
+        {
+            "name": "modify_ldt",
+            "number": 123,
+            "signature": [
+                "int func",
+                "void *ptr",
+                "unsigned long bytecount"
+            ]
+        },
+        {
+            "name": "adjtimex",
+            "number": 124,
+            "signature": [
+                "struct old_timex32 *utp"
+            ]
+        },
+        {
+            "name": "mprotect",
+            "number": 125,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned long prot"
+            ]
+        },
+        {
+            "name": "sigprocmask",
+            "number": 126,
+            "signature": [
+                "int how",
+                "old_sigset_t *nset",
+                "old_sigset_t *oset"
+            ]
+        },
+        {
+            "name": "init_module",
+            "number": 128,
+            "signature": [
+                "void *umod",
+                "unsigned long len",
+                "const char *uargs"
+            ]
+        },
+        {
+            "name": "delete_module",
+            "number": 129,
+            "signature": [
+                "const char *name_user",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "quotactl",
+            "number": 131,
+            "signature": [
+                "unsigned int cmd",
+                "const char *special",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "getpgid",
+            "number": 132,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "fchdir",
+            "number": 133,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "sysfs",
+            "number": 135,
+            "signature": [
+                "int option",
+                "unsigned long arg1",
+                "unsigned long arg2"
+            ]
+        },
+        {
+            "name": "personality",
+            "number": 136,
+            "signature": [
+                "unsigned int personality"
+            ]
+        },
+        {
+            "name": "setfsuid16",
+            "number": 138,
+            "signature": [
+                "old_uid_t uid"
+            ]
+        },
+        {
+            "name": "setfsgid16",
+            "number": 139,
+            "signature": [
+                "old_gid_t gid"
+            ]
+        },
+        {
+            "name": "llseek",
+            "number": 140,
+            "signature": [
+                "unsigned int fd",
+                "unsigned long offset_high",
+                "unsigned long offset_low",
+                "loff_t *result",
+                "unsigned int whence"
+            ]
+        },
+        {
+            "name": "getdents",
+            "number": 141,
+            "signature": [
+                "unsigned int fd",
+                "struct linux_dirent *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "select",
+            "number": 142,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct __kernel_old_timeval *tvp"
+            ]
+        },
+        {
+            "name": "flock",
+            "number": 143,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd"
+            ]
+        },
+        {
+            "name": "msync",
+            "number": 144,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "readv",
+            "number": 145,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "writev",
+            "number": 146,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen"
+            ]
+        },
+        {
+            "name": "getsid",
+            "number": 147,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "fdatasync",
+            "number": 148,
+            "signature": [
+                "unsigned int fd"
+            ]
+        },
+        {
+            "name": "mlock",
+            "number": 150,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "munlock",
+            "number": 151,
+            "signature": [
+                "unsigned long start",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "mlockall",
+            "number": 152,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "munlockall",
+            "number": 153,
+            "signature": []
+        },
+        {
+            "name": "sched_setparam",
+            "number": 154,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_getparam",
+            "number": 155,
+            "signature": [
+                "pid_t pid",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_setscheduler",
+            "number": 156,
+            "signature": [
+                "pid_t pid",
+                "int policy",
+                "struct sched_param *param"
+            ]
+        },
+        {
+            "name": "sched_getscheduler",
+            "number": 157,
+            "signature": [
+                "pid_t pid"
+            ]
+        },
+        {
+            "name": "sched_yield",
+            "number": 158,
+            "signature": []
+        },
+        {
+            "name": "sched_get_priority_max",
+            "number": 159,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_get_priority_min",
+            "number": 160,
+            "signature": [
+                "int policy"
+            ]
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "number": 161,
+            "signature": [
+                "pid_t pid",
+                "struct old_timespec32 *interval"
+            ]
+        },
+        {
+            "name": "nanosleep",
+            "number": 162,
+            "signature": [
+                "struct old_timespec32 *rqtp",
+                "struct old_timespec32 *rmtp"
+            ]
+        },
+        {
+            "name": "mremap",
+            "number": 163,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long old_len",
+                "unsigned long new_len",
+                "unsigned long flags",
+                "unsigned long new_addr"
+            ]
+        },
+        {
+            "name": "setresuid16",
+            "number": 164,
+            "signature": [
+                "old_uid_t ruid",
+                "old_uid_t euid",
+                "old_uid_t suid"
+            ]
+        },
+        {
+            "name": "getresuid16",
+            "number": 165,
+            "signature": [
+                "old_uid_t *ruidp",
+                "old_uid_t *euidp",
+                "old_uid_t *suidp"
+            ]
+        },
+        {
+            "name": "vm86",
+            "number": 166,
+            "signature": [
+                "unsigned long cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "poll",
+            "number": 168,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "int timeout_msecs"
+            ]
+        },
+        {
+            "name": "setresgid16",
+            "number": 170,
+            "signature": [
+                "old_gid_t rgid",
+                "old_gid_t egid",
+                "old_gid_t sgid"
+            ]
+        },
+        {
+            "name": "getresgid16",
+            "number": 171,
+            "signature": [
+                "old_gid_t *rgidp",
+                "old_gid_t *egidp",
+                "old_gid_t *sgidp"
+            ]
+        },
+        {
+            "name": "prctl",
+            "number": 172,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "rt_sigreturn",
+            "number": 173,
+            "signature": []
+        },
+        {
+            "name": "rt_sigaction",
+            "number": 174,
+            "signature": [
+                "int sig",
+                "const struct sigaction *act",
+                "struct sigaction *oact",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigprocmask",
+            "number": 175,
+            "signature": [
+                "int how",
+                "sigset_t *nset",
+                "sigset_t *oset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigpending",
+            "number": 176,
+            "signature": [
+                "sigset_t *uset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "number": 177,
+            "signature": [
+                "const sigset_t *uthese",
+                "siginfo_t *uinfo",
+                "const struct old_timespec32 *uts",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "rt_sigqueueinfo",
+            "number": 178,
+            "signature": [
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "rt_sigsuspend",
+            "number": 179,
+            "signature": [
+                "sigset_t *unewset",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "pread64",
+            "number": 180,
+            "signature": [
+                "unsigned int fd",
+                "char *ubuf",
+                "u32 count",
+                "u32 poslo",
+                "u32 poshi"
+            ]
+        },
+        {
+            "name": "pwrite64",
+            "number": 181,
+            "signature": [
+                "unsigned int fd",
+                "const char *ubuf",
+                "u32 count",
+                "u32 poslo",
+                "u32 poshi"
+            ]
+        },
+        {
+            "name": "chown16",
+            "number": 182,
+            "signature": [
+                "const char *filename",
+                "old_uid_t user",
+                "old_gid_t group"
+            ]
+        },
+        {
+            "name": "getcwd",
+            "number": 183,
+            "signature": [
+                "char *buf",
+                "unsigned long size"
+            ]
+        },
+        {
+            "name": "capget",
+            "number": 184,
+            "signature": [
+                "cap_user_header_t header",
+                "cap_user_data_t dataptr"
+            ]
+        },
+        {
+            "name": "capset",
+            "number": 185,
+            "signature": [
+                "cap_user_header_t header",
+                "const cap_user_data_t data"
+            ]
+        },
+        {
+            "name": "sigaltstack",
+            "number": 186,
+            "signature": [
+                "const stack_t *uss",
+                "stack_t *uoss"
+            ]
+        },
+        {
+            "name": "sendfile",
+            "number": 187,
+            "signature": [
+                "int out_fd",
+                "int in_fd",
+                "off_t *offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "vfork",
+            "number": 190,
+            "signature": []
+        },
+        {
+            "name": "getrlimit",
+            "number": 191,
+            "signature": [
+                "unsigned int resource",
+                "struct rlimit *rlim"
+            ]
+        },
+        {
+            "name": "mmap_pgoff",
+            "number": 192,
+            "signature": [
+                "unsigned long addr",
+                "unsigned long len",
+                "unsigned long prot",
+                "unsigned long flags",
+                "unsigned long fd",
+                "unsigned long pgoff"
+            ]
+        },
+        {
+            "name": "truncate64",
+            "number": 193,
+            "signature": [
+                "const char *filename",
+                "unsigned long offset_low",
+                "unsigned long offset_high"
+            ]
+        },
+        {
+            "name": "ftruncate64",
+            "number": 194,
+            "signature": [
+                "unsigned int fd",
+                "unsigned long offset_low",
+                "unsigned long offset_high"
+            ]
+        },
+        {
+            "name": "stat64",
+            "number": 195,
+            "signature": [
+                "const char *filename",
+                "struct stat64 *statbuf"
+            ]
+        },
+        {
+            "name": "lstat64",
+            "number": 196,
+            "signature": [
+                "const char *filename",
+                "struct stat64 *statbuf"
+            ]
+        },
+        {
+            "name": "fstat64",
+            "number": 197,
+            "signature": [
+                "unsigned long fd",
+                "struct stat64 *statbuf"
+            ]
+        },
+        {
+            "name": "lchown",
+            "number": 198,
+            "signature": [
+                "const char *filename",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "getuid",
+            "number": 199,
+            "signature": []
+        },
+        {
+            "name": "getgid",
+            "number": 200,
+            "signature": []
+        },
+        {
+            "name": "geteuid",
+            "number": 201,
+            "signature": []
+        },
+        {
+            "name": "getegid",
+            "number": 202,
+            "signature": []
+        },
+        {
+            "name": "setreuid",
+            "number": 203,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid"
+            ]
+        },
+        {
+            "name": "setregid",
+            "number": 204,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid"
+            ]
+        },
+        {
+            "name": "getgroups",
+            "number": 205,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "setgroups",
+            "number": 206,
+            "signature": [
+                "int gidsetsize",
+                "gid_t *grouplist"
+            ]
+        },
+        {
+            "name": "fchown",
+            "number": 207,
+            "signature": [
+                "unsigned int fd",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "setresuid",
+            "number": 208,
+            "signature": [
+                "uid_t ruid",
+                "uid_t euid",
+                "uid_t suid"
+            ]
+        },
+        {
+            "name": "getresuid",
+            "number": 209,
+            "signature": [
+                "uid_t *ruidp",
+                "uid_t *euidp",
+                "uid_t *suidp"
+            ]
+        },
+        {
+            "name": "setresgid",
+            "number": 210,
+            "signature": [
+                "gid_t rgid",
+                "gid_t egid",
+                "gid_t sgid"
+            ]
+        },
+        {
+            "name": "getresgid",
+            "number": 211,
+            "signature": [
+                "gid_t *rgidp",
+                "gid_t *egidp",
+                "gid_t *sgidp"
+            ]
+        },
+        {
+            "name": "chown",
+            "number": 212,
+            "signature": [
+                "const char *filename",
+                "uid_t user",
+                "gid_t group"
+            ]
+        },
+        {
+            "name": "setuid",
+            "number": 213,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setgid",
+            "number": 214,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "setfsuid",
+            "number": 215,
+            "signature": [
+                "uid_t uid"
+            ]
+        },
+        {
+            "name": "setfsgid",
+            "number": 216,
+            "signature": [
+                "gid_t gid"
+            ]
+        },
+        {
+            "name": "pivot_root",
+            "number": 217,
+            "signature": [
+                "const char *new_root",
+                "const char *put_old"
+            ]
+        },
+        {
+            "name": "mincore",
+            "number": 218,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "unsigned char *vec"
+            ]
+        },
+        {
+            "name": "madvise",
+            "number": 219,
+            "signature": [
+                "unsigned long start",
+                "size_t len_in",
+                "int behavior"
+            ]
+        },
+        {
+            "name": "getdents64",
+            "number": 220,
+            "signature": [
+                "unsigned int fd",
+                "struct linux_dirent64 *dirent",
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "fcntl64",
+            "number": 221,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "gettid",
+            "number": 224,
+            "signature": []
+        },
+        {
+            "name": "readahead",
+            "number": 225,
+            "signature": [
+                "int fd",
+                "unsigned int off_lo",
+                "unsigned int off_hi",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "setxattr",
+            "number": 226,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "lsetxattr",
+            "number": 227,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "fsetxattr",
+            "number": 228,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "const void *value",
+                "size_t size",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getxattr",
+            "number": 229,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "lgetxattr",
+            "number": 230,
+            "signature": [
+                "const char *pathname",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "fgetxattr",
+            "number": 231,
+            "signature": [
+                "int fd",
+                "const char *name",
+                "void *value",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "listxattr",
+            "number": 232,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "llistxattr",
+            "number": 233,
+            "signature": [
+                "const char *pathname",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "flistxattr",
+            "number": 234,
+            "signature": [
+                "int fd",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattr",
+            "number": 235,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "lremovexattr",
+            "number": 236,
+            "signature": [
+                "const char *pathname",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "fremovexattr",
+            "number": 237,
+            "signature": [
+                "int fd",
+                "const char *name"
+            ]
+        },
+        {
+            "name": "tkill",
+            "number": 238,
+            "signature": [
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "sendfile64",
+            "number": 239,
+            "signature": [
+                "int out_fd",
+                "int in_fd",
+                "loff_t *offset",
+                "size_t count"
+            ]
+        },
+        {
+            "name": "futex",
+            "number": 240,
+            "signature": [
+                "u32 *uaddr",
+                "int op",
+                "u32 val",
+                "const struct old_timespec32 *utime",
+                "u32 *uaddr2",
+                "u32 val3"
+            ]
+        },
+        {
+            "name": "sched_setaffinity",
+            "number": 241,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "sched_getaffinity",
+            "number": 242,
+            "signature": [
+                "pid_t pid",
+                "unsigned int len",
+                "unsigned long *user_mask_ptr"
+            ]
+        },
+        {
+            "name": "set_thread_area",
+            "number": 243,
+            "signature": [
+                "struct user_desc *u_info"
+            ]
+        },
+        {
+            "name": "get_thread_area",
+            "number": 244,
+            "signature": [
+                "struct user_desc *u_info"
+            ]
+        },
+        {
+            "name": "io_setup",
+            "number": 245,
+            "signature": [
+                "unsigned nr_events",
+                "aio_context_t *ctxp"
+            ]
+        },
+        {
+            "name": "io_destroy",
+            "number": 246,
+            "signature": [
+                "aio_context_t ctx"
+            ]
+        },
+        {
+            "name": "io_getevents",
+            "number": 247,
+            "signature": [
+                "__u32 ctx_id",
+                "__s32 min_nr",
+                "__s32 nr",
+                "struct io_event *events",
+                "struct old_timespec32 *timeout"
+            ]
+        },
+        {
+            "name": "io_submit",
+            "number": 248,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long nr",
+                "struct iocb **iocbpp"
+            ]
+        },
+        {
+            "name": "io_cancel",
+            "number": 249,
+            "signature": [
+                "aio_context_t ctx_id",
+                "struct iocb *iocb",
+                "struct io_event *result"
+            ]
+        },
+        {
+            "name": "fadvise64",
+            "number": 250,
+            "signature": [
+                "int fd",
+                "unsigned int offset_lo",
+                "unsigned int offset_hi",
+                "size_t len",
+                "int advice"
+            ]
+        },
+        {
+            "name": "exit_group",
+            "number": 252,
+            "signature": [
+                "int error_code"
+            ]
+        },
+        {
+            "name": "epoll_create",
+            "number": 254,
+            "signature": [
+                "int size"
+            ]
+        },
+        {
+            "name": "epoll_ctl",
+            "number": 255,
+            "signature": [
+                "int epfd",
+                "int op",
+                "int fd",
+                "struct epoll_event *event"
+            ]
+        },
+        {
+            "name": "epoll_wait",
+            "number": 256,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "int timeout"
+            ]
+        },
+        {
+            "name": "remap_file_pages",
+            "number": 257,
+            "signature": [
+                "unsigned long start",
+                "unsigned long size",
+                "unsigned long prot",
+                "unsigned long pgoff",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "set_tid_address",
+            "number": 258,
+            "signature": [
+                "int *tidptr"
+            ]
+        },
+        {
+            "name": "timer_create",
+            "number": 259,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct sigevent *timer_event_spec",
+                "timer_t *created_timer_id"
+            ]
+        },
+        {
+            "name": "timer_settime",
+            "number": 260,
+            "signature": [
+                "timer_t timer_id",
+                "int flags",
+                "struct old_itimerspec32 *new",
+                "struct old_itimerspec32 *old"
+            ]
+        },
+        {
+            "name": "timer_gettime",
+            "number": 261,
+            "signature": [
+                "timer_t timer_id",
+                "struct old_itimerspec32 *setting"
+            ]
+        },
+        {
+            "name": "timer_getoverrun",
+            "number": 262,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "timer_delete",
+            "number": 263,
+            "signature": [
+                "timer_t timer_id"
+            ]
+        },
+        {
+            "name": "clock_settime",
+            "number": 264,
+            "signature": [
+                "clockid_t which_clock",
+                "struct old_timespec32 *tp"
+            ]
+        },
+        {
+            "name": "clock_gettime",
+            "number": 265,
+            "signature": [
+                "clockid_t which_clock",
+                "struct old_timespec32 *tp"
+            ]
+        },
+        {
+            "name": "clock_getres",
+            "number": 266,
+            "signature": [
+                "clockid_t which_clock",
+                "struct old_timespec32 *tp"
+            ]
+        },
+        {
+            "name": "clock_nanosleep",
+            "number": 267,
+            "signature": [
+                "clockid_t which_clock",
+                "int flags",
+                "struct old_timespec32 *rqtp",
+                "struct old_timespec32 *rmtp"
+            ]
+        },
+        {
+            "name": "statfs64",
+            "number": 268,
+            "signature": [
+                "const char *pathname",
+                "size_t sz",
+                "struct statfs64 *buf"
+            ]
+        },
+        {
+            "name": "fstatfs64",
+            "number": 269,
+            "signature": [
+                "unsigned int fd",
+                "size_t sz",
+                "struct statfs64 *buf"
+            ]
+        },
+        {
+            "name": "tgkill",
+            "number": 270,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig"
+            ]
+        },
+        {
+            "name": "utimes",
+            "number": 271,
+            "signature": [
+                "const char *filename",
+                "struct old_timeval32 *t"
+            ]
+        },
+        {
+            "name": "fadvise64_64",
+            "number": 272,
+            "signature": [
+                "int fd",
+                "__u32 offset_low",
+                "__u32 offset_high",
+                "__u32 len_low",
+                "__u32 len_high",
+                "int advice"
+            ]
+        },
+        {
+            "name": "mbind",
+            "number": 274,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "get_mempolicy",
+            "number": 275,
+            "signature": [
+                "int *policy",
+                "unsigned long *nmask",
+                "unsigned long maxnode",
+                "unsigned long addr",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "set_mempolicy",
+            "number": 276,
+            "signature": [
+                "int mode",
+                "const unsigned long *nmask",
+                "unsigned long maxnode"
+            ]
+        },
+        {
+            "name": "mq_open",
+            "number": 277,
+            "signature": [
+                "const char *u_name",
+                "int oflag",
+                "umode_t mode",
+                "struct mq_attr *u_attr"
+            ]
+        },
+        {
+            "name": "mq_unlink",
+            "number": 278,
+            "signature": [
+                "const char *u_name"
+            ]
+        },
+        {
+            "name": "mq_timedsend",
+            "number": 279,
+            "signature": [
+                "mqd_t mqdes",
+                "const char *u_msg_ptr",
+                "unsigned int msg_len",
+                "unsigned int msg_prio",
+                "const struct old_timespec32 *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_timedreceive",
+            "number": 280,
+            "signature": [
+                "mqd_t mqdes",
+                "char *u_msg_ptr",
+                "unsigned int msg_len",
+                "unsigned int *u_msg_prio",
+                "const struct old_timespec32 *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_notify",
+            "number": 281,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct sigevent *u_notification"
+            ]
+        },
+        {
+            "name": "mq_getsetattr",
+            "number": 282,
+            "signature": [
+                "mqd_t mqdes",
+                "const struct mq_attr *u_mqstat",
+                "struct mq_attr *u_omqstat"
+            ]
+        },
+        {
+            "name": "kexec_load",
+            "number": 283,
+            "signature": [
+                "unsigned long entry",
+                "unsigned long nr_segments",
+                "struct kexec_segment *segments",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "waitid",
+            "number": 284,
+            "signature": [
+                "int which",
+                "pid_t upid",
+                "struct siginfo *infop",
+                "int options",
+                "struct rusage *ru"
+            ]
+        },
+        {
+            "name": "add_key",
+            "number": 286,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const void *_payload",
+                "size_t plen",
+                "key_serial_t ringid"
+            ]
+        },
+        {
+            "name": "request_key",
+            "number": 287,
+            "signature": [
+                "const char *_type",
+                "const char *_description",
+                "const char *_callout_info",
+                "key_serial_t destringid"
+            ]
+        },
+        {
+            "name": "keyctl",
+            "number": 288,
+            "signature": [
+                "int option",
+                "unsigned long arg2",
+                "unsigned long arg3",
+                "unsigned long arg4",
+                "unsigned long arg5"
+            ]
+        },
+        {
+            "name": "ioprio_set",
+            "number": 289,
+            "signature": [
+                "int which",
+                "int who",
+                "int ioprio"
+            ]
+        },
+        {
+            "name": "ioprio_get",
+            "number": 290,
+            "signature": [
+                "int which",
+                "int who"
+            ]
+        },
+        {
+            "name": "inotify_init",
+            "number": 291,
+            "signature": []
+        },
+        {
+            "name": "inotify_add_watch",
+            "number": 292,
+            "signature": [
+                "int fd",
+                "const char *pathname",
+                "u32 mask"
+            ]
+        },
+        {
+            "name": "inotify_rm_watch",
+            "number": 293,
+            "signature": [
+                "int fd",
+                "__s32 wd"
+            ]
+        },
+        {
+            "name": "migrate_pages",
+            "number": 294,
+            "signature": [
+                "pid_t pid",
+                "unsigned long maxnode",
+                "const unsigned long *old_nodes",
+                "const unsigned long *new_nodes"
+            ]
+        },
+        {
+            "name": "openat",
+            "number": 295,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int flags",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "mkdirat",
+            "number": 296,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "mknodat",
+            "number": 297,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int dev"
+            ]
+        },
+        {
+            "name": "fchownat",
+            "number": 298,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "uid_t user",
+                "gid_t group",
+                "int flag"
+            ]
+        },
+        {
+            "name": "futimesat",
+            "number": 299,
+            "signature": [
+                "unsigned int dfd",
+                "const char *filename",
+                "struct old_timeval32 *t"
+            ]
+        },
+        {
+            "name": "fstatat64",
+            "number": 300,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct stat64 *statbuf",
+                "int flag"
+            ]
+        },
+        {
+            "name": "unlinkat",
+            "number": 301,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "int flag"
+            ]
+        },
+        {
+            "name": "renameat",
+            "number": 302,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "linkat",
+            "number": 303,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "int flags"
+            ]
+        },
+        {
+            "name": "symlinkat",
+            "number": 304,
+            "signature": [
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname"
+            ]
+        },
+        {
+            "name": "readlinkat",
+            "number": 305,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "char *buf",
+                "int bufsiz"
+            ]
+        },
+        {
+            "name": "fchmodat",
+            "number": 306,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode"
+            ]
+        },
+        {
+            "name": "faccessat",
+            "number": 307,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode"
+            ]
+        },
+        {
+            "name": "pselect6",
+            "number": 308,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct old_timespec32 *tsp",
+                "void *sig"
+            ]
+        },
+        {
+            "name": "ppoll",
+            "number": 309,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "struct old_timespec32 *tsp",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "unshare",
+            "number": 310,
+            "signature": [
+                "unsigned long unshare_flags"
+            ]
+        },
+        {
+            "name": "set_robust_list",
+            "number": 311,
+            "signature": [
+                "struct robust_list_head *head",
+                "size_t len"
+            ]
+        },
+        {
+            "name": "get_robust_list",
+            "number": 312,
+            "signature": [
+                "int pid",
+                "struct robust_list_head **head_ptr",
+                "size_t *len_ptr"
+            ]
+        },
+        {
+            "name": "splice",
+            "number": 313,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "sync_file_range",
+            "number": 314,
+            "signature": [
+                "int fd",
+                "unsigned int off_low",
+                "unsigned int off_hi",
+                "unsigned int n_low",
+                "unsigned int n_hi",
+                "int flags"
+            ]
+        },
+        {
+            "name": "tee",
+            "number": 315,
+            "signature": [
+                "int fdin",
+                "int fdout",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "vmsplice",
+            "number": 316,
+            "signature": [
+                "int fd",
+                "const struct iovec *uiov",
+                "unsigned long nr_segs",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "move_pages",
+            "number": 317,
+            "signature": [
+                "pid_t pid",
+                "unsigned long nr_pages",
+                "const void **pages",
+                "const int *nodes",
+                "int *status",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getcpu",
+            "number": 318,
+            "signature": [
+                "unsigned *cpup",
+                "unsigned *nodep",
+                "struct getcpu_cache *unused"
+            ]
+        },
+        {
+            "name": "epoll_pwait",
+            "number": 319,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "int timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "utimensat",
+            "number": 320,
+            "signature": [
+                "unsigned int dfd",
+                "const char *filename",
+                "struct old_timespec32 *t",
+                "int flags"
+            ]
+        },
+        {
+            "name": "signalfd",
+            "number": 321,
+            "signature": [
+                "int ufd",
+                "sigset_t *user_mask",
+                "size_t sizemask"
+            ]
+        },
+        {
+            "name": "timerfd_create",
+            "number": 322,
+            "signature": [
+                "int clockid",
+                "int flags"
+            ]
+        },
+        {
+            "name": "eventfd",
+            "number": 323,
+            "signature": [
+                "unsigned int count"
+            ]
+        },
+        {
+            "name": "fallocate",
+            "number": 324,
+            "signature": [
+                "int fd",
+                "int mode",
+                "unsigned int offset_lo",
+                "unsigned int offset_hi",
+                "unsigned int len_lo",
+                "unsigned int len_hi"
+            ]
+        },
+        {
+            "name": "timerfd_settime",
+            "number": 325,
+            "signature": [
+                "int ufd",
+                "int flags",
+                "const struct old_itimerspec32 *utmr",
+                "struct old_itimerspec32 *otmr"
+            ]
+        },
+        {
+            "name": "timerfd_gettime",
+            "number": 326,
+            "signature": [
+                "int ufd",
+                "struct old_itimerspec32 *otmr"
+            ]
+        },
+        {
+            "name": "signalfd4",
+            "number": 327,
+            "signature": [
+                "int ufd",
+                "sigset_t *user_mask",
+                "size_t sizemask",
+                "int flags"
+            ]
+        },
+        {
+            "name": "eventfd2",
+            "number": 328,
+            "signature": [
+                "unsigned int count",
+                "int flags"
+            ]
+        },
+        {
+            "name": "epoll_create1",
+            "number": 329,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "dup3",
+            "number": 330,
+            "signature": [
+                "unsigned int oldfd",
+                "unsigned int newfd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "pipe2",
+            "number": 331,
+            "signature": [
+                "int *fildes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "inotify_init1",
+            "number": 332,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "preadv",
+            "number": 333,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "pwritev",
+            "number": 334,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h"
+            ]
+        },
+        {
+            "name": "rt_tgsigqueueinfo",
+            "number": 335,
+            "signature": [
+                "pid_t tgid",
+                "pid_t pid",
+                "int sig",
+                "siginfo_t *uinfo"
+            ]
+        },
+        {
+            "name": "perf_event_open",
+            "number": 336,
+            "signature": [
+                "struct perf_event_attr *attr_uptr",
+                "pid_t pid",
+                "int cpu",
+                "int group_fd",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "recvmmsg",
+            "number": 337,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags",
+                "struct old_timespec32 *timeout"
+            ]
+        },
+        {
+            "name": "fanotify_init",
+            "number": 338,
+            "signature": [
+                "unsigned int flags",
+                "unsigned int event_f_flags"
+            ]
+        },
+        {
+            "name": "fanotify_mark",
+            "number": 339,
+            "signature": [
+                "int fanotify_fd",
+                "unsigned int flags",
+                "u32 mask_lo",
+                "u32 mask_hi",
+                "int dfd",
+                "const char *pathname"
+            ]
+        },
+        {
+            "name": "prlimit64",
+            "number": 340,
+            "signature": [
+                "pid_t pid",
+                "unsigned int resource",
+                "const struct rlimit64 *new_rlim",
+                "struct rlimit64 *old_rlim"
+            ]
+        },
+        {
+            "name": "name_to_handle_at",
+            "number": 341,
+            "signature": [
+                "int dfd",
+                "const char *name",
+                "struct file_handle *handle",
+                "void *mnt_id",
+                "int flag"
+            ]
+        },
+        {
+            "name": "open_by_handle_at",
+            "number": 342,
+            "signature": [
+                "int mountdirfd",
+                "struct file_handle *handle",
+                "int flags"
+            ]
+        },
+        {
+            "name": "clock_adjtime",
+            "number": 343,
+            "signature": [
+                "clockid_t which_clock",
+                "struct old_timex32 *utp"
+            ]
+        },
+        {
+            "name": "syncfs",
+            "number": 344,
+            "signature": [
+                "int fd"
+            ]
+        },
+        {
+            "name": "sendmmsg",
+            "number": 345,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "setns",
+            "number": 346,
+            "signature": [
+                "int fd",
+                "int flags"
+            ]
+        },
+        {
+            "name": "process_vm_readv",
+            "number": 347,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "process_vm_writev",
+            "number": 348,
+            "signature": [
+                "pid_t pid",
+                "const struct iovec *lvec",
+                "unsigned long liovcnt",
+                "const struct iovec *rvec",
+                "unsigned long riovcnt",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "kcmp",
+            "number": 349,
+            "signature": [
+                "pid_t pid1",
+                "pid_t pid2",
+                "int type",
+                "unsigned long idx1",
+                "unsigned long idx2"
+            ]
+        },
+        {
+            "name": "finit_module",
+            "number": 350,
+            "signature": [
+                "int fd",
+                "const char *uargs",
+                "int flags"
+            ]
+        },
+        {
+            "name": "sched_setattr",
+            "number": 351,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "sched_getattr",
+            "number": 352,
+            "signature": [
+                "pid_t pid",
+                "struct sched_attr *uattr",
+                "unsigned int usize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "renameat2",
+            "number": 353,
+            "signature": [
+                "int olddfd",
+                "const char *oldname",
+                "int newdfd",
+                "const char *newname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "seccomp",
+            "number": 354,
+            "signature": [
+                "unsigned int op",
+                "unsigned int flags",
+                "void *uargs"
+            ]
+        },
+        {
+            "name": "getrandom",
+            "number": 355,
+            "signature": [
+                "char *ubuf",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "memfd_create",
+            "number": 356,
+            "signature": [
+                "const char *uname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "bpf",
+            "number": 357,
+            "signature": [
+                "int cmd",
+                "union bpf_attr *uattr",
+                "unsigned int size"
+            ]
+        },
+        {
+            "name": "execveat",
+            "number": 358,
+            "signature": [
+                "int fd",
+                "const char *filename",
+                "const char *const *argv",
+                "const char *const *envp",
+                "int flags"
+            ]
+        },
+        {
+            "name": "socket",
+            "number": 359,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol"
+            ]
+        },
+        {
+            "name": "socketpair",
+            "number": 360,
+            "signature": [
+                "int family",
+                "int type",
+                "int protocol",
+                "int *usockvec"
+            ]
+        },
+        {
+            "name": "bind",
+            "number": 361,
+            "signature": [
+                "int fd",
+                "struct sockaddr *umyaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "connect",
+            "number": 362,
+            "signature": [
+                "int fd",
+                "struct sockaddr *uservaddr",
+                "int addrlen"
+            ]
+        },
+        {
+            "name": "listen",
+            "number": 363,
+            "signature": [
+                "int fd",
+                "int backlog"
+            ]
+        },
+        {
+            "name": "accept4",
+            "number": 364,
+            "signature": [
+                "int fd",
+                "struct sockaddr *upeer_sockaddr",
+                "int *upeer_addrlen",
+                "int flags"
+            ]
+        },
+        {
+            "name": "getsockopt",
+            "number": 365,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int *optlen"
+            ]
+        },
+        {
+            "name": "setsockopt",
+            "number": 366,
+            "signature": [
+                "int fd",
+                "int level",
+                "int optname",
+                "char *optval",
+                "int optlen"
+            ]
+        },
+        {
+            "name": "getsockname",
+            "number": 367,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "getpeername",
+            "number": 368,
+            "signature": [
+                "int fd",
+                "struct sockaddr *usockaddr",
+                "int *usockaddr_len"
+            ]
+        },
+        {
+            "name": "sendto",
+            "number": 369,
+            "signature": [
+                "int fd",
+                "void *buff",
+                "size_t len",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int addr_len"
+            ]
+        },
+        {
+            "name": "sendmsg",
+            "number": 370,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "recvfrom",
+            "number": 371,
+            "signature": [
+                "int fd",
+                "void *ubuf",
+                "size_t size",
+                "unsigned int flags",
+                "struct sockaddr *addr",
+                "int *addr_len"
+            ]
+        },
+        {
+            "name": "recvmsg",
+            "number": 372,
+            "signature": [
+                "int fd",
+                "struct user_msghdr *msg",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "shutdown",
+            "number": 373,
+            "signature": [
+                "int fd",
+                "int how"
+            ]
+        },
+        {
+            "name": "userfaultfd",
+            "number": 374,
+            "signature": [
+                "int flags"
+            ]
+        },
+        {
+            "name": "membarrier",
+            "number": 375,
+            "signature": [
+                "int cmd",
+                "unsigned int flags",
+                "int cpu_id"
+            ]
+        },
+        {
+            "name": "mlock2",
+            "number": 376,
+            "signature": [
+                "unsigned long start",
+                "size_t len",
+                "int flags"
+            ]
+        },
+        {
+            "name": "copy_file_range",
+            "number": 377,
+            "signature": [
+                "int fd_in",
+                "loff_t *off_in",
+                "int fd_out",
+                "loff_t *off_out",
+                "size_t len",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "preadv2",
+            "number": 378,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "pwritev2",
+            "number": 379,
+            "signature": [
+                "unsigned long fd",
+                "const struct iovec *vec",
+                "unsigned long vlen",
+                "unsigned long pos_l",
+                "unsigned long pos_h",
+                "rwf_t flags"
+            ]
+        },
+        {
+            "name": "statx",
+            "number": 383,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags",
+                "unsigned int mask",
+                "struct statx *buffer"
+            ]
+        },
+        {
+            "name": "arch_prctl",
+            "number": 384,
+            "signature": [
+                "int option",
+                "unsigned long arg2"
+            ]
+        },
+        {
+            "name": "io_pgetevents",
+            "number": 385,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct old_timespec32 *timeout",
+                "const struct __aio_sigset *usig"
+            ]
+        },
+        {
+            "name": "rseq",
+            "number": 386,
+            "signature": [
+                "struct rseq *rseq",
+                "u32 rseq_len",
+                "int flags",
+                "u32 sig"
+            ]
+        },
+        {
+            "name": "semget",
+            "number": 393,
+            "signature": [
+                "key_t key",
+                "int nsems",
+                "int semflg"
+            ]
+        },
+        {
+            "name": "semctl",
+            "number": 394,
+            "signature": [
+                "int semid",
+                "int semnum",
+                "int cmd",
+                "unsigned long arg"
+            ]
+        },
+        {
+            "name": "shmget",
+            "number": 395,
+            "signature": [
+                "key_t key",
+                "size_t size",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmctl",
+            "number": 396,
+            "signature": [
+                "int shmid",
+                "int cmd",
+                "struct shmid_ds *buf"
+            ]
+        },
+        {
+            "name": "shmat",
+            "number": 397,
+            "signature": [
+                "int shmid",
+                "char *shmaddr",
+                "int shmflg"
+            ]
+        },
+        {
+            "name": "shmdt",
+            "number": 398,
+            "signature": [
+                "char *shmaddr"
+            ]
+        },
+        {
+            "name": "msgget",
+            "number": 399,
+            "signature": [
+                "key_t key",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgsnd",
+            "number": 400,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgrcv",
+            "number": 401,
+            "signature": [
+                "int msqid",
+                "struct msgbuf *msgp",
+                "size_t msgsz",
+                "long msgtyp",
+                "int msgflg"
+            ]
+        },
+        {
+            "name": "msgctl",
+            "number": 402,
+            "signature": [
+                "int msqid",
+                "int cmd",
+                "struct msqid_ds *buf"
+            ]
+        },
+        {
+            "name": "clock_gettime",
+            "number": 403,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_settime",
+            "number": 404,
+            "signature": [
+                "const clockid_t which_clock",
+                "const struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_adjtime",
+            "number": 405,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timex *utx"
+            ]
+        },
+        {
+            "name": "clock_getres",
+            "number": 406,
+            "signature": [
+                "const clockid_t which_clock",
+                "struct __kernel_timespec *tp"
+            ]
+        },
+        {
+            "name": "clock_nanosleep",
+            "number": 407,
+            "signature": [
+                "const clockid_t which_clock",
+                "int flags",
+                "const struct __kernel_timespec *rqtp",
+                "struct __kernel_timespec *rmtp"
+            ]
+        },
+        {
+            "name": "timer_gettime",
+            "number": 408,
+            "signature": [
+                "timer_t timer_id",
+                "struct __kernel_itimerspec *setting"
+            ]
+        },
+        {
+            "name": "timer_settime",
+            "number": 409,
+            "signature": [
+                "timer_t timer_id",
+                "int flags",
+                "const struct __kernel_itimerspec *new_setting",
+                "struct __kernel_itimerspec *old_setting"
+            ]
+        },
+        {
+            "name": "timerfd_gettime",
+            "number": 410,
+            "signature": [
+                "int ufd",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "timerfd_settime",
+            "number": 411,
+            "signature": [
+                "int ufd",
+                "int flags",
+                "const struct __kernel_itimerspec *utmr",
+                "struct __kernel_itimerspec *otmr"
+            ]
+        },
+        {
+            "name": "utimensat",
+            "number": 412,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct __kernel_timespec *utimes",
+                "int flags"
+            ]
+        },
+        {
+            "name": "pselect6",
+            "number": 413,
+            "signature": [
+                "int n",
+                "fd_set *inp",
+                "fd_set *outp",
+                "fd_set *exp",
+                "struct __kernel_timespec *tsp",
+                "void *sig"
+            ]
+        },
+        {
+            "name": "ppoll",
+            "number": 414,
+            "signature": [
+                "struct pollfd *ufds",
+                "unsigned int nfds",
+                "struct __kernel_timespec *tsp",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "io_pgetevents",
+            "number": 416,
+            "signature": [
+                "aio_context_t ctx_id",
+                "long min_nr",
+                "long nr",
+                "struct io_event *events",
+                "struct __kernel_timespec *timeout",
+                "const struct __aio_sigset *usig"
+            ]
+        },
+        {
+            "name": "recvmmsg",
+            "number": 417,
+            "signature": [
+                "int fd",
+                "struct mmsghdr *mmsg",
+                "unsigned int vlen",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "mq_timedsend",
+            "number": 418,
+            "signature": [
+                "mqd_t mqdes",
+                "const char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "mq_timedreceive",
+            "number": 419,
+            "signature": [
+                "mqd_t mqdes",
+                "char *u_msg_ptr",
+                "size_t msg_len",
+                "unsigned int *u_msg_prio",
+                "const struct __kernel_timespec *u_abs_timeout"
+            ]
+        },
+        {
+            "name": "semtimedop",
+            "number": 420,
+            "signature": [
+                "int semid",
+                "struct sembuf *tsops",
+                "unsigned int nsops",
+                "const struct __kernel_timespec *timeout"
+            ]
+        },
+        {
+            "name": "rt_sigtimedwait",
+            "number": 421,
+            "signature": [
+                "const sigset_t *uthese",
+                "siginfo_t *uinfo",
+                "const struct __kernel_timespec *uts",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "futex",
+            "number": 422,
+            "signature": [
+                "u32 *uaddr",
+                "int op",
+                "u32 val",
+                "const struct __kernel_timespec *utime",
+                "u32 *uaddr2",
+                "u32 val3"
+            ]
+        },
+        {
+            "name": "sched_rr_get_interval",
+            "number": 423,
+            "signature": [
+                "pid_t pid",
+                "struct __kernel_timespec *interval"
+            ]
+        },
+        {
+            "name": "pidfd_send_signal",
+            "number": 424,
+            "signature": [
+                "int pidfd",
+                "int sig",
+                "siginfo_t *info",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "io_uring_setup",
+            "number": 425,
+            "signature": [
+                "u32 entries",
+                "struct io_uring_params *params"
+            ]
+        },
+        {
+            "name": "io_uring_enter",
+            "number": 426,
+            "signature": [
+                "unsigned int fd",
+                "u32 to_submit",
+                "u32 min_complete",
+                "u32 flags",
+                "const void *argp",
+                "size_t argsz"
+            ]
+        },
+        {
+            "name": "io_uring_register",
+            "number": 427,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int opcode",
+                "void *arg",
+                "unsigned int nr_args"
+            ]
+        },
+        {
+            "name": "open_tree",
+            "number": 428,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "unsigned flags"
+            ]
+        },
+        {
+            "name": "move_mount",
+            "number": 429,
+            "signature": [
+                "int from_dfd",
+                "const char *from_pathname",
+                "int to_dfd",
+                "const char *to_pathname",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsopen",
+            "number": 430,
+            "signature": [
+                "const char *_fs_name",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fsconfig",
+            "number": 431,
+            "signature": [
+                "int fd",
+                "unsigned int cmd",
+                "const char *_key",
+                "const void *_value",
+                "int aux"
+            ]
+        },
+        {
+            "name": "fsmount",
+            "number": 432,
+            "signature": [
+                "int fs_fd",
+                "unsigned int flags",
+                "unsigned int attr_flags"
+            ]
+        },
+        {
+            "name": "fspick",
+            "number": 433,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "pidfd_open",
+            "number": 434,
+            "signature": [
+                "pid_t pid",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "clone3",
+            "number": 435,
+            "signature": [
+                "struct clone_args *uargs",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "close_range",
+            "number": 436,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int max_fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "openat2",
+            "number": 437,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "struct open_how *how",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "pidfd_getfd",
+            "number": 438,
+            "signature": [
+                "int pidfd",
+                "int fd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "faccessat2",
+            "number": 439,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "int mode",
+                "int flags"
+            ]
+        },
+        {
+            "name": "process_madvise",
+            "number": 440,
+            "signature": [
+                "int pidfd",
+                "const struct iovec *vec",
+                "size_t vlen",
+                "int behavior",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "epoll_pwait2",
+            "number": 441,
+            "signature": [
+                "int epfd",
+                "struct epoll_event *events",
+                "int maxevents",
+                "const struct __kernel_timespec *timeout",
+                "const sigset_t *sigmask",
+                "size_t sigsetsize"
+            ]
+        },
+        {
+            "name": "mount_setattr",
+            "number": 442,
+            "signature": [
+                "int dfd",
+                "const char *path",
+                "unsigned int flags",
+                "struct mount_attr *uattr",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "quotactl_fd",
+            "number": 443,
+            "signature": [
+                "unsigned int fd",
+                "unsigned int cmd",
+                "qid_t id",
+                "void *addr"
+            ]
+        },
+        {
+            "name": "landlock_create_ruleset",
+            "number": 444,
+            "signature": [
+                "const struct landlock_ruleset_attr *const attr",
+                "const size_t size",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_add_rule",
+            "number": 445,
+            "signature": [
+                "const int ruleset_fd",
+                "const enum landlock_rule_type rule_type",
+                "const void *const rule_attr",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "landlock_restrict_self",
+            "number": 446,
+            "signature": [
+                "const int ruleset_fd",
+                "const __u32 flags"
+            ]
+        },
+        {
+            "name": "memfd_secret",
+            "number": 447,
+            "signature": [
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "process_mrelease",
+            "number": 448,
+            "signature": [
+                "int pidfd",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_waitv",
+            "number": 449,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int nr_futexes",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "set_mempolicy_home_node",
+            "number": 450,
+            "signature": [
+                "unsigned long start",
+                "unsigned long len",
+                "unsigned long home_node",
+                "unsigned long flags"
+            ]
+        },
+        {
+            "name": "cachestat",
+            "number": 451,
+            "signature": [
+                "unsigned int fd",
+                "struct cachestat_range *cstat_range",
+                "struct cachestat *cstat",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "fchmodat2",
+            "number": 452,
+            "signature": [
+                "int dfd",
+                "const char *filename",
+                "umode_t mode",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wake",
+            "number": 454,
+            "signature": [
+                "void *uaddr",
+                "unsigned long mask",
+                "int nr",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "futex_wait",
+            "number": 455,
+            "signature": [
+                "void *uaddr",
+                "unsigned long val",
+                "unsigned long mask",
+                "unsigned int flags",
+                "struct __kernel_timespec *timeout",
+                "clockid_t clockid"
+            ]
+        },
+        {
+            "name": "futex_requeue",
+            "number": 456,
+            "signature": [
+                "struct futex_waitv *waiters",
+                "unsigned int flags",
+                "int nr_wake",
+                "int nr_requeue"
+            ]
+        },
+        {
+            "name": "statmount",
+            "number": 457,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "struct statmount *buf",
+                "size_t bufsize",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "listmount",
+            "number": 458,
+            "signature": [
+                "const struct mnt_id_req *req",
+                "u64 *mnt_ids",
+                "size_t nr_mnt_ids",
+                "unsigned int flags"
+            ]
+        },
+        {
+            "name": "lsm_get_self_attr",
+            "number": 459,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_set_self_attr",
+            "number": 460,
+            "signature": [
+                "unsigned int attr",
+                "struct lsm_ctx *ctx",
+                "u32 size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "lsm_list_modules",
+            "number": 461,
+            "signature": [
+                "u64 *ids",
+                "u32 *size",
+                "u32 flags"
+            ]
+        },
+        {
+            "name": "setxattrat",
+            "number": 463,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "const struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "getxattrat",
+            "number": 464,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name",
+                "struct xattr_args *uargs",
+                "size_t usize"
+            ]
+        },
+        {
+            "name": "listxattrat",
+            "number": 465,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "char *list",
+                "size_t size"
+            ]
+        },
+        {
+            "name": "removexattrat",
+            "number": 466,
+            "signature": [
+                "int dfd",
+                "const char *pathname",
+                "unsigned int at_flags",
+                "const char *name"
+            ]
+        }
+    ]
 }

--- a/libdebug/utils/syscall_utils.py
+++ b/libdebug/utils/syscall_utils.py
@@ -9,7 +9,14 @@ import json
 import os
 from pathlib import Path
 
-import requests
+try:
+    # requests is used to fetch syscall definitions from a remote server
+    # if available, otherwise we silently fall back to static definitions
+    import requests
+
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 
 SYSCALLS_REMOTE = "https://syscalls.mebeim.net/db"
 LOCAL_FOLDER_PATH = (Path.home() / ".cache" / "libdebug" / "syscalls").resolve()
@@ -71,7 +78,7 @@ def get_syscall_definitions(arch: str) -> dict:
         pass
 
     # Let's check if LOCAL_FOLDER_PATH is even writable
-    if not LOCAL_FOLDER_PATH.is_dir() or not os.access(LOCAL_FOLDER_PATH, os.W_OK):
+    if not HAS_REQUESTS or not LOCAL_FOLDER_PATH.is_dir() or not os.access(LOCAL_FOLDER_PATH, os.W_OK):
         # Even if we attempt to fetch the remote definition, we won't be able to save them,
         # so let's fallback to the static definitions directly
         syscall_definition = fetch_static_syscall_definition(arch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ keywords = ["libdebug", "debugger", "elf", "ptrace", "gdb", "debug", "ctf", "rev
 dependencies = [
     "psutil",
     "pyelftools",
-    "requests",
     "prompt-toolkit",
 ]
 
 [project.optional-dependencies]
 dev = [
     "rich",
+    "requests",
 ]
 
 [project.urls]


### PR DESCRIPTION
So we don't unexpectedly crash whenever we cannot fetch the remote definitions and we don't have a local cache available.