### PR TITLE
Locals in the stacktrace

### DIFF
--- a/libdebug/__init__.py
+++ b/libdebug/__init__.py
@@ -55,7 +55,7 @@ try:
 except ImportError:
     pass
 else:
-    install()
+    install(show_locals=True)
 
 from libdebug.data.breakpoint import Breakpoint
 from libdebug.data.signal_catcher import SignalCatcher

--- a/newsfragments/295.improvement.md
+++ b/newsfragments/295.improvement.md
@@ -1,0 +1,1 @@
+Show locals in stack traces (via `rich.traceback`) to improve error diagnosis.


### PR DESCRIPTION
This is a proposal to add visualization of local variables in the stack trace, as offered by `rich.traceback` (which we already use).

**Rationale:** We will always have at least the debugger available as a local variable, so printing it would be helpful when errors occur, making it easier to spot asymmetry mistakes.

**Drawback:** This will make the stacktrace even bigger.

<img width="966" height="899" alt="image" src="https://github.com/user-attachments/assets/1e6156db-051e-4279-8869-dd72f63cec1e" />

