### PR TITLE
Do not rely on absolute paths to `bash`, `ls`, `gdb`

### DIFF
--- a/cmake/prepare_for_wheel_distrib_almalinux.sh
+++ b/cmake/prepare_for_wheel_distrib_almalinux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This file should not go here, but I've not found a better place yet.
 # Intended for AlmaLinux 8

--- a/cmake/prepare_for_wheel_distrib_alpine.sh
+++ b/cmake/prepare_for_wheel_distrib_alpine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This file should not go here, but I've not found a better place yet.
 # Intended for Musl-based Alpine Linux

--- a/cmake/prepare_for_wheel_distrib_centos.sh
+++ b/cmake/prepare_for_wheel_distrib_centos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This file should not go here, but I've not found a better place yet.
 # Intended for CentOS 7 / manylinux2014

--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -937,7 +937,7 @@ class InternalDebugger:
         Returns:
             str: The command to migrate to GDB.
         """
-        gdb_command = f'/bin/gdb -q --pid {self.process_id} -ex "source {GDB_GOBACK_LOCATION} " -ex "ni" -ex "ni"'
+        gdb_command = f'gdb -q --pid {self.process_id} -ex "source {GDB_GOBACK_LOCATION} " -ex "ni" -ex "ni"'
 
         if not migrate_breakpoints:
             return gdb_command
@@ -972,7 +972,7 @@ class InternalDebugger:
         # create a temporary script that will run the command. This script will be executed by the terminal.
         command = self._craft_gdb_migration_command(migrate_breakpoints)
         with NamedTemporaryFile(delete=False, mode="w", suffix=".sh") as temp_file:
-            temp_file.write("#!/bin/bash\n")
+            temp_file.write("#!/bin/sh\n")
             temp_file.write(command)
             script_path = temp_file.name
 
@@ -1004,7 +1004,7 @@ class InternalDebugger:
         terminal_pid = Popen(command).pid
 
         # This is the command line that we are looking for
-        cmdline_target = ["/bin/bash", script_path]
+        cmdline_target = ["/bin/sh", script_path]
 
         self._wait_for_gdb(terminal_pid, cmdline_target)
 
@@ -1043,7 +1043,7 @@ class InternalDebugger:
         gdb_pid = os.fork()
 
         if gdb_pid == 0:  # This is the child process.
-            os.execv("/bin/bash", ["/bin/bash", script_path])
+            os.execv("/bin/sh", ["/bin/sh", script_path])
             raise RuntimeError("Failed to execute GDB.")
 
         # This is the parent process.

--- a/test/dockerfiles/run_tests.sh
+++ b/test/dockerfiles/run_tests.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # Check if the system is Debian
 if [ "$(uname -s)" = "Linux" ] && [ -f /etc/os-release ]; then
     if grep -q "^ID=debian" /etc/os-release; then
         cd /test
-        source venv/bin/activate
+        . venv/bin/activate
         cd test
         echo "Running Python3 tests..."
         python3 run_suite.py
@@ -17,7 +17,7 @@ fi
 if [ "$(uname -s)" = "Linux" ] && [ -f /etc/os-release ]; then
     if grep -q "^ID=ubuntu" /etc/os-release; then
         cd /test
-        source venv/bin/activate
+        . venv/bin/activate
         cd test
         echo "Running Python3 tests..."
         python3 run_suite.py
@@ -30,12 +30,12 @@ fi
 if [ "$(uname -s)" = "Linux" ] && [ -f /etc/os-release ]; then
     if grep -q "^ID=arch" /etc/os-release; then
         cd /test
-        source venv_python/bin/activate
+        . venv_python/bin/activate
         cd test
         echo "Running Python3 tests..."
         python3 run_suite.py
         deactivate
-        source ../venv_pypy/bin/activate
+        . ../venv_pypy/bin/activate
         echo "Running PyPy3 tests..."
         pypy3 run_suite.py
         deactivate

--- a/test/run_containerized_tests.sh
+++ b/test/run_containerized_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Building Fedora..."
 docker build -f dockerfiles/fedora.Dockerfile -t libdebug_test_fedora ../

--- a/test/scripts/signal_catch_test.py
+++ b/test/scripts/signal_catch_test.py
@@ -1495,7 +1495,7 @@ class SignalCatchTest(TestCase):
         def catch_signal(t, ch):
             self.assertNotEqual(t.signal, "SIGTRAP")
 
-        d = debugger("/bin/ls")
+        d = debugger("ls")
 
         d.run()
 


### PR DESCRIPTION
Some distros (like Alpine, NixOS) do not necessarily have `bash`, `ls`, `gdb` in `/bin`. For portability, it's better to let the system find these executables in the PATH.

Also, since bash features are not used in the scripts, we can use `/bin/sh`, which is available on all systems.

Note: the change to `test/dockerfiles/run_tests.sh` is technically not required, since we know that `/bin/bash` exists in these containers, but it's still good practice if no bashisms are used