### PR TITLE
fix(debugging_utils): do not default to hex for offsets

### DIFF
--- a/libdebug/utils/debugging_utils.py
+++ b/libdebug/utils/debugging_utils.py
@@ -54,7 +54,7 @@ def resolve_symbol_in_maps(symbol: str, maps: MemoryMapList[MemoryMap]) -> int:
 
     if "+" in symbol:
         symbol, offset_str = symbol.split("+")
-        offset = int(offset_str, 16)
+        offset = int(offset_str, 0)
     else:
         offset = 0
 


### PR DESCRIPTION
Currently, setting a breakpoint at `func+123` breaks at `func.address + 0x123`, which is somewhat uninituitive/unexpected 

By changing `int(offset, 16)` to `int(offset, 0)`, `+0x123` will work continue working as before, but `+123` will be `123` (decimal) instead of `291`

see https://docs.python.org/3/library/functions.html#int for details on `int(N, 0)`