### PR TITLE
Improvements on the first examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,13 @@ print(f"RAX is {hex(d.regs.rax)}")
 # Write to memory
 d.memory[0x10ad, 8, "binary"] = b"Hello!\x00\x00"
 
-# Continue the execution
+# Continue the execution (non-blocking!)
 d.cont()
+# Wait for the process to stop
+d.wait()
+
+# Kill the process
+d.kill()
 ```
 
 The above script will run the binary `test` in the working directory and set two breakpoints: one at the function `function` and another at `function2`. 
@@ -150,6 +155,8 @@ d.cont()
 d.wait()
 
 d.gdb()
+
+d.kill()
 ```
 
 ## Auto Interrupt on Command

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,8 @@ print(f"RAX is {hex(d.regs.rax)}") # (8)!
 
 # Write to memory
 d.memory[0x10ad, 8, "binary"] = b"Hello!\x00\x00" # (9)!
+
+d.terminate() # (10)!
 ```
 
 1. A debugger is created for the `test` executable
@@ -83,6 +85,7 @@ d.memory[0x10ad, 8, "binary"] = b"Hello!\x00\x00" # (9)!
 7. Wait for the process to print `libdebug is like sushi` on the standard output
 8. The value of the RAX register is read and printed when the process is stopped at the `my_breakpoint` breakpoint
 9. A memory write is performed at address `0x10ad` in the binary
+10. Kill the process and dispose of the debugger
 
 The above script will run the binary `test` in the working directory and set two breakpoints: one at the function `function` and another at `f2`. 
 

--- a/libdebug/debugger/internal_debugger_holder.py
+++ b/libdebug/debugger/internal_debugger_holder.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024-2025 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2024-2026 Gabriele Digregorio, Roberto Alessandro Bertolini, Francesco Panebianco. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -55,6 +55,9 @@ def _cleanup_internal_debugger() -> None:
         # as only the main thread is aware of the script termination or the user's control-C interruption.
         if debugger.instanced and debugger.kill_on_exit:
             if debugger.is_debugging:
+                # If the debuggee is still running, chances are someone did not add a d.kill(), d.terminate(), d.wait() or similar after a non-blocking action.
+                if debugger.running:
+                    liblog.warning("Script terminated while the debuggee is still running. Is your last statement non-blocking?")
                 # We will leverage the fact that we are in the wrong thread but the same process to kill the debuggee
                 # process without relying on the background thread.
                 try:

--- a/newsfragments/298.doc.md
+++ b/newsfragments/298.doc.md
@@ -1,0 +1,1 @@
+Improved the example code for first script to avoid confusion with non-blocking functions.

--- a/test/scripts/atexit_handler_test.py
+++ b/test/scripts/atexit_handler_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024-2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2024-2026 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -11,6 +11,9 @@ from unittest import TestCase
 from utils.binary_utils import RESOLVE_EXE
 from time import sleep
 from pwn import process
+import io
+import logging
+import sys
 
 
 from libdebug import debugger
@@ -19,6 +22,30 @@ from multiprocessing import Process, Queue
 
 
 class AtexitHandlerTest(TestCase):
+    def setUp(self):
+        # Redirect stdout
+        self.capturedOutput = io.StringIO()
+        sys.stdout = self.capturedOutput
+        sys.stderr = self.capturedOutput
+
+        self.log_capture_string = io.StringIO()
+        self.log_handler = logging.StreamHandler(self.log_capture_string)
+        self.log_handler.setLevel(logging.WARNING)
+
+        self.logger = logging.getLogger("libdebug")
+        self.original_handlers = self.logger.handlers
+        self.logger.handlers = []
+        self.logger.addHandler(self.log_handler)
+        self.logger.setLevel(logging.WARNING)
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+        self.logger.removeHandler(self.log_handler)
+        self.logger.handlers = self.original_handlers
+        self.log_handler.close()
+
     def test_run_1(self):
         def provola(queue):
             d = debugger(RESOLVE_EXE("infinite_loop_test"))
@@ -316,3 +343,31 @@ class AtexitHandlerTest(TestCase):
 
         p.close()
         del p
+
+    def test_warning_nonblocking(self):
+        d = debugger(RESOLVE_EXE("infinite_loop_test"))
+
+        d.run()
+        d.cont()
+
+        # Simulate atexit handler
+        _cleanup_internal_debugger()
+
+        self.assertIn("WARNING", self.log_capture_string.getvalue())
+        self.assertIn(
+            "Script terminated while the debuggee is still running. Is your last statement non-blocking?",
+            self.log_capture_string.getvalue(),
+        )
+
+    def test_no_warning_correct_usage(self):
+        d = debugger(RESOLVE_EXE("infinite_loop_test"))
+
+        d.run()
+
+        # Simulate atexit handler
+        _cleanup_internal_debugger()
+
+        self.assertNotIn(
+            "Script terminated while the debuggee is still running. Is your last statement non-blocking?",
+            self.log_capture_string.getvalue(),
+        )


### PR DESCRIPTION
This PR improves the examples of first scripts in the `README.md` and the documentation, to make it clear that `cont()` is a non-blocking command. Failing to add any subsequent blocking command will terminate the script before the process stops, creating confusion in early adopters.