### PR TITLE
pprint_memory exception improvement

### DIFF
--- a/libdebug/debugger/internal_debugger.py
+++ b/libdebug/debugger/internal_debugger.py
@@ -606,19 +606,32 @@ class InternalDebugger:
         if file == "absolute":
             address_start = start
         elif file == "hybrid":
+            resolved_as_absolute = False
             try:
                 # Try to resolve the address as absolute
                 self.memory[start, 1, "absolute"]
                 address_start = start
+                resolved_as_absolute = True
             except ValueError:
+                pass
+
+            # If the address is not absolute, we try to resolve it as relative
+            if not resolved_as_absolute:
+                binary_maps = self.maps.filter("binary")
+                if end > binary_maps[-1].end:
+                    raise ValueError(
+                        f"Requested memory pprint from {start:#x} to {end:#x} relative to binary. Relative end address {end:#x} is beyond the end of the binary file {binary_maps[-1].backing_file!r} ({binary_maps[-1].end:#x}).",
+                    )
+
                 # If the address is not in the maps, we use the binary file
-                address_start = start + self.maps.filter("binary")[0].start
+                address_start = start + binary_maps[0].start
                 file = "binary"
         else:
             map_file = self.maps.filter(file)[0]
             address_start = start + map_file.base
             file = map_file.backing_file if file != "binary" else "binary"
 
+        # Addresses are validated, now we can extract the memory
         extract = self.memory[start:end, file]
 
         file_info = f" (file: {file})" if file not in ("absolute", "hybrid") else ""

--- a/libdebug/snapshots/diff.py
+++ b/libdebug/snapshots/diff.py
@@ -231,13 +231,25 @@ class Diff:
         if file == "absolute":
             address_start = start
         elif file == "hybrid":
+            resolved_as_absolute = False
             try:
                 # Try to resolve the address as absolute
                 self.snapshot1.memory[start, 1, "absolute"]
                 address_start = start
+                resolved_as_absolute = True
             except ValueError:
+                pass
+
+            # If the address is not absolute, we try to resolve it as relative
+            if not resolved_as_absolute:
+                binary_maps = self.snapshot1.maps.filter("binary")
+                if end > binary_maps[-1].end:
+                    raise ValueError(
+                        f"Requested memory pprint from {start:#x} to {end:#x} relative to binary. Relative end address {end:#x} is beyond the end of the binary file {binary_maps[-1].backing_file!r} ({binary_maps[-1].end:#x}).",
+                    )
+
                 # If the address is not in the maps, we use the binary file
-                address_start = start + self.snapshot1.maps.filter("binary")[0].start
+                address_start = start + binary_maps[0].start
                 file = "binary"
         else:
             map_file = self.snapshot1.maps.filter(file)[0]


### PR DESCRIPTION
This PR improves the safety check for hybrid-mode resolution of addresses in `pprint_memory`, so that the end address is also checked for being part of the memory maps of the binary. Prior to this PR, the exception raised by

`d.pprint_memory(d.regs.rsp, d.regs.rbp)` for rbp 0

would just print `ValueError: Address 0x7ffe2d2b25e0 does not belong to any memory map.`, a false statement resulting from considering `d.regs.rsp` as a relative address with respect to the binary.