### PR TITLE
Attach to non-existent PID

### DIFF
--- a/libdebug/memory/process_memory_manager.py
+++ b/libdebug/memory/process_memory_manager.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2024-2025 Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2024-2026 Roberto Alessandro Bertolini. Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -18,7 +18,12 @@ if TYPE_CHECKING:
 class ProcessMemoryManager:
     """A class that provides accessors to the memory of a process, through /proc/pid/mem."""
 
-    max_size = sys.maxsize
+    max_size: int = sys.maxsize
+
+    def __init__(self: ProcessMemoryManager) -> None:
+        """Initializes the ProcessMemoryManager in a consistent state."""
+        self.process_id = 0
+        self._mem_file = None
 
     def open(self: ProcessMemoryManager, process_id: int) -> None:
         """Initializes the ProcessMemoryManager."""

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -580,7 +580,7 @@ std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_
     // zombies. This means that the other threads will not receive the PTRACE_EVENT_EXIT event.
     
     std::vector<std::pair<pid_t, int>> thread_statuses;
-    int tid, status, main_status;
+    int tid, status, main_status = 0;
     
     std::unordered_set<pid_t> tids_with_event = {};
     int main_tid = threads.begin()->first;
@@ -593,7 +593,7 @@ std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_
             tid = waitpid(t.first, &status, WNOHANG);
             return (tid == main_tid);
         });
-
+        
         if (tid > 0) {
             // Record the PID and its status
             thread_statuses.push_back({tid, status});

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -471,6 +471,13 @@ unsigned long LibdebugPtraceInterface::get_thread_event_msg(const pid_t tid)
 
 std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_regs(const bool all_zombies)
 {
+    // Check if the list of threads is empty. If it is, we raise an error
+    // This should never happen, but some corner cases in the past have shown that it can actually happen if 
+    // we have skill issues in other parts of the code, so we want to be sure that we handle it gracefully
+    if (threads.empty()) {
+        throw std::runtime_error("No threads to wait for. This should not happen. Please, open an issue if you see this error.");
+    }
+    
     if (all_zombies) {
         // All threads are zombies, we might be in the case of a fatal signal
         // that killed all the threads

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -1,6 +1,6 @@
 //
 // This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-// Copyright (c) 2024-2025 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
+// Copyright (c) 2024-2026 Roberto Alessandro Bertolini, Gabriele Digregorio, Francesco Panebianco. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 

--- a/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
+++ b/libdebug/ptrace/native/libdebug_ptrace_binding.cpp
@@ -491,7 +491,7 @@ std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_
 {
     std::vector<std::pair<pid_t, int>> thread_statuses;
 
-    int tid, status;
+    int tid = -1, status = -1;
 
     while (true) {
         // Check if any thread has finished
@@ -580,7 +580,7 @@ std::vector<std::pair<pid_t, int>> LibdebugPtraceInterface::wait_all_and_update_
     // zombies. This means that the other threads will not receive the PTRACE_EVENT_EXIT event.
     
     std::vector<std::pair<pid_t, int>> thread_statuses;
-    int tid, status, main_status = 0;
+    int tid = -1, status = -1, main_status = -1;
     
     std::unordered_set<pid_t> tids_with_event = {};
     int main_tid = threads.begin()->first;

--- a/libdebug/utils/process_utils.py
+++ b/libdebug/utils/process_utils.py
@@ -61,6 +61,11 @@ def get_process_tasks(process_id: int) -> list[int]:
     tids = []
     if Path(f"/proc/{process_id}/task").exists():
         tids = [int(task) for task in os.listdir(f"/proc/{process_id}/task")]
+    else:
+        raise RuntimeError(
+            f"Failed to get tasks for process {process_id}. The /proc/{process_id}/task directory does not exist. "
+            f"Are you sure that the process is still running?",
+        )
     return tids
 
 

--- a/libdebug/utils/process_utils.py
+++ b/libdebug/utils/process_utils.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2025 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
+# Copyright (c) 2023-2026 Roberto Alessandro Bertolini, Gabriele Digregorio. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 

--- a/newsfragments/300.bugfix.md
+++ b/newsfragments/300.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue when attaching to a non-existent PID that caused libdebug to hang indefinitely.

--- a/test/scripts/attach_detach_test.py
+++ b/test/scripts/attach_detach_test.py
@@ -1,6 +1,6 @@
 #
 # This file is part of libdebug Python library (https://github.com/libdebug/libdebug).
-# Copyright (c) 2023-2024 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
+# Copyright (c) 2023-2026 Gabriele Digregorio, Roberto Alessandro Bertolini. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
@@ -58,6 +58,11 @@ class AttachDetachTest(unittest.TestCase):
 
         r.close()
         del r
+    
+    def test_attach_non_existent_process(self):
+        d = debugger()
+        self.assertRaises(RuntimeError, d.attach, 999999)
+        d.terminate()
         
     def test_attach_multithread(self):
         r = subprocess.Popen([RESOLVE_EXE("multithread_input")], stdin=subprocess.PIPE, stdout=subprocess.PIPE)


### PR DESCRIPTION
This fixes an issue when attaching to a non-existent PID. Previously, we never checked for the existence of the PID, returning an empty list of TIDs in `get_process_tasks`. This caused us to wait on an empty list of threads, which in turn resulted in an infinite loop (causing libdebug to hang in that case).