### PR TITLE
fix: Help to FindLibIberty(.cmake) by adding PATH_SUFFIXES "libiberty"

### DIFF
--- a/cmake/FindLibIberty.cmake
+++ b/cmake/FindLibIberty.cmake
@@ -70,6 +70,7 @@ else()
     message(STATUS "FindLibIberty: libiberty not found via pkg-config. Trying manual search.")
     find_path(LibIberty_MANUAL_INCLUDE_DIR NAMES demangle.h
               PATHS /usr/include/libiberty
+              PATH_SUFFIXES libiberty
               HINTS ENV CPATH ENV C_INCLUDE_PATH ENV CPLUS_INCLUDE_PATH
               DOC "Directory containing demangle.h")
     find_library(LibIberty_MANUAL_LIBRARY NAMES iberty


### PR DESCRIPTION
On some systems the "libiberty.h" headers are within another libiberty directory inside the include dir like this: .../include/libiberty/libiberty.h

PATH_SUFFIXES Allows to specify additional subdirectories to check below each directory location otherwise considered. This just increases the likelihood of finding "libiberty.h".

This problem arises on e.g. nixos.

Thank you very much for this awesome library!!